### PR TITLE
KAS-1553: Fix Access Level

### DIFF
--- a/app/components/access-level-pill/component.js
+++ b/app/components/access-level-pill/component.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import EmberObject from '@ember/object';
 import { action, computed } from '@ember/object';
-import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import DS from 'ember-data';
 
@@ -11,8 +10,7 @@ export default class AccessLevelPill extends Component {
   @service() intl;
   @service('current-session') session;
   classNameBindings = [':vl-u-display-flex', ':vl-u-flex-align-center'];
-
-  @alias('accessLevel.isPending') loading;
+  loading = false;
 
   @computed('item.accessLevel')
   get accessLevel() {
@@ -97,9 +95,11 @@ export default class AccessLevelPill extends Component {
 
   @action
   async save() {
-    this.set('loading', true);
-    await this.item.storeAccessLevel(this.get('accessLevel'));
-    this.set('loading', false);
-    this.set('editing', false);
+    if (this.get('accessLevel')) {
+      this.set('loading', true);
+      await this.get('item').storeAccessLevel(this.get('accessLevel'));
+      this.set('loading', false);
+      this.set('editing', false);
+    }
   }
 }

--- a/app/components/access-level-pill/template.hbs
+++ b/app/components/access-level-pill/template.hbs
@@ -14,7 +14,7 @@
           data-test-model-selector
           @modelName="access-level"
           @allowClear={{true}}
-          @searchField="label"
+          @hideSearch={{true}}
           @propertyToShow="label"
           @readOnly={{item.confidential}}
           @sortField="priority"

--- a/app/components/agenda/agendaitem/agendaitem-case/subcase-document/document-link/template.hbs
+++ b/app/components/agenda/agendaitem/agendaitem-case/subcase-document/document-link/template.hbs
@@ -12,9 +12,7 @@
         <div class="vlc-toolbar__right">
           <div class="vlc-toolbar__item vl-u-display-flex">
             {{#if lastDocumentVersion}}
-              {{access-level-pill
-                item=lastDocumentVersion
-              }}
+              <AccessLevelPill @item={{lastDocumentVersion}} />
             {{/if}}
           </div>
           <div class="vlc-toolbar__item">

--- a/app/components/utils/model-selector/template.hbs
+++ b/app/components/utils/model-selector/template.hbs
@@ -12,6 +12,7 @@
     search=(perform searchTask)
     oninput=(action "resetValueIfEmpty")
     onchange=(action "selectModel")
+    searchEnabled=(not hideSearch)
   as |model|
   }}
     {{await (model-property-to-show model propertyToShow)}}


### PR DESCRIPTION
# 🐞 Bugfix: Access Level Saving Inconsistencies

![image](https://user-images.githubusercontent.com/1874332/82489232-979a1c80-9ae1-11ea-86e1-969c90c39583.png)

## What changed?

* Added some protection against saving an empty state `null`
* Disabled useless search in the dropdown (like designs)
* Added a protection against trying to change the loading state when `null`, by moving to a normal class based property for the state