### PR TITLE
KAS-1613: Bugfix vetrouwelijkheid op agendaoverview

### DIFF
--- a/app/components/agenda/agenda-list/list-item/template.hbs
+++ b/app/components/agenda/agenda-list/list-item/template.hbs
@@ -107,38 +107,40 @@
               {{/if}}
             {{/if}}
             {{#if (not isEditingOverview)}}
-              {{#if (and currentSessionService.isViewer agendaitem.explanation)}}
+              {{#if (and currentSessionService.isViewer)}}
                 <div class="vlc-hr"></div>
                 <div class="vlc-agenda-items__remarks">
                   <div>
-                  <span class="vl-u-text--bold">{{ t "remark-title" }}
-                    : </span> {{agendaitem.explanation}}
+                    {{#if agendaitem.explanation}}
+                      <span class="vl-u-text--bold">{{ t "remark-title" }}
+                      : </span> {{agendaitem.explanation}}
+                    {{/if}}
                   </div>
                   <div class="vlc-agenda-items__icons">
-                    {{#if (and agendaitem.showAsRemark (not agendaitem.showInNewsletter))}}
-                      <i class="vl-button__icon vl-vi vl-vi-hide vl-u-spacer-extended-left-s opacity-lighter"></i>
-                    {{/if}}
-
-                    {{#if (await agendaitem.checkAdded)}}
-                      <i class="vl-link__icon vl-vi vl-vi-calendar-add">
-                        {{#attach-tooltip
-                          arrow="true"
-                          animation="shift"
-                          placement="top"
-                          class="ember-attacher-tooltip"
-                        }}
-                          <p>
-                            {{t "added-agendaitem-text"}}
-                          </p>
-                        {{/attach-tooltip}}
-                      </i>
-                    {{/if}}
+                    <div class="vl-u-display-flex vlc-agenda-items__icons">
+                      {{#if (and agendaitem.showAsRemark (not agendaitem.showInNewsletter))}}
+                        <i class="vl-button__icon vl-vi ki-hide vlc-u-opacity-50 vl-u-spacer-extended-left-s opacity-lighter"></i>
+                      {{/if}}
+                      {{#if (await agendaitem.checkAdded)}}
+                        <i class="vl-link__icon vl-vi ki-calendar-plus vlc-agenda-item__icons--margin">
+                          {{#attach-tooltip
+                            arrow="true"
+                            animation="shift"
+                            placement="top"
+                            class="ember-attacher-tooltip"
+                          }}
+                            <p>
+                              {{t "added-agendaitem-text"}}
+                            </p>
+                          {{/attach-tooltip}}
+                        </i>
+                      {{/if}}
+                    </div>
                     {{#if (await agendaitem.subcase.confidential)}}
                       <span type="button" class="vlc-agenda-items__confidentiality-button vlc-pill vlc-pill--error">
-                      <span
-                              class="vl-icon vl-vi vl-vi-lock vlc-agenda-items__icons"
-                              data-test-icon-agenda-confidentiality-locked
-                      ></span>
+                      <i class="vl-icon vl-vi ki-lock-closed vlc-agenda-items__icons"
+                         data-test-icon-agenda-confidentiality-locked
+                      ></i>
                         {{t "confidential"}}
                       </span>
                     {{/if}}

--- a/app/components/agenda/agenda-list/list-item/template.hbs
+++ b/app/components/agenda/agenda-list/list-item/template.hbs
@@ -107,7 +107,7 @@
               {{/if}}
             {{/if}}
             {{#if (not isEditingOverview)}}
-              {{#if (and currentSessionService.isViewer)}}
+              {{#if currentSessionService.isViewer}}
                 <div class="vlc-hr"></div>
                 <div class="vlc-agenda-items__remarks">
                   <div>

--- a/app/styles/custom-components/_vlc-agenda-items.scss
+++ b/app/styles/custom-components/_vlc-agenda-items.scss
@@ -224,7 +224,12 @@ $i: 0;
     color: $dove-gray;
     font-size: 1.7rem;
   }
+
+  .vlc-agenda-item__icons--margin {
+    margin-left: 1rem;
+  }
 }
+
 
 .vlc-agenda-items__confidentiality-button {
   margin-left: 1rem;

--- a/app/styles/custom-components/_vlc-agenda-items.scss
+++ b/app/styles/custom-components/_vlc-agenda-items.scss
@@ -230,7 +230,6 @@ $i: 0;
   }
 }
 
-
 .vlc-agenda-items__confidentiality-button {
   margin-left: 1rem;
   align-items: center;


### PR DESCRIPTION
# 🐞 KAS-1613: Bugfix vertrouwelijkheid op agenda overview

## ⚠️ ⚠️ ⚠️ Dit is de PR voor op `Acceptance`

## What has changed?
Het vetrouwelijkheid icon/pill werd niet weergeven bij een procedurestap van het type mededeling.
Dit lag aan herordening van de view waardoor deze niet weergeven werd.

In deze bugfix zijn ook direct de icons geupdatet naar de nieuwe icons..

![image](https://user-images.githubusercontent.com/11557630/84136554-c3a71e80-aa4b-11ea-8207-670db1748b90.png)


