### PR TITLE
KAS-1218: add constraint to alert for nota

### DIFF
--- a/app/components/agenda/agendaitem/agendaitem-case/subcase-document/document-link/template.hbs
+++ b/app/components/agenda/agendaitem/agendaitem-case/subcase-document/document-link/template.hbs
@@ -20,6 +20,7 @@
           <div class="vlc-toolbar__item">
             {{#if isEditor}}
               <button class="vl-button vl-button--link vl-button--icon"
+                      data-test-documents-show-more
                       type="button">
                 <i class="vl-vi vl-vi-nav-show-more-horizontal"></i>
                 {{#attach-popover
@@ -34,6 +35,7 @@
                     <li class="vlc-dropdown-menu__item">
                       <a class="vl-link vl-link--block"
                          href=""
+                         data-test-document-upload-new-version
                         {{action attacher.hide}}
                         {{action "openUploadDialog" document}}
                       >

--- a/app/services/agenda-service.js
+++ b/app/services/agenda-service.js
@@ -270,15 +270,19 @@ export default Service.extend(ModifiedMixin, isAuthenticatedMixin, {
 
     const documentVersion = await nota.get('lastDocumentVersion');
     const modifiedDateFromMostRecentlyAddedNotaDocumentVersion = documentVersion.created;
-    const newsletterInfoOnSubcaseLastModifiedTime = newsletterInfoForSubcase.modified;
-    if (newsletterInfoOnSubcaseLastModifiedTime) {
-      if (moment(newsletterInfoOnSubcaseLastModifiedTime).isBefore(moment(modifiedDateFromMostRecentlyAddedNotaDocumentVersion))) {
-        return moment(modifiedDateFromMostRecentlyAddedNotaDocumentVersion);
+    const notaDocumentVersions = await nota.get('documentVersions');
+    if(notaDocumentVersions.length > 1) {
+      const newsletterInfoOnSubcaseLastModifiedTime = newsletterInfoForSubcase.modified;
+      if (newsletterInfoOnSubcaseLastModifiedTime) {
+        if (moment(newsletterInfoOnSubcaseLastModifiedTime).isBefore(moment(modifiedDateFromMostRecentlyAddedNotaDocumentVersion))) {
+          return moment(modifiedDateFromMostRecentlyAddedNotaDocumentVersion);
+        } else {
+          return null;
+        }
       } else {
-        return null;
+        return moment(modifiedDateFromMostRecentlyAddedNotaDocumentVersion);
       }
-    } else {
-      return moment(modifiedDateFromMostRecentlyAddedNotaDocumentVersion);
     }
+    return null;
   }
 });

--- a/app/services/agenda-service.js
+++ b/app/services/agenda-service.js
@@ -224,7 +224,7 @@ export default Service.extend(ModifiedMixin, isAuthenticatedMixin, {
   },
 
   async deleteAgendaitemFromMeeting(agendaitem) {
-    let itemToDelete = await this.store.findRecord('agendaitem', agendaitem.get('id'), {reload: true});
+    let itemToDelete = await this.store.findRecord('agendaitem', agendaitem.get('id'), { reload: true });
     const currentAgenda = await itemToDelete.get('agenda');
     const currentMeeting = await currentAgenda.get('createdFor');
     const currentMeetingId = await currentMeeting.get('id');
@@ -264,14 +264,14 @@ export default Service.extend(ModifiedMixin, isAuthenticatedMixin, {
   async retrieveModifiedDateFromNota(agendaItem) {
     const newsletterInfoForSubcase = await agendaItem.get('subcase.newsletterInfo');
     const nota = await agendaItem.get('nota');
-    if(!nota) {
+    if (!nota) {
       return null;
     }
 
     const documentVersion = await nota.get('lastDocumentVersion');
     const modifiedDateFromMostRecentlyAddedNotaDocumentVersion = documentVersion.created;
     const notaDocumentVersions = await nota.get('documentVersions');
-    if(notaDocumentVersions.length > 1) {
+    if (notaDocumentVersions.length > 1) {
       const newsletterInfoOnSubcaseLastModifiedTime = newsletterInfoForSubcase.modified;
       if (newsletterInfoOnSubcaseLastModifiedTime) {
         if (moment(newsletterInfoOnSubcaseLastModifiedTime).isBefore(moment(modifiedDateFromMostRecentlyAddedNotaDocumentVersion))) {

--- a/app/templates/cases/overview.hbs
+++ b/app/templates/cases/overview.hbs
@@ -95,7 +95,8 @@
           {{/if}}
           <td class="vl-u-align-right">
             {{#if isEditor}}
-              <button type="button" class="vl-button vl-button--link vl-button--icon">
+              <button type="button"
+                      class="vl-button vl-button--link vl-button--icon">
                 <i class="vl-button__icon vl-vi vl-vi-nav-show-more-horizontal"
                 ></i>
                 {{#attach-popover

--- a/cypress/integration/unit/NewsletterInfo/shouldCloseChangesWarning.js
+++ b/cypress/integration/unit/NewsletterInfo/shouldCloseChangesWarning.js
@@ -84,11 +84,12 @@ context('Show warning in newsletterinfo', () => {
     cy.get('@fileUploadDialog').within(() => {
       cy.get('.vl-button').contains('Documenten toevoegen').click();
     });
-
     cy.wait('@createNewDocumentVersion', { timeout: 12000 });
     cy.wait('@createNewDocument', { timeout: 12000 });
     cy.wait('@patchModel', { timeout: 12000  + 6000 * files.length });
-
+    cy.route('/');
+    cy.openAgendaForDate(agendaDate);
+    cy.addNewDocumentVersionToAgendaItem(subcaseTitle1, file.newFileName , file);
     cy.get(agendaAgendaItemKortBestekTabSelector)
       .should('be.visible')
       .click()
@@ -97,7 +98,6 @@ context('Show warning in newsletterinfo', () => {
     cy.get(changesAlertComponentCloseButtonSelector).click();
     cy.get(changesAlertComponentSelector).should('not.be.visible');
   })
-
 });
 
 function currentMoment() {

--- a/cypress/integration/unit/NewsletterInfo/shouldShowWarningInNewsletterInfo.js
+++ b/cypress/integration/unit/NewsletterInfo/shouldShowWarningInNewsletterInfo.js
@@ -85,6 +85,9 @@ context('Show warning in newsletterinfo', () => {
     cy.wait('@createNewDocumentVersion', { timeout: 12000 });
     cy.wait('@createNewDocument', { timeout: 12000 });
     cy.wait('@patchModel', { timeout: 12000  + 6000 * files.length });
+    cy.route('/');
+    cy.openAgendaForDate(agendaDate);
+    cy.addNewDocumentVersionToAgendaItem(subcaseTitle1, file.newFileName , file);
 
     cy.get(agendaAgendaItemKortBestekTabSelector)
       .should('be.visible')
@@ -92,7 +95,6 @@ context('Show warning in newsletterinfo', () => {
       .wait(2000); //Access-levels GET occured earlier, general wait instead
     cy.get(changesAlertComponentSelector).should('be.visible');
   })
-
 });
 
 function currentMoment() {

--- a/cypress/integration/unit/NewsletterInfo/shouldTestFullWarningFlowOnKB.js
+++ b/cypress/integration/unit/NewsletterInfo/shouldTestFullWarningFlowOnKB.js
@@ -95,6 +95,18 @@ context('Should upload nota, see the warning, close warning, edit KB and see no 
       .should('be.visible')
       .click()
       .wait(2000); //Access-levels GET occured earlier, general wait instead
+    cy.get(changesAlertComponentSelector).should('not.be.visible');
+
+    // Upload another file
+    cy.route('/');
+    cy.openAgendaForDate(agendaDate);
+    cy.addNewDocumentVersionToAgendaItem(subcaseTitle1, file.newFileName , file);
+
+    cy.get(agendaAgendaItemKortBestekTabSelector)
+      .should('be.visible')
+      .click()
+      .wait(2000); //Access-levels GET occured earlier, general wait instead
+
     cy.get(changesAlertComponentSelector).should('be.visible');
     cy.get(changesAlertComponentCloseButtonSelector).click();
     cy.get(changesAlertComponentSelector).should('not.be.visible');
@@ -102,7 +114,9 @@ context('Should upload nota, see the warning, close warning, edit KB and see no 
     cy.get(newsletterEditSelector).should('be.visible').click();
     cy.get(newsletterRdfaEditorSelector).type('Aanpassing');
     cy.get(newsletterEditSave).type('Aanpassing');
+    cy.wait(2000);
     cy.get(modalVerifySaveSelector).click();
+    cy.wait(5000);
     cy.get(agendaAgendaItemDocumentsTabSelector).should('be.visible').click();
     cy.get(agendaAgendaItemKortBestekTabSelector).should('be.visible').click();
     cy.get(changesAlertComponentSelector).should('not.be.visible');

--- a/cypress/selectors/documents/documentSelectors.js
+++ b/cypress/selectors/documents/documentSelectors.js
@@ -1,2 +1,4 @@
 export const modalDocumentVersionDeleteSelector = '[data-test-vl-uploaded-document-deleteversion]';
 export const modalDocumentVersionUploadedFilenameSelector = '[data-test-vl-uploaded-document-filename]';
+export const documentUploadNewVersionSelector = '[data-test-document-upload-new-version]';
+export const documentUploadShowMoreSelector = '[data-test-documents-show-more]';

--- a/cypress/support/document-commands.js
+++ b/cypress/support/document-commands.js
@@ -2,8 +2,13 @@
 /// <reference types="Cypress" />
 
 import 'cypress-file-upload';
-import {modalDocumentVersionUploadedFilenameSelector} from "../selectors/documents/documentSelectors";
+import {
+  documentUploadNewVersionSelector, documentUploadShowMoreSelector,
+  modalDocumentVersionUploadedFilenameSelector
+} from '../selectors/documents/documentSelectors';
 import { agendaAgendaItemDocumentsTabSelector } from '../selectors/agenda/agendaSelectors';
+import { formSaveSelector } from '../selectors/formSelectors/formSelectors';
+import { modalDialogSelector } from '../selectors/models/modelSelectors';
 // ***********************************************
 // Commands
 
@@ -190,14 +195,13 @@ function addNewDocumentVersion(oldFileName, file, modelToPatch) {
     .parents('.vlc-document-card').as('documentCard');
 
   cy.get('@documentCard').within(() => {
-    cy.get('.vl-vi-nav-show-more-horizontal').click();
+    cy.get(documentUploadShowMoreSelector).click();
   });
-  cy.get('.vl-link--block')
-    .contains('Nieuwe versie uploaden', { timeout: 12000 })
+  cy.get(documentUploadNewVersionSelector)
     .should('be.visible')
     .click();
 
-  cy.get('.vl-modal-dialog').as('fileUploadDialog');
+  cy.get(modalDialogSelector).as('fileUploadDialog');
 
   cy.get('@fileUploadDialog').within(() => {
     cy.uploadFile(file.folder, file.fileName, file.fileExtension);
@@ -206,7 +210,7 @@ function addNewDocumentVersion(oldFileName, file, modelToPatch) {
   cy.wait(1000); //Cypress is too fast
 
   cy.get('@fileUploadDialog').within(() => {
-    cy.get('.vl-button').contains('Toevoegen').click();
+    cy.get(formSaveSelector).click();
   });
   cy.wait('@createNewDocumentVersion', { timeout: 12000 });
 

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -552,6 +552,5 @@
   "changes-could-not-be-saved-title": "Je wijzigingen kunnen niet opgeslagen worden.",
   "changes-could-not-be-saved-message": "{item} werd {time} aangepast door {firstname} {lastname}. Noteer je wijzigingen en hernieuw deze pagina om de laatste aanpassingen te zien.",
   "newsitem-changed-message": "Pas op, deze nota werd aangepast op {date} om {time}.",
-  "newsitem-changed-no-note-message": "Opgelet, er is nog geen nota aanwezig!",
   "select-minister": "Selecteer een minister"
 }


### PR DESCRIPTION
Extra check toegevoegd om ervoor te zorgen dat de melding enkel weergeven wordt wanneer de nota een bis-versie heeft.
Er stond ook nog een translate string in nl-be die niet gebruikt is, deze heb ik gecleaned.