### PR TITLE
KAS-1707: formeel ok niet zuiver fix

### DIFF
--- a/app/pods/components/utils/documents-list-lazy-loaded/component.js
+++ b/app/pods/components/utils/documents-list-lazy-loaded/component.js
@@ -2,6 +2,5 @@ import Component from '@ember/component';
 
 export default Component.extend({
 	tagName: 'ul',
-	classNames:['vlc-document-list'],
 	isClickable: null
 });

--- a/app/pods/components/utils/documents-list-lazy-loaded/template.hbs
+++ b/app/pods/components/utils/documents-list-lazy-loaded/template.hbs
@@ -1,10 +1,10 @@
-{{#each (await documentNames) as |documentName|}}
-  <li class="vlc-document-list__item vlc-document-list__item--loading">
-    <span>
-      <div class="vl-badge vl-badge--icon vl-badge--small-medium vl-badge--alt">
-        <i class="vl-badge__icon vl-vi vl-vi-synchronize"></i>
-      </div>
-      {{documentName}}
-    </span>
-  </li>
-{{/each}}
+<div class="grid-container">
+  {{#each (await documentNames) as |documentName|}}
+    <li class="vlc-document-list__item vlc-document-list__item--loading">
+      <span>
+          <i class="vl-badge__icon vl-vi vl-vi-synchronize"></i>
+        {{documentName}}
+      </span>
+    </li>
+  {{/each}}
+</div>


### PR DESCRIPTION
# ✅ KAS-1707: Formeel ok niet zuiver
In dit ticket hebben we een oplossing geïmplementeerd om de verspringing tijdens het veranderen van `formeel ok` status te beperken..

## ✏️ What has changed
De lazy loading component bevatte nog de oude layout van de documenten waardoor er veel verspringingen voorkomen, dit is er opgelost met deze PR.

## Screenshots:
**Lazy loading:**
![image](https://user-images.githubusercontent.com/11557630/87299111-b3cba000-c50b-11ea-87cf-0bfd6debe9b1.png)

## Tests:
`currrently running on jenkins`
