### PR TITLE
KAS-1613: Conditioneel tonen lijn onder documenten

### DIFF
--- a/app/components/agenda/agenda-list/list-item/template.hbs
+++ b/app/components/agenda/agenda-list/list-item/template.hbs
@@ -108,7 +108,11 @@
             {{/if}}
             {{#if (not isEditingOverview)}}
               {{#if currentSessionService.isViewer}}
-                <div class="vlc-hr"></div>
+                {{#if
+                  (or (await agendaitem.subcase.confidential) (or (await agendaitem.checkAdded) (or agendaitem.explanation (and agendaitem.showAsRemark (not agendaitem.showInNewsletter)))))
+                }}
+                  <div class="vlc-hr"></div>
+                {{/if}}
                 <div class="vlc-agenda-items__remarks">
                   <div>
                     {{#if agendaitem.explanation}}


### PR DESCRIPTION
# 🐞 KAS-1613: minor bugfix voor lijn onder documenten

### ⚠️⚠️ Dit is de bugfix op `acceptatie`!

Er ontbrak een lijn logica voor het verbergen van de lijn tussen documenten en de icon's. Wanneer er geen icon's zijn, hoeft er ook geen lijn zichtbaar te zijn.

## 🕵🏻‍♂️ Voorbeelden:
### ❌ Zonder documenten en zonder icons:
![image](https://user-images.githubusercontent.com/11557630/84163585-f06e2c80-aa71-11ea-9a5c-53494713296e.png)

### 💰 Zonder documenten met icons:
![image](https://user-images.githubusercontent.com/11557630/84163648-04199300-aa72-11ea-9ffb-2b35c4c3f8b9.png)

### 💰💰 Met documenten met icons:
![image](https://user-images.githubusercontent.com/11557630/84163730-1abfea00-aa72-11ea-90de-90e5b50b2b25.png)

 
