### PR TITLE
KAS-1245: Fix Look/Feel of Side Navigation in Agenda List

### DIFF
--- a/app/components/agenda/agenda-list/list-item/template.hbs
+++ b/app/components/agenda/agenda-list/list-item/template.hbs
@@ -25,7 +25,7 @@
     {{/if}}
   {{/if}}
   {{#if renderDetails}}
-    <div class="vl-u-display-flex vl-u-flex-space-between">
+    <div class="vlc-agenda-meta vl-u-display-flex vl-u-flex-space-between">
       {{#if (and selectedAgendaItem isEditingOverview)}}
         <span class="vlc-agenda-meta__times-passed vl-u-text--capitalize vl-u-flex-grow">
         </span>

--- a/app/styles/custom-components/_vlc-agenda-items.scss
+++ b/app/styles/custom-components/_vlc-agenda-items.scss
@@ -80,6 +80,10 @@ a.vlc-agenda-items__sub-item--active:focus {
   background: darken($science-blue, 5%);
 }
 
+.vlc-agenda-meta {
+  padding-left: 3rem;
+}
+
 .vlc-agenda-meta__times-passed {
   opacity: 0.65;
 }
@@ -88,7 +92,7 @@ a.vlc-agenda-items__sub-item--active:focus {
 .vlc-agenda-items__subject {
   display: flex;
   justify-content: flex-start;
-  font-size: 1.6rem;
+  font-size: 1.4rem;
   line-height: 1.1;
   margin: 0 0 1rem;
   font-weight: 500;
@@ -116,7 +120,7 @@ a.vlc-agenda-items__sub-item--active:focus {
 }
 
 .vlc-agenda-items-sub-item__numbering {
-  padding-right: 0.75rem
+  min-width: 3rem;
 }
 
 /* Agenda items compare view

--- a/app/styles/custom-components/_vlc-agenda-items.scss
+++ b/app/styles/custom-components/_vlc-agenda-items.scss
@@ -33,7 +33,7 @@
 .vlc-agenda-items__sub-item > span { // a
   display: block;
   position: relative;
-  padding: 2rem 1.5rem 2rem 3.5rem;
+  padding: 2rem 1.5rem;
   font-size: 1.3rem;
   text-decoration: none;
   color: $black;

--- a/app/styles/custom-components/_vlc-agenda-items.scss
+++ b/app/styles/custom-components/_vlc-agenda-items.scss
@@ -88,7 +88,7 @@ a.vlc-agenda-items__sub-item--active:focus {
 .vlc-agenda-items__subject {
   display: flex;
   justify-content: flex-start;
-  font-size: 1.6rem;
+  font-size: 1.4rem;
   line-height: 1.1;
   margin: 0 0 1rem;
   font-weight: 500;


### PR DESCRIPTION
# 🔧 Fix padding to the side

![image](https://user-images.githubusercontent.com/1874332/79578096-0bea3600-80c6-11ea-87bc-2473333b961b.png)

### What's fixed?

We used to have this case for agenda's with more than 100 items, that the number would stick to the title. I've given it a fixed width so that the alignment is never broken, and text never gets to stick into anything.