### PR TITLE
KAS-1680: bugfix instellen vertrouwelijkheid op documenten

### DIFF
--- a/app/pods/components/agenda/agendaitem/agendaitem-case/edit-subcase-documents/template.hbs
+++ b/app/pods/components/agenda/agendaitem/agendaitem-case/edit-subcase-documents/template.hbs
@@ -19,11 +19,11 @@
       </tr>
       </thead>
       <tbody>
-      {{#each (await documents) as |document|}}
+      {{#each (await documents) as |documentContainer|}}
         {{#if
-          (and (not document.deleted) (await document.lastDocumentVersion))
+          (and (not documentContainer.deleted) (await documentContainer.lastDocumentVersion))
         }}
-          {{edit-document-version document=document item=item}}
+          {{edit-document-version documentContainer=documentContainer item=item}}
         {{/if}}
       {{/each}}
       </tbody>

--- a/app/pods/components/edit-document-version/component.js
+++ b/app/pods/components/edit-document-version/component.js
@@ -53,6 +53,11 @@ export default Component.extend({
     async chooseAccessLevel(document, accessLevel) {
       let documentVersion = await document.get('lastDocumentVersion');
       documentVersion.set('accessLevel', accessLevel);
+    },
+
+    async toggleConfidential(document) {
+      const value = document.get('lastDocumentVersion.confidential');
+      document.set('lastDocumentVersion.confidential', !value);
     }
   }
 });

--- a/app/pods/components/edit-document-version/component.js
+++ b/app/pods/components/edit-document-version/component.js
@@ -54,10 +54,5 @@ export default Component.extend({
       let documentVersion = await document.get('lastDocumentVersion');
       documentVersion.set('accessLevel', accessLevel);
     },
-
-    async toggleConfidential(document) {
-      const value = document.get('lastDocumentVersion.confidential');
-      document.set('lastDocumentVersion.confidential', !value);
-    }
   }
 });

--- a/app/pods/components/edit-document-version/component.js
+++ b/app/pods/components/edit-document-version/component.js
@@ -4,36 +4,37 @@ import DS from 'ember-data';
 
 export default Component.extend({
   tagName: 'tr',
-  myDocumentVersions: computed.alias('item.documentVersions'),
+  myDocuments: computed.alias('item.documentVersions'),
 
-  lastDocumentVersion: computed('mySortedDocumentVersions.@each', function () {
-    const sortedVersions = this.get('mySortedDocumentVersions');
-    return sortedVersions.lastObject;
+  myLastDocument: computed('mySortedDocuments.@each', function () {
+    const mySortedDocuments = this.get('mySortedDocuments');
+    return mySortedDocuments.lastObject;
   }),
 
-  lastDocumentVersionName: computed('lastDocumentVersion.name', function () {
-    return this.get('lastDocumentVersion.name');
+  myLastDocumentName: computed('myLastDocument.name', function () {
+    return this.get('myLastDocument.name');
   }),
 
   // TODO: DUPLICATE CODE IN agenda/agendaitem/agendaitem-case/subcase-document/document-link/component.js
   // TODO: DUPLICATE CODE IN agendaitem/agendaitem-case/subcase-document/linked-document-link/component.js
   // TODO: DUPLICATE CODE IN edit-document-version/component.js
-  mySortedDocumentVersions: computed('myDocumentVersions.@each', 'document.sortedDocumentVersions.@each', function () {
+  // TODO: THIS CODE HAS BEEN REFACTORED TO USE BETTER VARIABLE NAMES
+  mySortedDocuments: computed('myDocuments.@each', 'documentContainer.sortedDocuments.@each', function () {
     return DS.PromiseArray.create({
       promise: (async () => {
-        const itemVersionIds = {};
-        const versions = await this.get('myDocumentVersions');
-        if (versions) {
-          versions.map((item) => {
-            itemVersionIds[item.get('id')] = true;
+        const documentIds = {};
+        const myDocuments = await this.get('myDocuments');
+        if (myDocuments) {
+          myDocuments.map((document) => {
+            documentIds[document.get('id')] = true;
           });
         }
-        const documentVersions = await this.get('document.sortedDocumentVersions');
-        if (documentVersions) {
-          const matchingVersions = await documentVersions.filter((item) => {
-            return itemVersionIds[item.id];
+        const documentsFromContainer = await this.get('documentContainer.sortedDocuments');
+        if (documentsFromContainer) {
+          const matchingDocuments = await documentsFromContainer.filter((document) => {
+            return documentIds[document.id];
           });
-          return matchingVersions;
+          return matchingDocuments;
         }
 
         return;
@@ -43,16 +44,15 @@ export default Component.extend({
 
   actions: {
 
-    deleteRow(document) {
-      document.set('deleted', true);
+    deleteRow(documentContainer) {
+      documentContainer.set('deleted', true);
     },
-    chooseDocumentType(document, type) {
-      document.set('type', type);
+    chooseDocumentType(documentContainer, type) {
+      documentContainer.set('type', type);
     },
 
     async chooseAccessLevel(document, accessLevel) {
-      let documentVersion = await document.get('lastDocumentVersion');
-      documentVersion.set('accessLevel', accessLevel);
+      document.set('accessLevel', accessLevel);
     },
   }
 });

--- a/app/pods/components/edit-document-version/template.hbs
+++ b/app/pods/components/edit-document-version/template.hbs
@@ -34,8 +34,7 @@
 </td>
 <td>
   {{web-components/vl-toggle
-    value=(mut document.confidential)
-    valueChanged=(action "toggleConfidential" document)
+    value=(mut document.lastDocumentVersion.confidential)
   }}
 </td>
 <td class="vl-u-align-right">

--- a/app/pods/components/edit-document-version/template.hbs
+++ b/app/pods/components/edit-document-version/template.hbs
@@ -5,7 +5,7 @@
     ></i>
   </div>
   <p>
-    {{await lastDocumentVersionName}}
+    {{await myLastDocumentName}}
   </p>
 </td>
 <td>
@@ -15,8 +15,8 @@
     searchField="label"
     propertyToShow="label"
     sortField="priority"
-    selectedItems=document.type
-    selectModel=(action "chooseDocumentType" document)
+    selectedItems=documentContainer.type
+    selectModel=(action "chooseDocumentType" documentContainer)
   }}
 </td>
 <td>
@@ -26,20 +26,20 @@
     searchField="label"
     allowClear=true
     propertyToShow="label"
-    readOnly=document.confidential
+    readOnly=myLastDocument.confidential
     sortField="label"
-    selectedItems=document.lastDocumentVersion.accessLevel
-    selectModel=(action "chooseAccessLevel" document)
+    selectedItems=myLastDocument.accessLevel
+    selectModel=(action "chooseAccessLevel" myLastDocument)
   }}
 </td>
 <td>
   {{web-components/vl-toggle
-    value=(mut document.lastDocumentVersion.confidential)
+    value=(mut myLastDocument.confidential)
   }}
 </td>
 <td class="vl-u-align-right">
   <button type="button" class="vl-button vl-button--link"
-    {{action "deleteRow" document}}
+    {{action "deleteRow" documentContainer}}
   >
     <i class="vl-vi vl-vi-trash" aria-hidden="true"></i>
     <span class="vl-u-visually-hidden">

--- a/app/pods/components/edit-document-version/template.hbs
+++ b/app/pods/components/edit-document-version/template.hbs
@@ -33,7 +33,10 @@
   }}
 </td>
 <td>
-  {{web-components/vl-toggle value=(mut document.confidential)}}
+  {{web-components/vl-toggle
+    value=(mut document.confidential)
+    valueChanged=(action "toggleConfidential" document)
+  }}
 </td>
 <td class="vl-u-align-right">
   <button type="button" class="vl-button vl-button--link"


### PR DESCRIPTION
# 🐞 KAS-1680: bugfix instellen vertrouwelijkheid op documenten
Het aanpassen van de vertrouwelijkheid van de documenten werkte niet meer, deze PR zal dit probleem oplossen. 
De issue was dat we in de view de laatste versie niet meegaven van het document maar het volledige document domeinmodel.

## What has changed:
In de code passen we nu de vertrouwelijkheid aan van de laatste documentversie via de slider.

![image](https://user-images.githubusercontent.com/11557630/86208946-d1931f80-bb71-11ea-90f2-c8557b0b2046.png)

## Tests
☢️ Currrently running
