### PR TITLE
KAS-1639: Refactor application controller

### DIFF
--- a/app/pods/application/controller.js
+++ b/app/pods/application/controller.js
@@ -1,6 +1,5 @@
 import Controller from '@ember/controller';
-import { computed, observer } from '@ember/object';
-import { on } from '@ember/object/evented';
+import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { A } from '@ember/array';
 
@@ -27,39 +26,6 @@ export default Controller.extend({
       passive: true,
     });
   },
-
-  async checkAccountlessUser(currentRouteName) {
-    if (currentRouteName.includes('loading')) {
-      return;
-    }
-
-    const user = await this.get('session.isAuthenticated');
-    if (!user) {
-      return;
-    }
-
-    const role = await this.get('currentSession.userRole');
-    if (role == 'no-access' || role === 'users') {
-      this.transitionToRoute('accountless-users');
-    }
-  },
-
-  shouldNavigateObserver: on(
-    'init',
-    observer(
-      'router.currentRouteName',
-      'currentSession.userRole',
-      'session.isAuthenticated',
-      function () {
-        const { router } = this;
-        if (!router || !router.currentRouteName) {
-          return;
-        }
-        const currentRouteName = router.get('currentRouteName');
-        this.checkAccountlessUser(currentRouteName);
-      }
-    )
-  ),
 
   showHeader: computed('currentSession.userRole', function () {
     let role = this.get('currentSession.userRole');

--- a/app/pods/application/controller.js
+++ b/app/pods/application/controller.js
@@ -39,7 +39,7 @@ export default Controller.extend({
     }
 
     const role = await this.get('currentSession.userRole');
-    if (role == 'no-access') {
+    if (role == 'no-access' || role === 'users') {
       this.transitionToRoute('accountless-users');
     }
   },

--- a/app/pods/application/route.js
+++ b/app/pods/application/route.js
@@ -2,7 +2,6 @@ import Route from '@ember/routing/route';
 import ENV from 'fe-redpencil/config/environment';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 import { inject as service } from '@ember/service';
-import { computed } from '@ember/object';
 
 export default Route.extend(ApplicationRouteMixin, {
   moment: service(),
@@ -39,52 +38,36 @@ export default Route.extend(ApplicationRouteMixin, {
     window.location.replace(logoutUrl);
   },
 
-  userRoleOfSession: computed('currentSession.userRole', async function() {
+  async userRoleOfSession() {
     const role = await this.get('currentSession.userRole');
     if (role) {
       return role;
     }
     return null;
-  }),
+  },
 
-  async userHasValidGroup(role) {
+  userHasValidGroup(role) {
     if (role !== 'no-access' && role !== 'users') {
       return true;
     }
     return false;
   },
 
-  isUserLoggedIn: computed('session.isAuthenticated', async function(){
-    const isAuthenticated = await this.get('session.isAuthenticated');
-    return isAuthenticated;
-  }),
+  async isUserLoggedIn(){
+    return await this.get('session.isAuthenticated');
+  },
 
-  currentRouteName: computed('router.currentRouteName', function() {
-    if (!this.router) {
-      return true;
-    }
-    const currentRouteName = this.router.currentRouteName;
-    return currentRouteName;
-  }),
-
-  isValidUser: computed('currentSession.userRole', 'session.isAuthenticated', async function (){
-    const userRoleOfSession = await this.userRoleOfSession;
-    if(this.currentRouteName) {
-      return await this.userHasValidGroup(userRoleOfSession);
-    }
-
-    if(this.router.rootURL) {
-      return await this.userHasValidGroup(userRoleOfSession);
-    }
-    return true;
-  }),
+  async isValidUser(){
+    const userRoleOfSession = await this.userRoleOfSession();
+    return this.userHasValidGroup(userRoleOfSession);
+    },
 
   async model() {
-    const userIsLoggedIn = await this.isUserLoggedIn;
+    const userIsLoggedIn = await this.isUserLoggedIn();
     if(userIsLoggedIn) {
-      const userRoleOfSession = await this.userRoleOfSession;
+      const userRoleOfSession = await this.userRoleOfSession();
       if(userRoleOfSession != null) {
-        const validUser = await this.isValidUser;
+        const validUser = await this.isValidUser();
         if(!validUser) {
           this.transitionTo('accountless-users');
         }
@@ -102,8 +85,8 @@ export default Route.extend(ApplicationRouteMixin, {
 
   actions: {
     willTransition: async function (transition) {
-      const userRoleOfSession = await this.userRoleOfSession;
-      const validUser = await this.isValidUser;
+      const userRoleOfSession = await this.userRoleOfSession();
+      const validUser = await this.isValidUser();
       if(userRoleOfSession != null) {
         if(!validUser) {
           this.transitionTo('accountless-users');

--- a/cypress/integration/unit/authentication.spec.js
+++ b/cypress/integration/unit/authentication.spec.js
@@ -13,13 +13,23 @@ context('Authentication tests', () => {
     // cy.url().should('contain', 'https://authenticatie-ti.vlaanderen.be/stb/html/pages?TAM_OP=logout_success', {timeout : 5000 });
   });
 
-  it.only('should logout using the logout button', () => {
+  it('should logout using the logout button', () => {
     cy.server();
     // cy.route('GET', "https://authenticatie-ti.vlaanderen.be/stb/html/pages?TAM_OP=logout_success").as('logoutURL')
     cy.loginFlow('Admin');
     cy.logoutFlow();
     cy.visit('/');
     cy.contains('Meld u aan');
+    // cy.url().should('contain', 'https://authenticatie-ti.vlaanderen.be/stb/html/pages?TAM_OP=logout_success', {timeout : 5000 });
+  });
+
+  it('Logging in as user should redirect to /accountless-users', () => {
+    cy.server();
+    // cy.route('GET', "https://authenticatie-ti.vlaanderen.be/stb/html/pages?TAM_OP=logout_success").as('logoutURL')
+    cy.login('User');
+    cy.visit('/');
+    cy.contains('U heeft zich aangemeld om binnen Kaleidos gebruiksrechten te bekomen.');
+    cy.url().should('contain', '/onbevoegde-gebruiker');
     // cy.url().should('contain', 'https://authenticatie-ti.vlaanderen.be/stb/html/pages?TAM_OP=logout_success', {timeout : 5000 });
   });
 });

--- a/cypress/integration/unit/toolbar/shouldSwitchPagesWhenClickingOnTabsLoggedInAsUser.spec.js
+++ b/cypress/integration/unit/toolbar/shouldSwitchPagesWhenClickingOnTabsLoggedInAsUser.spec.js
@@ -22,29 +22,21 @@ context('Testing the toolbar as user user', () => {
     cy.get(toolbar.settings).should('not.exist');
   });
 
-  it('Should switch to Agenda tab when agenda is clicked as user', () => {
+  it.only('Should switch to Agenda tab when agenda is clicked as user', () => {
     cy.get(toolbar.agenda).click();
-    cy.get(agenda.overviewTitle).should('exist');
-    cy.get(cases.casesOverviewTitle).should('not.exist');
-    cy.get(newsletter.overviewTitle).should('not.exist');
+    cy.contains('Geen rechten');
     cy.get(toolbar.settings).should('not.exist');
   });
 
   it('Should switch to cases tab when cases is clicked as user', () => {
     cy.get(toolbar.cases).click();
-    cy.get(agenda.overviewTitle).should('not.exist');
-    cy.get(cases.casesOverviewTitle).should('exist');
-    cy.get(newsletter.overviewTitle).should('not.exist');
-    cy.get(settings.generalSettings).should('not.exist');
+    cy.contains('Geen rechten');
     cy.get(toolbar.settings).should('not.exist');
   });
 
   it('Should switch to newsletter tab when newsletter is clicked as user', () => {
     cy.get(toolbar.newsletters).click();
-    cy.get(agenda.overviewTitle).should('not.exist');
-    cy.get(cases.casesOverviewTitle).should('not.exist');
-    cy.get(newsletter.title).should('exist');
-    cy.get(settings.generalSettings).should('not.exist');
+    cy.contains('Geen rechten');
     cy.get(toolbar.settings).should('not.exist');
   });
 });

--- a/cypress/integration/unit/toolbar/shouldSwitchPagesWhenClickingOnTabsLoggedInAsUser.spec.js
+++ b/cypress/integration/unit/toolbar/shouldSwitchPagesWhenClickingOnTabsLoggedInAsUser.spec.js
@@ -2,10 +2,6 @@
 /// <reference types="Cypress" />
 
 import toolbar from "../../../selectors/toolbar.selectors";
-import settings from "../../../selectors/settings.selectors";
-import cases from "../../../selectors/case.selectors";
-import agenda from "../../../selectors/agenda.selectors";
-import newsletter from "../../../selectors/newsletter.selector";
 
 context('Testing the toolbar as user user', () => {
 
@@ -22,7 +18,7 @@ context('Testing the toolbar as user user', () => {
     cy.get(toolbar.settings).should('not.exist');
   });
 
-  it.only('Should switch to Agenda tab when agenda is clicked as user', () => {
+  it('Should switch to Agenda tab when agenda is clicked as user', () => {
     cy.get(toolbar.agenda).click();
     cy.contains('Geen rechten');
     cy.get(toolbar.settings).should('not.exist');


### PR DESCRIPTION
# 👀 KAS-1639: Refactor Observer from application controller
In deze PR hebben we de observer herwerkt in de application controller zodat hier geen observer meer instaat.

## ✏️ What has changed:
De observer is herschreven tot een computed function die we oproepen op verschillende hooks in de route.

## 🖼 Screenshots
**Wanneer je ingelogd bent via mock-login en je veranderd van route via het klikken op de dossiers knop kom je in de willTransition action..**
![image](https://user-images.githubusercontent.com/11557630/87571718-c8a26200-c6ca-11ea-9e80-46d882f47390.png)

**Wanneer je rechtstreeks op de URL surft kom je terecht in de model hook**
![image](https://user-images.githubusercontent.com/11557630/87571828-e66fc700-c6ca-11ea-80ce-11c05dbd3299.png)

## 🚨🚨 Important note
het redirecten van een gebruiker met de rol `users` werkt niet lokaal omdat we inloggen via mock-login.. op het moment dat we hier inloggen zijn de rollen van de gebruiker nog niet gekend.. de initiële login zal dus gewoon doorgaan en je zal de standaard agenda pagina zien..

Op acceptatie zou dit echter niet mogelijk zijn omdat daar geen mock-login draait.. daar volg je de normale flow wat uitkomt in de `model` hook.. deze heeft wel reeds weet van de rol van de gebruiker en zal de gebruiker door redirecten naar de `accountless-users` route..

# 🧪 Tests
- `authentication.spec.js`
- `Suite running on jenkins`