### PR TITLE
KAS-1614: Formality issues in agendaoverview

### DIFF
--- a/app/components/agenda/agenda-list/template.hbs
+++ b/app/components/agenda/agenda-list/template.hbs
@@ -37,6 +37,7 @@
           {{#if overviewEnabled}}
           <div class="vl-u-spacer-extended-left-s">
             <a href=""
+               data-test-agenda-edit-formally-ok-button
                class="vlc-agenda-items-section-header__link"
               {{action "toggleIsEditingOverview"}}
             >

--- a/app/models/agenda.js
+++ b/app/models/agenda.js
@@ -38,7 +38,7 @@ export default Model.extend(LoadableModel, {
 
   isFinal: computed.alias('status.isFinal'),
 
-  isApprovable: computed('agendaitems.@each', function () {
+  isApprovable: computed('agendaitems.@each.formallyOk', function () {
     return this.get('agendaitems').then((agendaitems) => {
       const approvedAgendaItems = agendaitems.filter((agendaitem) =>
         this.checkFormallyOkStatus(agendaitem)

--- a/cypress/integration/unit/formally-ok.spec.js
+++ b/cypress/integration/unit/formally-ok.spec.js
@@ -1,5 +1,7 @@
-/*global context, before, it, cy,beforeEach, Cypress*/
+/*global context, it, cy,beforeEach*/
 /// <reference types="Cypress" />
+import agenda from '../../selectors/agenda.selectors';
+import modal from '../../selectors/modal.selectors';
 
 
 context('Formally ok/nok tests', () => {
@@ -13,11 +15,15 @@ context('Formally ok/nok tests', () => {
     cy.visit('/vergadering/5EBAB9B1BDF1690009000001/agenda/1d4f8091-51cf-4d3c-b776-1c07cc263e59/agendapunten');
     cy.get('.vlc-agenda-items__sub-item').should('have.length', 1);
     cy.get('.vlc-agenda-items__status').should('contain','Formeel OK');
+    cy.setFormalOkOnItemWithIndex(0,true,"Nog niet formeel OK");
+    cy.get(agenda.approveAgenda).click();
+    cy.get(modal.agenda.approveAgenda).should('exist');
+    cy.get(modal.verify.cancel).click();
+    cy.setFormalOkOnItemWithIndex(0,true,"Formeel OK");
     cy.get('.vlc-side-nav-item').as('agendas');
     cy.get('@agendas').eq(1).click();
     cy.wait(2000); //Make sure the formally ok can load (false positive if testing immediately)
     cy.get('.vlc-agenda-items__sub-item').should('have.length', 1);
     cy.get('.vlc-agenda-items__status').should('not.contain', 'Formeel OK');
   });
-
 });

--- a/cypress/selectors/agenda-overview.selectors.js
+++ b/cypress/selectors/agenda-overview.selectors.js
@@ -1,5 +1,6 @@
 const selectors = {
   agendaFilterInput: '[data-test-agendas-filter-input]',
-  agendaFilterButton: '[data-test-agendas-filter-button]'
+  agendaFilterButton: '[data-test-agendas-filter-button]',
+  agendaEditFormallyOkButton: '[data-test-agenda-edit-formally-ok-button]'
 };
 export default selectors;

--- a/cypress/support/commands/agenda-commands.js
+++ b/cypress/support/commands/agenda-commands.js
@@ -269,27 +269,31 @@ function deleteAgenda(meetingId, lastAgenda) {
  * @memberOf Cypress.Chainable#
  * @function
  */
-function setFormalOkOnItemWithIndex(indexOfItem) {
+function setFormalOkOnItemWithIndex(indexOfItem, fromWithinAgendaOverview = false, formalityStatus = "Formeel OK") {
   //TODO set only some items to formally ok with list as parameter
   cy.route('PATCH', '/agendaitems/**').as('patchAgendaItem');
 
-  cy.clickReverseTab('Overzicht');
+  if(!fromWithinAgendaOverview) {
+    cy.clickReverseTab('Overzicht');
 
-  cy.get('.vlc-agenda-items .vlc-toolbar__right > .vlc-toolbar__item')
-    .last().as('editFormality');
+    cy.get('.vlc-agenda-items .vlc-toolbar__right > .vlc-toolbar__item')
+      .last().as('editFormality');
 
-  cy.get('@editFormality').click();
+    cy.get('@editFormality').click();
+  } else {
+    cy.get(agendaOverview.agendaEditFormallyOkButton).click();
+  }
 
   cy.get('li.vlc-agenda-items__sub-item').as('agendaitems');
   cy.get('@agendaitems').eq(indexOfItem).scrollIntoView().within(() => {
     cy.get('.vl-u-spacer-extended-bottom-s').click();
   });
   cy.get('.ember-power-select-option')
-    .contains('Formeel OK')
+    .contains(formalityStatus)
     .click()
     .wait('@patchAgendaItem')
     .wait(1000) // sorry ik zou hier moeten wachten op access-levels maar net zoveel keer als dat er items zijn ...
-    .get('.ember-power-select-option').should('not.exist')
+    .get('.ember-power-select-option').should('not.exist');
   cy.get('.vlc-agenda-items .vl-alert button')
     .click();
 }


### PR DESCRIPTION
# 🟢 KAS-1614: Formality issues in agendaoverview

## 🔨 What has been done:
In deze PR is een de compute voor `isApproveable` aangepast om te luisteren op changes voor de `formallyOk` property.

`formally-ok.spec.js` is aangepast om ervoor te zorgen dat afgecheckt wordt dat de popup verschijnt wanneer er een element `nog niet formeel ok` is.

## 🧪 Tests
- ✅ `formally-ok.spec.js`
- ✅ `full-agenda.spec.js`