### PR TITLE
KAS-1560: consistentie in switchen tabs brengen

### DIFF
--- a/app/components/agenda/agendaitem/agendaitem-overview/component.js
+++ b/app/components/agenda/agendaitem/agendaitem-overview/component.js
@@ -12,7 +12,6 @@ export default Component.extend({
   store: inject(),
   agendaService: inject(),
   currentSession: inject(),
-  activeAgendaItemSection: 'details',
   @tracked timestampForMostRecentNota:null,
 
   checkAgendaItemSubcase: observer('subcase', function () {
@@ -57,7 +56,7 @@ export default Component.extend({
         const agendaItem = await this.get('agendaitem');
         this.timestampForMostRecentNota = await this.agendaService.retrieveModifiedDateFromNota(agendaItem);
       }
-      this.set('activeAgendaItemSection', section);
+      this.setActiveAgendaitemSection(section);
     },
 
     refreshRoute(id) {

--- a/app/controllers/agenda/agendaitems/agendaitem.js
+++ b/app/controllers/agenda/agendaitems/agendaitem.js
@@ -6,6 +6,11 @@ export default Controller.extend({
   sessionService: inject(),
   currentAgenda: alias('sessionService.currentAgenda'),
   currentSession: alias('sessionService.currentSession'),
+  activeAgendaItemSection: 'details',
+
+  setActiveAgendaitemSection(agendatItemSection) {
+    this.set('activeAgendaItemSection',agendatItemSection);
+  },
 
   actions: {
     refresh(id) {

--- a/app/templates/agenda/agendaitems/agendaitem.hbs
+++ b/app/templates/agenda/agendaitems/agendaitem.hbs
@@ -1,4 +1,6 @@
 {{agenda/agendaitem/agendaitem-overview
   agendaitem=(await model)
+  activeAgendaItemSection="details"
+  setActiveAgendaitemSection=setActiveAgendaitemSection
   refreshRoute=(action "refresh")
 }}


### PR DESCRIPTION
# ⚠️ KAS-1560: consistentie in switchen tabs

Deze branch zorgt ervoor dat de tabs consistent op de eerste tab gezet zullen worden bij het switchen.
Dit is een tijdelijke acceptatie fix die overschreven zal worden door een fix op development die het ten gronde zal oplossen.