### PR TITLE
Improve visual look of icon preview

### DIFF
--- a/app/styles/custom-application/icons-overview.scss
+++ b/app/styles/custom-application/icons-overview.scss
@@ -1,36 +1,30 @@
-.icons-page {
-    font-family: sans-serif;
-    margin: 0;
-    padding: 1rem 2rem;
-    text-align: center;
-}
+.c-icons-overview {
 
-.preview {
+  h1 {
+    display: none;
+  }
+  
+  .preview {
     width: 10rem;
     display: inline-block;
     margin: 1rem;
-}
+  }
 
-.preview .inner {
+  .preview .inner {
     display: inline-block;
     width: 100%;
     text-align: center;
-    background: #f5f5f5;
-    -webkit-border-radius: 0.3rem 0.3rem 0 0;
-    -moz-border-radius: 0.3rem 0.3rem 0 0;
-    border-radius: 0.3rem 0.3rem 0 0;
-}
+  }
 
-.preview .inner i {
+  .preview .inner i {
     line-height: 8.5rem;
-    font-size: 4rem;
+    font-size: 3.2rem;
     color: #333;
-}
+  }
 
-.label {
+  .label {
     display: inline-block;
     width: 100%;
-    box-sizing: border-box;
     padding: 0.5rem;
     font-size: 1rem;
     font-family: Monaco, monospace;
@@ -38,9 +32,9 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    background: #ddd;
-    -webkit-border-radius: 0 0 0.3rem 0.3rem;
-    -moz-border-radius: 0 0 0.3rem 0.3rem;
     border-radius: 0 0 0.3rem 0.3rem;
+    text-align: center;
     color: #666;
+  }
+
 }

--- a/generate-icon-font.sh
+++ b/generate-icon-font.sh
@@ -43,7 +43,7 @@ fi
 
 # Make the new overview page - disable linting, add an icons-page class wrapper, and copy the generated contents into this template
 echo '{{!-- template-lint-disable  --}}' > $OVERVIEW_PAGE_PATH \
-		&& echo '<div class="icons-page">' >> $OVERVIEW_PAGE_PATH \
+		&& echo '<div class="c-icons-overview">' >> $OVERVIEW_PAGE_PATH \
 		&& xmllint --xpath "//body/child::*" "tmp/icons-temp.html" >> $OVERVIEW_PAGE_PATH \
 		&& printf "\n</div>" >> $OVERVIEW_PAGE_PATH
 


### PR DESCRIPTION
## What this PR does

Slightly improve the look of the icons preview.

This is a generated file coming from a package, so this is not exactly in line with the CSS rules (BEM)

To make this accord to the rules would be too much overhead for now and it doesn't matter anyway for this use case. This visual look update is already an improvement imo. 

## Before

![image](https://user-images.githubusercontent.com/12690/84871471-dee3e080-b080-11ea-9929-04656e815b56.png)

## After

<img width="1278" alt="CleanShot 2020-06-17 at 09 54 39@2x" src="https://user-images.githubusercontent.com/12690/84871770-3b470000-b081-11ea-99e3-09065bc0c153.png">
