### PR TITLE
Scroll selected item overview pane in to view

### DIFF
--- a/app/pods/components/agenda/agenda-detail/sidebar-item/component.js
+++ b/app/pods/components/agenda/agenda-detail/sidebar-item/component.js
@@ -129,7 +129,7 @@ export default Component.extend( {
 
     conditionallyScrollIntoView () {
       if (this.isActive) {
-        this.element.scrollIntoView({ behavior: "smooth", block: "center" });
+        this.element.scrollIntoView({ behavior: 'smooth', block: 'center' });
       }
     }
   },

--- a/app/pods/components/agenda/agenda-detail/sidebar-item/component.js
+++ b/app/pods/components/agenda/agenda-detail/sidebar-item/component.js
@@ -126,5 +126,11 @@ export default Component.extend( {
           this.toaster.error();
         });
     },
+
+    conditionallyScrollIntoView () {
+      if (this.isActive) {
+        this.element.scrollIntoView({ behavior: "smooth", block: "center" });
+      }
+    }
   },
 });

--- a/app/pods/components/agenda/agenda-detail/sidebar-item/template.hbs
+++ b/app/pods/components/agenda/agenda-detail/sidebar-item/template.hbs
@@ -1,4 +1,10 @@
-<div class="vl-u-display-flex">
+{{!-- Long term, I think we rather want this component to trigger an action when the "active" status toggles.
+  With that, a higher-level component can decide if it wants to scroll this element in to view. Currently, because the active status
+  is set rigth from the beginning and the component is rendered only once, scrolling on "did-insert" works just fine --}}
+<div
+  class="vl-u-display-flex"
+  {{did-insert (action "conditionallyScrollIntoView")}}
+>
   <span class="vlc-agenda-detail-sidebar-sub-item__numbering">
     {{#if agendaitem.number}}
       {{agendaitem.number}}.


### PR DESCRIPTION
Scroll the selected agenda-item-element in the overview sidebar into view when navigating from agenda-item overview to agenda-item detail view. See [KAS-1561](https://kanselarij.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=KAS&modal=detail&selectedIssue=KAS-1561) description and comments for more info. 

Shouldn't affect any tests.