### PR TITLE
KAS-1644: Omzetten Date naar Datetime

### DIFF
--- a/app/models/agenda.js
+++ b/app/models/agenda.js
@@ -23,7 +23,7 @@ export default Model.extend(LoadableModel, {
     inverse: null,
     serialize: false,
   }),
-  created: attr('date'),
+  created: attr('datetime'),
   modified: attr('datetime'),
 
   isDesignAgenda: computed('status.isDesignAgenda', function() {

--- a/app/models/announcement.js
+++ b/app/models/announcement.js
@@ -8,8 +8,8 @@ const {
 export default Model.extend({
   title: attr('string'),
   text: attr('string'),
-  created: attr('date'),
-  modified: attr('date'),
+  created: attr('datetime'),
+  modified: attr('datetime'),
   agenda: belongsTo('agenda'),
   documentVersions: hasMany('document-version'),
 

--- a/app/models/approval.js
+++ b/app/models/approval.js
@@ -7,7 +7,7 @@ const {
 } = DS;
 
 export default Model.extend({
-  created: attr('date'),
+  created: attr('datetime'),
   mandatee: belongsTo('mandatee', {
     inverse: null,
   }),

--- a/app/models/meeting-record.js
+++ b/app/models/meeting-record.js
@@ -6,8 +6,8 @@ const {
 } = DS;
 
 export default Model.extend({
-  created: attr('date'),
-  modified: attr('date'),
+  created: attr('datetime'),
+  modified: attr('datetime'),
   announcements: attr('string'),
   others: attr('string'),
   richtext: attr('string'),


### PR DESCRIPTION
# 🧠 KAS-1644: Omzetten date naar datetime

In deze PR hebben we de nodige aanpassingen gedaan om de `date` types aan te passen naar `datetime`.

## ✏️ What has changed:
We hebben in het domeinmodel gekeken naar de occurrence van `date` en waar nodig het type veranderd naar `datetime`.. Deze PR hangt samen met de PR in de backend https://github.com/kanselarij-vlaanderen/kaleidos-project/pull/97