### PR TITLE
KAS-1636: Refactor Observer from add existing document (Including Octane refactor)

### DIFF
--- a/app/pods/components/utils/add-existing-document/component.js
+++ b/app/pods/components/utils/add-existing-document/component.js
@@ -52,16 +52,14 @@ export default class AddExistingDocument extends Component {
 
   @task(function* () {
     yield timeout(300);
-    const documents = yield this.store.query('document-version', this.queryOptions());
-    this.items = documents;
+    this.items = yield this.store.query('document-version', this.queryOptions());
     yield timeout(100);
     this.setSelectedToFalse();
   })findAll;
 
   @task(function* () {
     yield timeout(300);
-    const documents = yield this.store.query('document-version', this.queryOptions());
-    this.items = documents
+    this.items = yield this.store.query('document-version', this.queryOptions());
     this.page = 0;
     yield timeout(100);
   })searchTask;

--- a/app/pods/components/utils/add-existing-document/component.js
+++ b/app/pods/components/utils/add-existing-document/component.js
@@ -32,7 +32,7 @@ export default Component.extend({
       filter: {},
     };
     if (filter) {
-      options['filter']['name'] = filter;
+      options.filter.name = filter;
     }
     return options;
   }),
@@ -64,10 +64,10 @@ export default Component.extend({
       }
       if (document.selected) {
         document.set('selected', false);
-        this.delete(document)
+        this.delete(document);
       } else {
         document.set('selected', true);
-        this.add(document)
+        this.add(document);
       }
     }
   }

--- a/app/pods/components/utils/add-existing-document/component.js
+++ b/app/pods/components/utils/add-existing-document/component.js
@@ -1,76 +1,82 @@
-import Component from '@ember/component';
-import { inject } from '@ember/service';
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
 import { task, timeout } from 'ember-concurrency';
-import { computed, observer } from '@ember/object';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking'
 
+export default class AddExistingDocument extends Component {
+  @service store;
+  @tracked page = 0;
+  @tracked filter = '';
+  @tracked items = [];
 
-export default Component.extend({
+  size = 5;
+  sort = ['-created', 'name'];
 
-  store: inject(),
-
-  size: 5,
-  sort: '-created,name',
-
-  documents: computed('items.@each', function () {
-    (this.get('items') || []).map(item => item.set('selected', false));
-    return this.items;
-  }),
-
-  // dirty observers to make use of the datatable actions
-  pageObserver: observer('page', function () {
+  constructor() {
+    super(...arguments);
     this.findAll.perform();
-  }),
+  }
 
-  queryOptions: computed('sort', 'filter', 'page', function () {
-    const { page, filter, size, sort } = this;
+  get pageParam() {
+    return this.page;
+  }
+
+  set pageParam(page) {
+    if (page === undefined) {
+      this.page = 0;
+    } else {
+      this.page = page;
+    }
+    this.findAll.perform();
+  }
+
+  setSelectedToFalse() {
+    this.items.map(item => item.set('selected', false));
+  }
+
+  queryOptions() {
     let options = {
-      sort: sort,
+      sort: this.sort,
       page: {
-        number: page,
-        size: size
+        number: this.page,
+        size: this.size
       },
       filter: {},
     };
-    if (filter) {
-      options.filter.name = filter;
+    if (this.filter) {
+      options.filter.name = this.filter;
     }
     return options;
-  }),
-
-  findAll: task(function* () {
-    const { queryOptions } = this;
-    const documents = yield this.store.query('document-version', queryOptions);
-    this.set('items', documents);
-    yield timeout(100);
-  }),
-
-  searchTask: task(function* () {
-    yield timeout(300);
-    const { queryOptions } = this;
-    const documents = yield this.store.query('document-version', queryOptions);
-    this.set('items', documents);
-    yield timeout(100);
-  }).restartable(),
-
-  async didInsertElement() {
-    this._super(...arguments);
-    this.findAll.perform();
-  },
-
-  actions: {
-    async select(document, event) {
-      if (event) {
-        event.stopPropagation();
-      }
-      if (document.selected) {
-        document.set('selected', false);
-        this.delete(document);
-      } else {
-        document.set('selected', true);
-        this.add(document);
-      }
-    }
   }
 
+  @task(function* () {
+    yield timeout(300);
+    const documents = yield this.store.query('document-version', this.queryOptions());
+    this.items = documents;
+    yield timeout(100);
+    this.setSelectedToFalse();
+  })findAll;
 
-});
+  @task(function* () {
+    yield timeout(300);
+    const documents = yield this.store.query('document-version', this.queryOptions());
+    this.items = documents
+    this.page = 0;
+    yield timeout(100);
+  })searchTask;
+
+  @action
+  async select(document, event) {
+    if (event) {
+      event.stopPropagation();
+    }
+    if (document.selected) {
+      document.set('selected', false);
+      this.args.delete(document);
+    } else {
+      document.set('selected', true);
+      this.args.add(document);
+    }
+  }
+}

--- a/app/pods/components/utils/add-existing-document/template.hbs
+++ b/app/pods/components/utils/add-existing-document/template.hbs
@@ -4,18 +4,18 @@
       <div class="vlc-toolbar__justified custom-table-search">
         <div class="vlc-toolbar__item" style="width:100%;">
           <div class="vl-input-field--inline">
-            {{input
+            <Input
               data-test-search-exisiting-document
-              value=filter
-              id="searchId"
-              placeholder="Zoeken.."
-              key-press=(perform searchTask)
-              class="vl-input-field vl-input-field__input"
-            }}
+              @value={{this.filter}}
+              @id="searchId"
+              @placeholder="Zoeken.."
+              @input={{perform this.searchTask}}
+              @class="vl-input-field vl-input-field__input"
+            />
             <button type="button"
                     data-test-search-exisiting-document-button
                     class="vl-input-field__submit vl-button"
-                    onclick={{perform searchTask}}
+                    onclick={{perform this.searchTask}}
             >
               <i class="vl-vi vl-vi-magnifier"></i>
             </button>
@@ -25,18 +25,18 @@
     </div>
   </div>
   <div class="vl-col--3-12 vl-col--1-1--s">
-    {{#if searchTask.isRunning}}
+    {{#if this.performSearch.isRunning}}
       <div data-test-search-loader class="vl-loader" role="alert" aria-busy="true"></div>
     {{/if}}
   </div>
 </div>
 {{#data-table
-  content=documents
-  sort=sort
-  page=page
+  content=this.items
+  sort=this.sort
+  page=this.pageParam
   size=size
   noDataMessage=(t "no-results-found")
-  isLoading=findAll.isRunning
+  isLoading=this.findAll.isRunning
   onClickRow=(action "select")
 as |table|
 }}


### PR DESCRIPTION
## 🐙 KAS-1636: removed obeserver and refatorer to octane

# 👨‍⚕️ What did i do:
- octane refactor in `app/pods/components/utils/add-existing-document/component.js`
- removed observer from `app/pods/components/utils/add-existing-document/component.js`
- updated properties in `app/pods/components/utils/add-existing-document/template.hbs`