### PR TITLE
KAS-1455: Fix Document Upload Big

### DIFF
--- a/app/components/utils/add-signed-documents/component.js
+++ b/app/components/utils/add-signed-documents/component.js
@@ -29,6 +29,11 @@ export default Component.extend(UploadDocumentMixin, isAuthenticatedMixin, {
   },
 
   actions: {
+    closeModal() {
+      this.hideAddDocumentModal();
+      this.clearAllDocuments();
+    },
+
     toggleIsAddingNewDocument() {
       this.toggleProperty('isAddingNewDocument');
     },

--- a/app/components/utils/add-signed-documents/component.js
+++ b/app/components/utils/add-signed-documents/component.js
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
 import UploadDocumentMixin from 'fe-redpencil/mixins/upload-document-mixin';
 import { inject } from '@ember/service';
-import { computed } from '@ember/object';
+import { computed, set } from '@ember/object';
 import CONFIG from 'fe-redpencil/utils/config';
 import isAuthenticatedMixin from 'fe-redpencil/mixins/is-authenticated-mixin';
 import { tracked } from '@glimmer/tracking';
@@ -24,13 +24,9 @@ export default Component.extend(UploadDocumentMixin, isAuthenticatedMixin, {
     }
   }),
 
-  hideAddDocumentModal() {
-    this.isAddingNewDocument = false;
-  },
-
   actions: {
     closeModal() {
-      this.hideAddDocumentModal();
+      set(this, 'isAddingNewDocument', false);
       this.clearAllDocuments();
     },
 
@@ -43,6 +39,7 @@ export default Component.extend(UploadDocumentMixin, isAuthenticatedMixin, {
       const item = await this.get('item');
       const documents = await this.saveDocuments(null);
       // const documentType = await this.get('documentTypeToAssign');
+      this.send('closeModal');
 
       await Promise.all(
         documents.map(async (document) => {
@@ -52,7 +49,6 @@ export default Component.extend(UploadDocumentMixin, isAuthenticatedMixin, {
         })
       );
       await item.save();
-      this.hideAddDocumentModal();
     },
 
     delete() {

--- a/app/components/utils/add-signed-documents/template.hbs
+++ b/app/components/utils/add-signed-documents/template.hbs
@@ -14,7 +14,7 @@
 {{/if}}
 {{#if isAddingNewDocument}}
   {{#web-components/vl-modal
-    closeModal=(action "toggleIsAddingNewDocument")
+    closeModal=(action "closeModal")
     isOverlay=true
     large=true
     title=(t "document-add")
@@ -52,7 +52,7 @@
       isLoading=isLoading
       cancelButtonText=(t "cancel")
       saveButtonText=(t "document-add")
-      cancelAction=(action "toggleIsAddingNewDocument")
+      cancelAction=(action "closeModal")
       saveAction=(action "uploadNewDocument")
       disableSave=(eq documentsInCreation.length 0)
     }}

--- a/app/mixins/upload-document-mixin.js
+++ b/app/mixins/upload-document-mixin.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import moment from 'moment';
 import { downloadFilePrompt } from 'fe-redpencil/utils/file-utils';
 import { A } from '@ember/array';
+import { set } from '@ember/object';
 import config from '../utils/config';
 import { deprecatingAlias } from '@ember/object/computed';
 import { deprecate } from '@ember/debug';
@@ -14,10 +15,15 @@ export default Mixin.create({
 
   documentsInCreation: A([]), // When creating new documents
 
+  clearAllDocuments() {
+    set(this, 'documentsInCreation', A([]));
+  },
+
   document: deprecatingAlias('documentContainer', {
     id: 'model-refactor.documents',
     until: '?'
   }),
+
   documentContainer: null, // When adding a new version to an existing document
   defaultAccessLevel: null, // when creating a new document
 


### PR DESCRIPTION
# 🐞Bugfix: Clear Upload Document

In decisions for an agendaitem, you can upload new decision forms. When you select a file such that it is visible in the modal, and then cancel the upload so the modal closes, you will see the document again if you click to upload another form. This prevents the user from selecting another file until he/she refreshes.

### 🚑The Fix
I added functionality to clear all documents from the mixin for uploading documents. I made a separate and better named action to close the modal, in which we explicitly clear all documents in the pipeline for potential upload. this makes it so that the modal is cleared when you open it again 👍 