### PR TITLE
KAS-1640: Refactored the observer out of job model

### DIFF
--- a/app/models/job.js
+++ b/app/models/job.js
@@ -1,6 +1,5 @@
 import DS from 'ember-data';
 import Evented from '@ember/object/evented';
-import { observer } from '@ember/object';
 import { computed } from '@ember/object';
 
 export default DS.Model.extend(Evented, {
@@ -13,12 +12,10 @@ export default DS.Model.extend(Evented, {
   timeStarted: DS.attr(),
   timeEnded: DS.attr(),
   hasEnded: computed('status', function () {
-    return this.status === this.SUCCESS || this.status === this.FAILED;
-  }),
-
-  statusObserver: observer('hasEnded', function () {
-    if (this.hasEnded) {
+    const isSuccess = this.status === this.SUCCESS || this.status === this.FAILED;
+    if(isSuccess) {
       this.trigger('didEnd', this.status);
     }
-  })
+    return isSuccess;
+  }),
 });

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -13,7 +13,7 @@ export default DS.Model.extend(Evented, {
   timeEnded: DS.attr(),
   hasEnded: computed('status', function () {
     const isSuccess = this.status === this.SUCCESS || this.status === this.FAILED;
-    if(isSuccess) {
+    if (isSuccess) {
       this.trigger('didEnd', this.status);
     }
     return isSuccess;


### PR DESCRIPTION
# 👁‍🗨 KAS-1640: Refactored the observer out of job model
In deze PR hebben we de observer uit de job model gerefactored.

## ✏️ What has been done:
De logica die in de observer stak hebben we geïntegreerd in de computed property. Dit geeft na testen identiek hetzelfde resultaat.

## Tests:
- `currently running on jenkins`