### PR TITLE
Build commands for designers

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "scripts": {
     "prestart": "ember-template-lint .",
     "build": "ember build --environment=production",
+    "design": "ember serve --proxy=https://kaleidos-dev.vlaanderen.be",
+    "design-all": "npm-run-all lint:hbs design",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",


### PR DESCRIPTION
# Build commands for designers

In deze PR zorgen we ervoor dat de linter automatisch getriggerd wordt wanneer de designers het project opstarten die gebruik maken van de dev server als proxy voor data.

