### PR TITLE
KAS-1545 fix getting agendaitem changes and improve test flakyness

### DIFF
--- a/app/controllers/agenda.js
+++ b/app/controllers/agenda.js
@@ -10,7 +10,7 @@ export default Controller.extend({
   currentSession: inject(),
   isLoading: false,
 
-  selectedAgendaObserver: observer('this.model.agenda', async function () {
+  selectedAgendaObserver: observer('model.agenda', async function () {
     this.set('agendaService.addedAgendaitems', []);
     this.set('agendaService.addedDocuments', []);
 

--- a/cypress/integration/unit/agendaitem-changes.spec.js
+++ b/cypress/integration/unit/agendaitem-changes.spec.js
@@ -49,14 +49,16 @@ context('Agendaitem changes tests', () => {
 
     // when toggling show changes  the agendaitem added since current agenda should show
     cy.addAgendaitemToAgenda(subcaseTitle2, false);
+    cy.setFormalOkOnItemWithIndex(2);
     cy.toggleShowChanges(true);
     cy.agendaItemExists(subcaseTitle2);
 
-    cy.setFormalOkOnItemWithIndex(2);
     cy.approveDesignAgenda();
 
+    cy.openDetailOfAgendaitem(subcaseTitle2);
+
     // when toggling show changes  the agendaitem with a new document version should show
-    cy.addNewDocumentVersionToAgendaItem(subcaseTitle1, file.newFileName , file);
+    cy.addNewDocumentVersionToAgendaItem(subcaseTitle1, file.newFileName , file, true);
     // TODO we should not have to "refresh" to see the changes. The checking for changes is set to an observer
     // TODO This observer is not triggering during initial opening of the agenda, so as a 'hack', we switch agendas to trigger it in the tests
     cy.wait(1000); //Computeds are not reloaded yet , maybe

--- a/cypress/support/commands/agenda-commands.js
+++ b/cypress/support/commands/agenda-commands.js
@@ -373,6 +373,7 @@ function approveDesignAgenda() {
       .wait('@getAgendas', { timeout: 12000 });
   });
   cy.get('.vl-loader').should('not.exist');
+  cy.wait(2000); //After approving the agenda, some data is reloaded and waiting reduces flakyness
 }
 
 /**
@@ -501,6 +502,7 @@ function toggleShowChanges(refresh) {
     cy.get('.vlc-side-nav-item', { timeout: 12000 })
       .first({ timeout: 12000 })
       .click();
+      cy.wait(2000); //a lot of data is being reloaded
     // cy.wait('@getChanges', {timeout: 20000});
   } else {
     cy.clickReverseTab('Overzicht');
@@ -509,6 +511,7 @@ function toggleShowChanges(refresh) {
   cy.get('.vlc-agenda-items .vlc-toolbar__right > .vlc-toolbar__item')
     .first()
     .click();
+  cy.wait(1500); // the changes are not loaded yet, cypress does not find the get call to agenda-sort
 }
 
 /**


### PR DESCRIPTION
The backend fix was removing the "this" from the observer.
It now triggers both on first opening of and agenda and switching between agendas.

In order to make the cypress test more stable, some waits where added.