### PR TITLE
KAS-1326: Fix scrollbar on print

### DIFF
--- a/app/components/agenda/agenda-header/template.hbs
+++ b/app/components/agenda/agenda-header/template.hbs
@@ -131,7 +131,7 @@
                     {{t "printable-press-agenda"}}
                   </a>
                 </li>
-                {{!--#if showPrintButton}}
+                {{#if showPrintButton}}
                   <li class="vlc-dropdown-menu__item">
                     {{#link-to
                       "agenda.agendaitems"
@@ -159,7 +159,7 @@
                       {{t "printable-version"}}
                     {{/link-to}}
                   </li>
-                {{/if--}}
+                {{/if}}
                 {{#if isEditor}}
                   <li class="vlc-dropdown-menu__separator" role="none"></li>
                   <li class="vlc-dropdown-menu__item">

--- a/app/router.js
+++ b/app/router.js
@@ -11,7 +11,7 @@ Router.map(function () {
     this.route('overview', { path: '/overzicht' });
   });
   this.route('agenda', { path: '/agenda/:id' }, function() {
-    // this.route('print', { path: '/afdrukken' });
+    this.route('print', { path: '/afdrukken' });
     this.route('agendaitems', { path: '/agendapunten' }, function() {
       this.route('agendaitem', { path: '/:agendaitem_id' });
     });

--- a/app/styles/print/_print.scss
+++ b/app/styles/print/_print.scss
@@ -84,4 +84,13 @@
   .vlc-panel-layout {
     display: block;
   }
+
+  .hide-scrollbar-on-print {
+    -ms-overflow-style: none;  /* Internet Explorer 10+ */
+    scrollbar-width: none;  /* Firefox */
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
 }

--- a/app/styles/print/_print.scss
+++ b/app/styles/print/_print.scss
@@ -85,7 +85,7 @@
     display: block;
   }
 
-  .hide-scrollbar-on-print {
+  .vlc-hide-scrollbar-on-print {
     -ms-overflow-style: none;  /* Internet Explorer 10+ */
     scrollbar-width: none;  /* Firefox */
 

--- a/app/templates/agenda/print.hbs
+++ b/app/templates/agenda/print.hbs
@@ -1,4 +1,4 @@
-<div class="vlc-scroll-wrapper vlc-u-box-model-maximize-width vl-u-scroll-scrollable">
+<div class="vlc-scroll-wrapper vlc-u-box-model-maximize-width vl-u-scroll-scrollable hide-scrollbar-on-print">
   {{agenda/printable-agenda-list
     agendaitems=(await sortedAgendaitems)
     announcements=(await sortedAnnouncements)

--- a/app/templates/agenda/print.hbs
+++ b/app/templates/agenda/print.hbs
@@ -1,4 +1,4 @@
-<div class="vlc-scroll-wrapper vlc-u-box-model-maximize-width vl-u-scroll-scrollable hide-scrollbar-on-print">
+<div class="vlc-scroll-wrapper vlc-u-box-model-maximize-width vl-u-scroll-scrollable vlc-hide-scrollbar-on-print">
   {{agenda/printable-agenda-list
     agendaitems=(await sortedAgendaitems)
     announcements=(await sortedAnnouncements)

--- a/app/templates/print-overviews/newsletter.hbs
+++ b/app/templates/print-overviews/newsletter.hbs
@@ -1,5 +1,3 @@
 {{title (t "agendaitem-bestek")}}
 {{newsletter/newsletter-header-overview agenda=(await model)}}
-<div class="vlc-scroll-wrapper__body">
-  {{outlet}}
-</div>
+{{outlet}}

--- a/app/templates/print-overviews/newsletter/overview.hbs
+++ b/app/templates/print-overviews/newsletter/overview.hbs
@@ -1,5 +1,5 @@
 {{title (await documentTitle) replace=true}}
-<div class="vlc-scroll-wrapper__body">
+<div class="vlc-scroll-wrapper__body hide-scrollbar-on-print">
   <div class="vl-u-spacer-extended-l">
     <div class="vlc-container-center">
       {{utils/logo-header}}

--- a/app/templates/print-overviews/newsletter/overview.hbs
+++ b/app/templates/print-overviews/newsletter/overview.hbs
@@ -1,5 +1,5 @@
 {{title (await documentTitle) replace=true}}
-<div class="vlc-scroll-wrapper__body hide-scrollbar-on-print">
+<div class="vlc-scroll-wrapper__body vlc-hide-scrollbar-on-print">
   <div class="vl-u-spacer-extended-l">
     <div class="vlc-container-center">
       {{utils/logo-header}}


### PR DESCRIPTION
**BEFORE**
![image](https://user-images.githubusercontent.com/1874332/78030281-1daba980-7362-11ea-8a89-1d68a6b268ae.png)

**AFTER**
![image](https://user-images.githubusercontent.com/1874332/78030178-fbb22700-7361-11ea-91f4-cc03f635b0ce.png)

## 🔧 How was this fixed?
Removed the redundant scroll wrapper in KB first, so I could get the scrolling going on in the scroll wrapper that was also present on the route. There I added a class to enforce hiding the scrollbar when printing. I also did this for the record in agenda items print route, even though the error wasn't present there.
