### PR TITLE
KAS-1307: implementeren loader voor future agendas

### DIFF
--- a/app/pods/components/agenda/future-agendas/component.js
+++ b/app/pods/components/agenda/future-agendas/component.js
@@ -17,6 +17,14 @@ export default Component.extend({
     }
   }),
 
+  hasActiveAgendas: computed('meetings', async function () {
+    const meetings = await this.get('meetings');
+    if (meetings && meetings.length > 0) {
+      return true;
+    }
+    return false;
+  }),
+
   actions: {
     selectAgenda(meeting) {
       this.selectAgenda(meeting);

--- a/app/pods/components/agenda/future-agendas/template.hbs
+++ b/app/pods/components/agenda/future-agendas/template.hbs
@@ -1,116 +1,122 @@
 <h2 class="vl-title vl-title--h3">
   {{title}}
 </h2>
-{{#if (await meetings)}}
-  <table class="data-table vl-data-table vl-data-table--zebra vl-data-table--align-middle"
-         data-test-future-agenda-table>
-    <thead>
-    <tr>
-      <th class="vl-data-table-col-3 vl-data-table__header-title table-header-unsortable">
-        <div class="vl-u-display-flex vl-u-flex-align-center">
+{{#if (not (is-pending hasActiveAgendas))}}
+  {{#if (await hasActiveAgendas)}}
+    <table class="data-table vl-data-table vl-data-table--zebra vl-data-table--align-middle"
+           data-test-future-agenda-table>
+      <thead>
+      <tr>
+        <th class="vl-data-table-col-3 vl-data-table__header-title table-header-unsortable">
+          <div class="vl-u-display-flex vl-u-flex-align-center">
             <span>
               {{t "agenda"}}
             </span>
-        </div>
-      </th>
-      <th class="vl-data-table-col-2 vl-data-table__header-title table-header-unsortable"
-      >
-        <div class="vl-u-display-flex vl-u-flex-align-center">
+          </div>
+        </th>
+        <th class="vl-data-table-col-2 vl-data-table__header-title table-header-unsortable"
+        >
+          <div class="vl-u-display-flex vl-u-flex-align-center">
             <span>
               {{t "agenda-version"}}
             </span>
-        </div>
-      </th>
-      <th class="vl-data-table-col-2 vl-data-table__header-title table-header-unsortable"
-      >
-        <div class="vl-u-display-flex vl-u-flex-align-center">
+          </div>
+        </th>
+        <th class="vl-data-table-col-2 vl-data-table__header-title table-header-unsortable"
+        >
+          <div class="vl-u-display-flex vl-u-flex-align-center">
             <span>
               {{t "latest-modified"}}
             </span>
-        </div>
-      </th>
-      <th class="vl-data-table-col-2 vl-data-table__header-title table-header-unsortable"
-      >
-        <div class="vl-u-display-flex vl-u-flex-align-center">
+          </div>
+        </th>
+        <th class="vl-data-table-col-2 vl-data-table__header-title table-header-unsortable"
+        >
+          <div class="vl-u-display-flex vl-u-flex-align-center">
             <span>
               {{t "status"}}
             </span>
-        </div>
-      </th>
-      <th class="vl-data-table-col-2 vl-data-table__header-title table-header-unsortable"
-      >
-        <div class="vl-u-display-flex vl-u-flex-align-center">
+          </div>
+        </th>
+        <th class="vl-data-table-col-2 vl-data-table__header-title table-header-unsortable"
+        >
+          <div class="vl-u-display-flex vl-u-flex-align-center">
             <span>
               {{t "kind"}}
             </span>
-        </div>
-      </th>
-      <th class="vl-data-table-col-1"></th>
-    </tr>
-    </thead>
-    <tbody class="tr-hover" data-test-future-agenda-table-body>
-    {{#each (await items) as |meeting|}}
-      {{#link-to
-        "agenda.agendaitems"
-        meeting.id
-        meeting.latestAgenda.id
-        tagName="tr"
-        classNames="tr-hover"
-      }}
-        <td>
-          {{#if (is-pending meeting)}}
-            <div class="skeletal-loader" role="alert" aria-busy="true"></div>
-          {{else}}
-            {{t "agenda-for"}}
-            {{moment-format meeting.plannedStart "DD.MM.YYYY"}}
-          {{/if}}
-        </td>
-        <td>
-          {{#if (is-pending meeting.latestAgendaName)}}
-            <div class="skeletal-loader" role="alert" aria-busy="true"></div>
-          {{else if (await meeting.latestAgendaName)}}
-            {{await meeting.latestAgendaName}}
-          {{else}}
-            {{t "no-agenda"}}
-          {{/if}}
-        </td>
-        <td>
-          {{#if (is-pending meeting.latestAgenda)}}
-            <div class="skeletal-loader" role="alert" aria-busy="true"></div>
-          {{else}}
-            {{moment-format
-              (await meeting.latestAgenda.modified)
-              "DD-MM-YYYY HH:mm"
+          </div>
+        </th>
+        <th class="vl-data-table-col-1"></th>
+      </tr>
+      </thead>
+      <tbody class="tr-hover" data-test-future-agenda-table-body>
+      {{#each (await items) as |meeting|}}
+        {{#link-to
+          "agenda.agendaitems"
+          meeting.id
+          meeting.latestAgenda.id
+          tagName="tr"
+          classNames="tr-hover"
+        }}
+          <td>
+            {{#if (is-pending meeting)}}
+              <div class="skeletal-loader" role="alert" aria-busy="true"></div>
+            {{else}}
+              {{t "agenda-for"}}
+              {{moment-format meeting.plannedStart "DD.MM.YYYY"}}
+            {{/if}}
+          </td>
+          <td>
+            {{#if (is-pending meeting.latestAgendaName)}}
+              <div class="skeletal-loader" role="alert" aria-busy="true"></div>
+            {{else if (await meeting.latestAgendaName)}}
+              {{await meeting.latestAgendaName}}
+            {{else}}
+              {{t "no-agenda"}}
+            {{/if}}
+          </td>
+          <td>
+            {{#if (is-pending meeting.latestAgenda)}}
+              <div class="skeletal-loader" role="alert" aria-busy="true"></div>
+            {{else}}
+              {{moment-format
+                (await meeting.latestAgenda.modified)
+                "DD-MM-YYYY HH:mm"
+              }}
+            {{/if}}
+          </td>
+          <td>
+            {{#if meeting.isFinal}}
+              {{t "closed"}}
+            {{else}}
+              {{t "opened"}}
+            {{/if}}
+          </td>
+          <td>
+            {{meeting.kindToShow.label}}
+          </td>
+          <td class="vl-u-align-right">
+            {{#link-to
+              "agenda.agendaitems"
+              meeting.id
+              meeting.latestAgenda.id
+              class="vl-button vl-button--link vl-button--icon"
+              bubbles=false
             }}
-          {{/if}}
-        </td>
-        <td>
-          {{#if meeting.isFinal}}
-            {{t "closed"}}
-          {{else}}
-            {{t "opened"}}
-          {{/if}}
-        </td>
-        <td>
-          {{meeting.kindToShow.label}}
-        </td>
-        <td class="vl-u-align-right">
-          {{#link-to
-            "agenda.agendaitems"
-            meeting.id
-            meeting.latestAgenda.id
-            class="vl-button vl-button--link vl-button--icon"
-            bubbles=false
-          }}
-            <i class="vl-button__icon vl-vi vl-vi-nav-right"></i>
-          {{/link-to}}
-        </td>
-      {{/link-to}}
-    {{/each}}
-    </tbody>
-  </table>
+              <i class="vl-button__icon vl-vi vl-vi-nav-right"></i>
+            {{/link-to}}
+          </td>
+        {{/link-to}}
+      {{/each}}
+      </tbody>
+    </table>
+  {{else}}
+    <div>
+      {{web-components/vl-alert message=emptyText}}
+    </div>
+  {{/if}}
 {{else}}
-  <div>
-    {{web-components/vl-alert message=emptyText}}
-  </div>
+  {{web-components/vl-loader
+    text=(concat (t "loading-active-agendas") " " (t "please-be-patient"))
+  }}
 {{/if}}

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -583,5 +583,6 @@
   "reassign-agendaitem-priorities-title": "Aanpassen van agendapunten",
   "reassign-agendaitem-priorities-message": "Uw aanpassing wordt opgeslagen.",
   "show-more": "Toon meer",
-  "show-less": "Toon minder"
+  "show-less": "Toon minder",
+  "loading-active-agendas": "De actieve agendas worden geladen."
 }


### PR DESCRIPTION
# 🕔 KAS-1307: implementeren loader voor future agendas
In deze PR hebben we een minor design issue opgelost waar je voor enkele tienden van een seconde, zag staan dat er geen agenda's waren terwijl er toch agenda's waren.

## 🔨 What has been done:

Ter fix hebben we een loader geïmplementeerd die weergeven wordt terwijl de agenda's aan het laden zijn.

**Old:**
![image](https://user-images.githubusercontent.com/11557630/85521241-3c89a700-b604-11ea-8627-753fd1d619d1.png)

**New:**
<img width="1663" alt="futureagendas" src="https://user-images.githubusercontent.com/11557630/85521174-2a0f6d80-b604-11ea-9223-2520f49a5811.png">

## 🧪 Testen:
Zijn aan het lopen op de CI.
