### PR TITLE
Feature/kas 1706 ministers mededelingen

### DIFF
--- a/app/pods/components/agenda/agenda-list/template.hbs
+++ b/app/pods/components/agenda/agenda-list/template.hbs
@@ -148,13 +148,13 @@
         as |announcement|
         }}
 
-          <div class="vlc-list-section-header">
-            {{!-- TODO: these triple curlies are used for displaying a computed string with br tags in it.
-              These items concatenated by <br> should become a list that is iterated over in a .hbs template --}}
-            {{!-- template-lint-disable no-triple-curlies  --}}
-            {{{announcement.groupName}}}
-            {{!-- template-lint-enable no-triple-curlies  --}}
-          </div>
+<!--          <div class="vlc-list-section-header">-->
+<!--            {{!-- TODO: these triple curlies are used for displaying a computed string with br tags in it.-->
+<!--              These items concatenated by <br> should become a list that is iterated over in a .hbs template --}}-->
+<!--            {{!-- template-lint-disable no-triple-curlies  --}}-->
+<!--            {{! {{{announcement.groupName}}-->
+<!--            {{!-- template-lint-enable no-triple-curlies  --}}-->
+<!--          </div>-->
           {{#sortable-item
             tagName="li"
             class="vlc-agenda-items__sub-item"

--- a/app/pods/components/agenda/agenda-list/template.hbs
+++ b/app/pods/components/agenda/agenda-list/template.hbs
@@ -147,14 +147,6 @@
           (await announcements)
         as |announcement|
         }}
-
-<!--          <div class="vlc-list-section-header">-->
-<!--            {{!-- TODO: these triple curlies are used for displaying a computed string with br tags in it.-->
-<!--              These items concatenated by <br> should become a list that is iterated over in a .hbs template --}}-->
-<!--            {{!-- template-lint-disable no-triple-curlies  --}}-->
-<!--            {{! {{{announcement.groupName}}-->
-<!--            {{!-- template-lint-enable no-triple-curlies  --}}-->
-<!--          </div>-->
           {{#sortable-item
             tagName="li"
             class="vlc-agenda-items__sub-item"


### PR DESCRIPTION
###   Remove minister header voor announcements =>🗑️

Er stond een minster header voor Announcements. 
Dit was niet gewenst.
hier ziet u de header
<img width="556" alt="Screenshot 2020-07-09 at 11 03 58" src="https://user-images.githubusercontent.com/592312/87021626-bb223f00-c1d5-11ea-806c-85d389c2cd39.png">

Zo moet het echter zijn:
<img width="584" alt="Screenshot 2020-07-09 at 11 04 36" src="https://user-images.githubusercontent.com/592312/87021629-bc536c00-c1d5-11ea-9710-db81c6eab5df.png">
