### PR TITLE
KAS-1349: Toast Download Button

### DIFF
--- a/app/components/utils/toaster/download-file-toast/template.hbs
+++ b/app/components/utils/toaster/download-file-toast/template.hbs
@@ -1,6 +1,5 @@
 <ClickOutside @action={{@onClose}}>
   <div class="vl-modal">
-    {{!-- TODO: revise custom CSS classes that get loaded on top of generic alert classes --}}
     <WebComponents::VlAlert
       class="vl-alert-relative vl-alert-relative--center-mid"
       aria-live="assertive"
@@ -10,8 +9,8 @@
       @onClose={{@options.onClose}}
     >
       <div class="vl-alert__message vl-u-text--capitalize">
-        {{!-- TODO: Extra CSS, so the button has an outline within the alert --}}
-        <a class="vl-button vl-button--link"
+        <p>{{t "agenda-documents-download-ready"}}</p>
+        <a class="vl-button vl-button--link vlc-toaster-button"
            href={{@options.downloadLink}}
            download
            {{on "click" @options.onClose}}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -115,6 +115,7 @@ $icon-font-location: '/fonts/';
 @import 'custom-components/vlc-subline';
 @import 'custom-components/vlc-tabs-reverse';
 @import 'custom-components/vlc-themes-selector';
+@import 'custom-components/vlc-toaster-button';
 @import 'custom-components/vlc-toolbar';
 @import 'custom-components/vlc-user';
 @import 'custom-components/vlc-user-management-table';

--- a/app/styles/custom-application/toast.scss
+++ b/app/styles/custom-application/toast.scss
@@ -22,13 +22,15 @@
     right: 2%;
     & button.vl-alert__close {
       font-size: 1.3em;
+      top: 1.3rem;
+      right: 1.3rem;
     }
   }
 
   &:hover {
     opacity: 1;
   }
- 
+
 }
 
 .toasts-container {
@@ -50,6 +52,8 @@
       right: 2%;
       & button.vl-alert__close {
         font-size: 1.3em;
+        top: 1.3rem;
+        right: 1.3rem;
       }
     }
   }

--- a/app/styles/custom-components/_vlc-toaster-button.scss
+++ b/app/styles/custom-components/_vlc-toaster-button.scss
@@ -1,0 +1,11 @@
+/* ==========================================================================
+	 Toast buttons
+	 ========================================================================== */
+
+.vlc-toaster-button {
+  margin-top: 1rem;
+  padding: 0 1rem;
+  border: 1px solid $blue-gray-light;
+  background-color: unset;
+  cursor: pointer;
+}

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -30,6 +30,7 @@
   "agenda-release-decisions": "Beslissingen vrijgeven",
   "agenda-release-documents": "Documenten vrijgeven",
   "agenda-version": "Agenda versie",
+  "agenda-documents-download-ready": "Uw archiefbestand is klaar",
   "agendaitem-bestek": "Kort bestek",
   "agendaitem-case": "Dossier",
   "agendaitem-comment": "Opmerkingen",


### PR DESCRIPTION
# 🍞 Toast download button fix

**REST**
![image](https://user-images.githubusercontent.com/1874332/78348148-d7dd2400-75a1-11ea-8e99-0f72dafa4971.png)

**HOVER**
![image](https://user-images.githubusercontent.com/1874332/78348191-e9263080-75a1-11ea-80ef-f27413d8bcc7.png)

## 📣 Also in this fix...
I've noticed the ugliest thing ever, take a look at this:
![image](https://user-images.githubusercontent.com/1874332/78348452-52a63f00-75a2-11ea-8bbb-965242b7849f.png)

That **close button** is not inside of the inner padding's bounds:
![image](https://user-images.githubusercontent.com/1874332/78348501-6e114a00-75a2-11ea-8231-cb03613537aa.png)

This is extremely ugly, and easy to fix. This is also what the designs imply it should look like. So I side-tracked that into this issue.

Much better:
![image](https://user-images.githubusercontent.com/1874332/78348614-a153d900-75a2-11ea-8a0e-ea14f2971d98.png)
