### PR TITLE
KAS-1362 fix not showing the correct titles

### DIFF
--- a/app/components/agenda/agenda-list/list-item/template.hbs
+++ b/app/components/agenda/agenda-list/list-item/template.hbs
@@ -16,7 +16,7 @@
 </h4>
 {{#if (not aboutToDelete)}}
   {{#if (not selectedAgendaItem)}}
-    {{#if agendaitem.showAsRemark}} {{!-- What is this test for? Determining if announcement better through "showAsRemark"? --}}
+    {{#if (not agendaitem.isApproval)}}
       {{#if agendaitem.shortTitle}} {{!-- Avoid rendering the same thing twice if no "shortTitle" exists --}}
         <pre class="vl-u-text">
           {{agendaitem.title}}


### PR DESCRIPTION
We should show the title when the agendaitem is connected to a subcase or if the agendaitem is an announcement.
The only situation where we don't want to show the long title is for the approval (point 1)
So changed the if statement to check for the "isApproval" attribuut, which is only true for that type of agendaitem.
