### PR TITLE
KAS-1171: Tooltip fixes

### DIFF
--- a/app/components/agenda/agenda-list/list-item/template.hbs
+++ b/app/components/agenda/agenda-list/list-item/template.hbs
@@ -38,14 +38,16 @@
         <span class="added-tag vlc-agenda-meta__recently-added">
           {{#if (await agendaitem.checkAdded)}}
             <i class="vl-link__icon vl-vi vl-vi-calendar-add"></i>
-            {{#attach-popover
+            {{#attach-tooltip
+              arrow="true"
+              animation="shift"
               placement="top"
-              class="ember-attacher-popper ember-attacher-popper-wide"
+              class="ember-attacher-tooltip"
             }}
               <p>
                 {{t "added-agendaitem-text"}}
               </p>
-            {{/attach-popover}}
+            {{/attach-tooltip}}
           {{/if}}
         </span>
         {{#if (and isEditor (await currentAgenda.isDesignAgenda))}}

--- a/app/components/news-item/edit-item/template.hbs
+++ b/app/components/news-item/edit-item/template.hbs
@@ -19,12 +19,16 @@
       {{/if}}
     {{else}}
       <div class="vl-loader" role="alert" aria-busy="true">
-        {{#attach-popover
-          placement="bottom"
-          class="ember-attacher-popper ember-attacher-popper-small"
-        }}
-          {{t "nota-loading-text"}}
-        {{/attach-popover}}
+        <div class="vl-loader" role="alert" aria-busy="true">
+          {{#attach-tooltip
+            arrow="true"
+            animation="shift"
+            placement="bottom"
+            class="ember-attacher-tooltip"
+          }}
+            {{t "nota-loading-text"}}
+          {{/attach-tooltip}}
+        </div>
       </div>
     {{/if}}
   </div>

--- a/app/components/utils/text-template/template.hbs
+++ b/app/components/utils/text-template/template.hbs
@@ -15,14 +15,5 @@
   as |model|
   }}
     {{model.label}}
-    {{!-- Disabled for the time being, because this makes for horrible UX (decision Johan Ronsse KAS-1171)
-    {{#attach-popover
-      placement="top"
-      class="ember-attacher-popper ember-attacher-popper-wide"
-    }}
-      <p>
-        {{sanitize-html raw=true value=model.description}}
-      </p>
-    {{/attach-popover--}}
   {{/power-select}}
 </div>

--- a/app/components/utils/text-template/template.hbs
+++ b/app/components/utils/text-template/template.hbs
@@ -15,6 +15,7 @@
   as |model|
   }}
     {{model.label}}
+    {{!-- Disabled for the time being, because this makes for horrible UX (decision Johan Ronsse KAS-1171)
     {{#attach-popover
       placement="top"
       class="ember-attacher-popper ember-attacher-popper-wide"
@@ -22,6 +23,6 @@
       <p>
         {{sanitize-html raw=true value=model.description}}
       </p>
-    {{/attach-popover}}
+    {{/attach-popover--}}
   {{/power-select}}
 </div>

--- a/app/components/web-components/vl-table-actions/template.hbs
+++ b/app/components/web-components/vl-table-actions/template.hbs
@@ -9,12 +9,14 @@
         {{action "openDocument" row bubbles=false}}
       >
         <i class="vl-button__icon vl-vi vl-vi-document"></i>
-        {{#attach-popover
+        {{#attach-tooltip
+          arrow="true"
+          animation="shift"
           placement="bottom"
-          class="ember-attacher-popper ember-attacher-popper-small"
+          class="ember-attacher-tooltip"
         }}
           {{t "no-nota"}}
-        {{/attach-popover}}
+        {{/attach-tooltip}}
       </button>
     {{else}}
       <button type="button" class="vl-button vl-button--link vl-button--icon"
@@ -25,12 +27,14 @@
     {{/if}}
   {{else}}
     <div class="vl-loader" role="alert" aria-busy="true">
-      {{#attach-popover
+      {{#attach-tooltip
+        arrow="true"
+        animation="shift"
         placement="bottom"
-        class="ember-attacher-popper ember-attacher-popper-small"
+        class="ember-attacher-tooltip"
       }}
         {{t "nota-loading-text"}}
-      {{/attach-popover}}
+      {{/attach-tooltip}}
     </div>
   {{/if}}
   {{#link-to

--- a/app/styles/_colors.scss
+++ b/app/styles/_colors.scss
@@ -150,3 +150,9 @@ $white-background: #eee;
 $environment-local-color: #e86ab9;
 $environment-dev-color: #4CAF50;
 $environment-test-color: #FFF176;
+
+
+/* Tooltips
+	 ========================================================================== */
+
+$tooltip-dark-color: #454545;

--- a/app/styles/custom-application/ember-attacher.scss
+++ b/app/styles/custom-application/ember-attacher.scss
@@ -12,6 +12,17 @@
   max-width: 90vw;
   z-index: 11000;
 
+  &.ember-attacher-tooltip {
+    background-color: $tooltip-dark-color;
+    min-width: unset;
+    width: unset;
+
+    & > div[x-arrow] {
+      background-color: $tooltip-dark-color;
+      border-color: $tooltip-dark-color;
+    }
+  }
+
   @include respond-to(small) {
     max-height: 65vh;
     width: 100%;

--- a/app/templates/settings/ministers.hbs
+++ b/app/templates/settings/ministers.hbs
@@ -105,12 +105,14 @@
                 {{action "toggleProperty" "isResigningMandatee" mandatee}}
               >
                 <i class="vl-button__icon vl-vi vl-vi-cog"></i>
-                {{#attach-popover
+                {{#attach-tooltip
+                  arrow="true"
+                  animation="shift"
                   placement="bottom"
-                  class="ember-attacher-popper ember-attacher-popper-small"
+                  class="ember-attacher-tooltip"
                 }}
                   {{t "resign"}}
-                {{/attach-popover}}
+                {{/attach-tooltip}}
               </button>
               <button type="button"
                       data-test-mandatee-delete={{index}}


### PR DESCRIPTION
# Tooltip Fixes

![image](https://user-images.githubusercontent.com/1874332/79461733-d88ca600-7ff6-11ea-95e9-2a75f09f0509.png)

### 📣What changed?

We just simply made text-only tooltips to look like the dark one's from Figma. (Like the one's you can see in the screenshot above). For this we also had to use the `attach-tooltip` which was `attach-popover` for some reason.

### 💡Good to know

In order to make the arrows work on the tooltip, you should do the following:

* Add `arrow="true"` to the attacher.
* Change the animation to something that supports arrows (like: `animation="shift"`). ⚠️ 