### PR TITLE
KAS-1723: Fix bug in het saven van beslissingen

### DIFF
--- a/app/pods/components/agenda/agendaitem/agendaitem-decision-edit/component.js
+++ b/app/pods/components/agenda/agendaitem/agendaitem-decision-edit/component.js
@@ -48,8 +48,6 @@ export default Component.extend({
 
     async saveChanges() {
       this._super.call(this);
-      debugger;
-
       this.set('isLoading', true);
 
       const decision = await this.get('item');

--- a/app/pods/components/agenda/agendaitem/agendaitem-decision-edit/component.js
+++ b/app/pods/components/agenda/agendaitem/agendaitem-decision-edit/component.js
@@ -48,6 +48,8 @@ export default Component.extend({
 
     async saveChanges() {
       this._super.call(this);
+      debugger;
+
       this.set('isLoading', true);
 
       const decision = await this.get('item');
@@ -61,14 +63,14 @@ export default Component.extend({
       if (!this.get('isDestroyed')) {
         let agendaitemToUpdate;
         if (this.isTableRow) {
-          const agendaActivity = await this.agendaitem.get('agendaActivity');
+          const agendaActivity = await this.agendaitem.content.get('agendaActivity');
           if (agendaActivity) {
             const subcase = await agendaActivity.get('subcase');
             (await subcase.get('decisions')).reload();
             agendaitemToUpdate = await this.agendaitem.content;
           }
         } else {
-          agendaitemToUpdate = await this.agendaitem;
+          agendaitemToUpdate = await this.agendaitem.content;
         }
         await agendaitemToUpdate.save();
         this.set('isLoading', false);

--- a/app/pods/components/agenda/agendaitem/agendaitem-decision/template.hbs
+++ b/app/pods/components/agenda/agendaitem/agendaitem-decision/template.hbs
@@ -60,7 +60,7 @@
         {{!-- TODO KAS-1420 @agendaitem={{@subcase}} ??  --}}
         <Utils::DocumentsListForItem
           @item={{this.decision}}
-          @agendaitem={{@subcase}} 
+          @agendaitem={{@subcase}}
           @isClickable={{true}}
         />
       </div>
@@ -84,7 +84,7 @@
     @isEditing={{this.isEditing}}
     @item={{this.decision}}
     @subcase={{@subcase}}
-    @agendaitem={{@agendaItem}}
+    @agendaitem={{@agendaitem}}
   />
 {{/if}}
 {{#if this.isVerifyingDelete}}


### PR DESCRIPTION
# 🐞 KAS-1723: Fix bug in het saven van beslissingen
In deze PR hebben we een bug opgelost die ervoor zorgde dat je een aanpassing aan een beslissing niet kon opslaan en de UI bleef hangen..

Dit leek een minor typefout bug te zijn die niet gespot geweest is tijdens de reviews.. jammer.

## 🔨 What has been done
- Parameter aangepast zodat deze gevonden wordt..
- Value uit de content gehaald zodat deze gebruikt kan worden.

## 🖼 Screenshots
De bug bevond zich in de overview pagina van de beslissingen..
- agenda openen => acties => Beslissingen bekijken => Beslissing aanpassen

![image](https://user-images.githubusercontent.com/11557630/87408317-96f2a380-c5c3-11ea-891f-ba85efcd6cdf.png)


## 🧪 Tests
`currently running on jenkins`
