### PR TITLE
Refactor next button component

### DIFF
--- a/app/components/settings/user/next-button/component.js
+++ b/app/components/settings/user/next-button/component.js
@@ -1,14 +1,15 @@
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 import { inject } from '@ember/service';
+import { action } from '@ember/object';
 
-export default Component.extend({
-  router: inject(),
-  actions: {
-    async onRowClick() {
-      const account = await this.get('row.account');
-      const user = await account.get('user');
-      const userId = await user.get('id');
-      this.router.transitionTo('settings.users.user', userId);
-    },
+export default class NextButton extends Component {
+  router = inject();
+
+  @action
+  async onRowClick() {
+    const account = await this.args.row.account;
+    const user = await account.user;
+    const userId = await user.id;
+    this.args.goToRoute('settings.users.user',userId);
   }
-});
+}

--- a/app/components/web-components/light-table/vlc-user-table-actionbar/template.hbs
+++ b/app/components/web-components/light-table/vlc-user-table-actionbar/template.hbs
@@ -3,5 +3,7 @@
     row=row
     refreshRoute=tableActions.refreshRoute
   }}
-  {{components/settings/user/next-button row=row}}
+  <Settings::User::NextButton
+          @row={{row}}
+          @goToRoute={{goToRoute}}/>
 </div>

--- a/app/controllers/settings/users/index.js
+++ b/app/controllers/settings/users/index.js
@@ -56,4 +56,9 @@ export default class UsersSettingsController extends Controller {
   refreshRoute() {
     this.send('refresh');
   }
+
+  @action
+  goToRoute(route, param) {
+    this.transitionToRoute(route, param);
+  }
 }

--- a/app/templates/settings/users/index.hbs
+++ b/app/templates/settings/users/index.hbs
@@ -112,6 +112,7 @@
                     <td>
                       {{web-components/light-table/vlc-user-table-actionbar
                         row=user
+                        goToRoute=goToRoute
                       }}
                     </td>
                   {{/c.body}}


### PR DESCRIPTION
# 👨🏼‍⚕️ Refactor `next-button` component to Octane

## 🔨 What has been done
In deze PR is de `next-button` component gerefactored naar een glimmer component. De instanties van `next-button` zijn verander van `{{` naar `<` en de parameters worden doorgegeven via `this.args`

Anderzijds doordat `this.router.transitionToRoute` niet meer werkte in het component, heb ik de actie toegevoegd aan de controller en is deze doorgegeven aan de component om vervolgens te gebruiken.