### PR TITLE
Feature/kas 1488 cypress beforeall script

### DIFF
--- a/.env.cypress
+++ b/.env.cypress
@@ -1,0 +1,2 @@
+PROJECT_PATH=../kaleidos-project
+COMPOSE_FILE= -f ${PROJECT_PATH}/docker-compose.yml -f ${PROJECT_PATH}/docker-compose.development.yml -f ${PROJECT_PATH}/docker-compose.test.yml -f ${PROJECT_PATH}/docker-compose.override.yml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+include .env.cypress
+export $(shell sed 's/=.*//' .env.cypress)
+
+run-cypress-tests-after-reset-elastic:
+	- docker-compose ${COMPOSE_FILE} kill triplestore elasticsearch musearch file cache resource
+	- rm -rf ${PROJECT_PATH}/testdata
+	- unzip -o ${PROJECT_PATH}/testdata.zip -d ${PROJECT_PATH}
+	- docker-compose ${COMPOSE_FILE} up -d
+	- sleep 60
+	- npx cypress run --spec cypress/integration/unit/click-table.spec.js

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+include .env.cypress
+export $(shell sed 's/=.*//' .env.cypress)
+
+run-cypress-tests-after-reset-elastic:
+	- docker-compose ${COMPOSE_FILE} kill triplestore elasticsearch musearch file cache resource
+	- rm -rf ${PROJECT_PATH}/testdata
+	- unzip -o ${PROJECT_PATH}/testdata.zip -d ${PROJECT_PATH}
+	- docker-compose ${COMPOSE_FILE} up -d
+	- sleep 60
+	- npx cypress run

--- a/cypress/integration/unit/click-table.spec.js
+++ b/cypress/integration/unit/click-table.spec.js
@@ -25,8 +25,8 @@ context("Table Row Click tests", () => {
 	it("should open a case after clicking a row", () => {
 		cy.route('GET', '/cases/search**').as('getCases');
 		cy.visit('/dossiers');
-		cy.wait('@getCases', {timeout: 12000});
-		cy.get('.data-table > tbody').children().as('rows').eq(0).click();
+    cy.wait('@getCases', {timeout: 12000});
+    cy.openCase('Eerste dossier');
 		cy.url().should('contain', 'deeldossiers');
 	});
 

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -28,10 +28,6 @@ Cypress.on('uncaught:exception', (err, runnable) => {
   return !err.message.includes('calling set on destroyed object')
 });
 
-before(() => {
-  cy.resetSearch();
-});
-
 // workaround for issue DOES NOT WORK!!
 // CypressError: Timed out after waiting '60000ms' for your remote page to load.
 // Your page did not fire its 'load' event within '60000ms'.


### PR DESCRIPTION
I left the code resetSearch() in the commands so we can still use it if needed.

Running the full spec locally can be done with command:
`make run-cypress-tests-after-reset-elastic`

