### PR TITLE
KAS-1359: remove padding from active state preventing jumping tabs

### DIFF
--- a/app/styles/custom-components/_vlc-tabs-reverse.scss
+++ b/app/styles/custom-components/_vlc-tabs-reverse.scss
@@ -40,7 +40,6 @@
 }
 
 .vlc-tabs-reverse__link--active {
-  padding: 0.7rem 1.5rem 0.8rem;
   border-top-color: #000;
   color: #000;
 }


### PR DESCRIPTION
Fixed by removing padding from active state, checked through the application to see if this breaks anything but nothing was found.