### PR TITLE
KAS-1286: Zittingnummer - ACCEPTANCE

### DIFF
--- a/app/models/meeting.js
+++ b/app/models/meeting.js
@@ -14,6 +14,7 @@ export default Model.extend({
   endedOn: attr('datetime'),
   location: attr('string'),
   number: attr('number'),
+  numberRepresentation: attr('string'),
   isFinal: attr('boolean'),
   extraInfo: attr('string'),
   kind: attr('string'),

--- a/app/pods/agendas/controller.js
+++ b/app/pods/agendas/controller.js
@@ -16,8 +16,8 @@ export default Controller.extend(DefaultQueryParamsMixin, {
     },
     successfullyAdded() {
       this.set('creatingNewSession', false);
-      this.send('refreshRoute')
+      this.send('refreshRoute');
       this.transitionToRoute('agendas.overview');
-    }
+    },
   }
 });

--- a/app/pods/agendas/template.hbs
+++ b/app/pods/agendas/template.hbs
@@ -35,6 +35,7 @@
     {{sessions/forms/new-session
       successfullyAdded=(action "successfullyAdded")
       cancelForm=(action "cancelNewSessionForm")
+      formattedMeetingIdentifier=formattedMeetingIdentifier
     }}
   {{/web-components/vl-modal}}
 {{/if}}

--- a/app/pods/components/sessions/forms/edit-session/component.js
+++ b/app/pods/components/sessions/forms/edit-session/component.js
@@ -15,7 +15,7 @@ export default Component.extend({
   startDate: null,
   extraInfo: null,
   meetingNumber: null,
-
+  numberRepresentation: null,
   date: computed('startDate', function () {
     return A([this.startDate])
   }),
@@ -28,11 +28,12 @@ export default Component.extend({
     this.set('startDate', this.get('meeting.plannedStart'));
     this.set('extraInfo', this.get('meeting.extraInfo'));
     this.set('meetingNumber', this.get('meeting.number'));
+    this.set('numberRepresentation', this.get('meeting.numberRepresentation'));
   },
 
   actions: {
     async updateSession() {
-      const { isDigital, extraInfo, selectedKindUri, meeting, meetingNumber } = this;
+      const { isDigital, extraInfo, selectedKindUri, meeting, meetingNumber, numberRepresentation } = this;
       this.set('isLoading', true);
       const kindUriToAdd = selectedKindUri || CONFIG.defaultKindUri;
       const date = this.formatter.formatDate(null);
@@ -44,6 +45,7 @@ export default Component.extend({
       await meeting.set('created', date);
       await meeting.set('kind', kindUriToAdd);
       await meeting.set('number', meetingNumber);
+      await meeting.set('numberRepresentation', numberRepresentation);
 
       meeting.save()
         .catch(() => {

--- a/app/pods/components/sessions/forms/edit-session/template.hbs
+++ b/app/pods/components/sessions/forms/edit-session/template.hbs
@@ -18,7 +18,7 @@
   </div>
   <div class="vl-u-spacer-extended-bottom-s">
     <div class="vlc-input-field-block">
-      {{web-components/vl-form-label value=(t "meeting-number")}}
+      {{web-components/vl-form-label value=(t "meeting-number-visual-representation")}}
       {{web-components/vl-form-input value=numberRepresentation width="4"}}
     </div>
   </div>

--- a/app/pods/components/sessions/forms/edit-session/template.hbs
+++ b/app/pods/components/sessions/forms/edit-session/template.hbs
@@ -18,6 +18,12 @@
   </div>
   <div class="vl-u-spacer-extended-bottom-s">
     <div class="vlc-input-field-block">
+      {{web-components/vl-form-label value=(t "meeting-number")}}
+      {{web-components/vl-form-input value=numberRepresentation width="4"}}
+    </div>
+  </div>
+  <div class="vl-u-spacer-extended-bottom-s">
+    <div class="vlc-input-field-block">
       {{web-components/vl-form-label value=(t "meeting-location")}}
       {{web-components/vl-form-input width="4" value=extraInfo}}
     </div>

--- a/app/pods/components/sessions/forms/new-session/component.js
+++ b/app/pods/components/sessions/forms/new-session/component.js
@@ -12,10 +12,13 @@ export default Component.extend({
   kind: null,
   selectedKindUri: null,
   meetingNumber: null,
+  isEditingFormattedMeetingIdentifier: false,
+  formattedMeetingIdentifier: null,
+  currentYear: moment().year(),
+  meetingNumberPrefix: null,
 
   init() {
     this._super(...arguments);
-    const currentYear = moment().year();
     // TODO: Improve samen met Michael of Sven
     this.store.query('meeting',
       {
@@ -25,7 +28,7 @@ export default Component.extend({
       if (meetings.length) {
 
         meetingsFromThisYear = meetings.map(meeting => {
-         if (moment(meeting.plannedStart).year() === currentYear) {
+         if (moment(meeting.plannedStart).year() === this.currentYear) {
            return meeting;
          }
         }).filter(meeting => meeting); // Filter undefineds out of results..
@@ -38,6 +41,8 @@ export default Component.extend({
           }
         });
          this.set('meetingNumber', id + 1);
+         this.set('meetingNumberPrefix', `VR PV ${this.currentYear}/`);
+        this.set('formattedMeetingIdentifier', `${this.meetingNumberPrefix}${this.meetingNumber}`);
       }
     });
   },
@@ -77,9 +82,13 @@ export default Component.extend({
     return await agendaitem.save();
   },
 
+  test(){
+    console.log('dit is een functie');
+  },
+
   actions: {
     async createNewSession() {
-      const { isDigital, extraInfo, selectedKindUri, meetingNumber } = this;
+      const { isDigital, extraInfo, selectedKindUri, meetingNumber, formattedMeetingIdentifier } = this;
       this.set('isLoading', true);
       const kindUriToAdd = selectedKindUri || CONFIG.defaultKindUri;
       const date = this.formatter.formatDate(null);
@@ -90,7 +99,8 @@ export default Component.extend({
         plannedStart: startDate,
         created: date,
         kind: kindUriToAdd,
-        number: meetingNumber
+        number: meetingNumber,
+        numberRepresentation: formattedMeetingIdentifier
       });
       const closestMeeting = await this.agendaService.getClosestMeetingAndAgendaId(startDate);
 
@@ -128,5 +138,19 @@ export default Component.extend({
     setKind(kind) {
       this.set('selectedKindUri', kind);
     },
+
+    meetingNumberChangedAction(meetingNumber){
+      this.set('meetingNumber', meetingNumber);
+      this.set('formattedMeetingIdentifier', `VR PV ${this.currentYear}/${meetingNumber}`);
+    },
+
+    editFormattedMeetingIdentifier() {
+      this.set('isEditingFormattedMeetingIdentifier', true);
+    },
+
+    saveAction(){
+      this.set('formattedMeetingIdentifier', `${this.get('meetingNumberPrefix')}${this.get('meetingNumber')}`);
+      this.set('isEditingFormattedMeetingIdentifier', false);
+    }
   },
 });

--- a/app/pods/components/sessions/forms/new-session/component.js
+++ b/app/pods/components/sessions/forms/new-session/component.js
@@ -40,8 +40,8 @@ export default Component.extend({
             id = number;
           }
         });
-         this.set('meetingNumber', id + 1);
-         this.set('meetingNumberPrefix', `VR PV ${this.currentYear}/`);
+        this.set('meetingNumber', id + 1);
+        this.set('meetingNumberPrefix', `VR PV ${this.currentYear}/`);
         this.set('formattedMeetingIdentifier', `${this.meetingNumberPrefix}${this.meetingNumber}`);
       }
     });
@@ -80,10 +80,6 @@ export default Component.extend({
       isApproval: true
     });
     return await agendaitem.save();
-  },
-
-  test(){
-    console.log('dit is een functie');
   },
 
   actions: {

--- a/app/pods/components/sessions/forms/new-session/template.hbs
+++ b/app/pods/components/sessions/forms/new-session/template.hbs
@@ -12,10 +12,30 @@
     </div>
   </div>
   <div class="vl-u-spacer-extended-bottom-s">
-    <div class="vlc-input-field-block">
+    <div class="vlc-input-field-block" style="display: flex; flex-direction: column">
       {{web-components/vl-form-label value=(t "meeting-number")}}
-      {{web-components/vl-form-input type="number" value=meetingNumber width="4"}}
+      <div class="vlc-new-session__flex">
+        {{web-components/vl-form-input type="number" value=meetingNumber input=(action "meetingNumberChangedAction" meetingNumber) width="2"}}
+        <div class="vlc-new-session vlc-new-session__flex">
+          <span class="vlc-new-session__label">
+            <span class="vlc-new-session__identifier">{{formattedMeetingIdentifier}}</span>
+            <button type="button" class="vl-link"
+              {{action "editFormattedMeetingIdentifier"}}
+            >
+              <small>{{t "edit"}}</small>
+            </button>
+          </span>
+        </div>
+      </div>
     </div>
+    {{#if isEditingFormattedMeetingIdentifier}}
+      <div class="vlc-new-session__meetingNumberPrefix">
+        <div class="vlc-new-session__flex">
+          {{web-components/vl-form-input value=meetingNumberPrefix width="2" class="vlc-new-session__meetingNumberPrefix__container"}}
+          {{web-components/vl-save-button text=(t "save") saveAction=(action "saveAction") }}
+        </div>
+      </div>
+    {{/if}}
   </div>
   <div class="vl-u-spacer-extended-bottom-s">
     <div class="vlc-input-field-block">

--- a/app/pods/components/sessions/forms/new-session/template.hbs
+++ b/app/pods/components/sessions/forms/new-session/template.hbs
@@ -23,8 +23,9 @@
         }}
         <div class="vlc-new-session vlc-new-session__flex">
           <span class="vlc-new-session__label">
-            <span class="vlc-new-session__identifier">{{formattedMeetingIdentifier}}</span>
+            <span class="vlc-new-session__identifier" data-test-meeting-formattedMeetingIdentifier>{{formattedMeetingIdentifier}}</span>
             <button type="button" class="vl-link"
+              data-test-meeting-edit-identifier-button
               {{action "editFormattedMeetingIdentifier"}}
             >
               <small>{{t "edit"}}</small>
@@ -37,6 +38,7 @@
       <div class="vlc-new-session__meetingNumberPrefix">
         <div class="vlc-new-session__flex">
           {{web-components/vl-form-input
+            data-test-meeting-formattedMeetingIdentifier-edit-value
             value=meetingNumberPrefix
             width="2"
             class="vlc-new-session__meetingNumberPrefix__container"

--- a/app/pods/components/sessions/forms/new-session/template.hbs
+++ b/app/pods/components/sessions/forms/new-session/template.hbs
@@ -15,7 +15,12 @@
     <div class="vlc-input-field-block" style="display: flex; flex-direction: column">
       {{web-components/vl-form-label value=(t "meeting-number")}}
       <div class="vlc-new-session__flex">
-        {{web-components/vl-form-input type="number" value=meetingNumber input=(action "meetingNumberChangedAction" meetingNumber) width="2"}}
+        {{web-components/vl-form-input
+          type="number"
+          value=meetingNumber
+          input=(action "meetingNumberChangedAction" meetingNumber)
+          width="2"
+        }}
         <div class="vlc-new-session vlc-new-session__flex">
           <span class="vlc-new-session__label">
             <span class="vlc-new-session__identifier">{{formattedMeetingIdentifier}}</span>
@@ -31,8 +36,15 @@
     {{#if isEditingFormattedMeetingIdentifier}}
       <div class="vlc-new-session__meetingNumberPrefix">
         <div class="vlc-new-session__flex">
-          {{web-components/vl-form-input value=meetingNumberPrefix width="2" class="vlc-new-session__meetingNumberPrefix__container"}}
-          {{web-components/vl-save-button text=(t "save") saveAction=(action "saveAction") }}
+          {{web-components/vl-form-input
+            value=meetingNumberPrefix
+            width="2"
+            class="vlc-new-session__meetingNumberPrefix__container"
+          }}
+          {{web-components/vl-save-button
+            text=(t "save")
+            saveAction=(action "saveAction")
+          }}
         </div>
       </div>
     {{/if}}

--- a/app/pods/components/web-components/vl-form-input/template.hbs
+++ b/app/pods/components/web-components/vl-form-input/template.hbs
@@ -1,8 +1,8 @@
 <div class="vl-form__input">
   {{input
+    data-test-vl-input
     type=type
     id=id
-    data-test-vl-input=true
     class="vl-input-field vl-input-field--block"
     value=value
   }}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -106,6 +106,7 @@ $icon-font-location: '/fonts/';
 @import 'custom-components/vlc-minister';
 @import 'custom-components/vlc-mock-login';
 @import 'custom-components/vlc-navbar';
+@import 'custom-components/vlc-new-session';
 @import 'custom-components/vlc-page-header';
 @import 'custom-components/vlc-panel-layout';
 @import 'custom-components/vlc-panel';

--- a/app/styles/custom-components/_vlc-new-session.scss
+++ b/app/styles/custom-components/_vlc-new-session.scss
@@ -1,0 +1,25 @@
+.vlc-new-session {
+  align-items: center;
+  margin-left: 5px;
+
+  .vlc-new-session__label {
+    font-size: 1.6rem;
+  }
+
+  .vlc-new-session__identifier {
+    padding-left: 0.3rem;
+    padding-right: 0.3rem;
+  }
+}
+
+.vlc-new-session__meetingNumberPrefix {
+  margin-top: 1rem;
+}
+
+.vlc-new-session__meetingNumberPrefix__container {
+  margin-right: 1rem;
+}
+
+.vlc-new-session__flex {
+  display: flex;
+}

--- a/cypress/integration/unit/agenda.spec.js
+++ b/cypress/integration/unit/agenda.spec.js
@@ -110,7 +110,7 @@ context('Agenda tests', () => {
     cy.get(agenda.agendaitemTitelsConfidential).should('exist').should('be.visible');
   });
 
-  it.only('It should be able to make a new agenda with a meetingID and another meeting will automatically get the next meetingID assigned in the UI', () => {
+  it('It should be able to make a new agenda with a meetingID and another meeting will automatically get the next meetingID assigned in the UI', () => {
     const agendaDate = Cypress.moment().add(1, 'week').day(6);
     cy.createAgenda('Ministerraad', agendaDate, "Brussel", 1);
     cy.createAgenda('Ministerraad', agendaDate, "Brussel",null,"VV AA 1999/").then((result) => {

--- a/cypress/integration/unit/agenda.spec.js
+++ b/cypress/integration/unit/agenda.spec.js
@@ -108,16 +108,17 @@ context('Agenda tests', () => {
     cy.contains('dit is de korte titel');
     cy.contains('dit is de lange titel');
     cy.get(agenda.agendaitemTitelsConfidential).should('exist').should('be.visible');
-  })
+  });
 
-  it('It should be able to make a new agenda with a meetingID and another meeting will automatically get the next meetingID assigned in the UI', () => {
+  it.only('It should be able to make a new agenda with a meetingID and another meeting will automatically get the next meetingID assigned in the UI', () => {
     const agendaDate = Cypress.moment().add(1, 'week').day(6);
     cy.createAgenda('Ministerraad', agendaDate, "Brussel", 1);
-    cy.createAgenda('Ministerraad', agendaDate, "Brussel").then((result) => {
+    cy.createAgenda('Ministerraad', agendaDate, "Brussel",null,"VV AA 1999/").then((result) => {
       cy.visit(`/vergadering/${result.meetingId}/agenda/${result.agendaId}/agendapunten`);
       cy.get(actionModel.showActionOptions).click();
       cy.get(actionModel.toggleeditingsession).click();
       cy.get('input[type="number"]').should('have.value', result.meetingNumber);
+      cy.get(form.formInput).eq(1).should('have.value', `${result.meetingNumberVisualRepresentation}${result.meetingNumber}`);
       cy.visit('/');
       cy.get(agenda.createNewAgendaButton).click();
       cy.wait(500);

--- a/cypress/selectors/form.selectors.js
+++ b/cypress/selectors/form.selectors.js
@@ -4,5 +4,10 @@ const selectors = {
   formCancelButton: '[data-test-vl-modal-footer-cancel]',
   formVlToggle: '[data-test-vl-toggle]',
   datepickerInput: '[data-test-vl-datepicker-input]',
+  meeting: {
+    formattedMeetingIdentifier: '[data-test-meeting-formattedMeetingIdentifier]',
+    formattedMeetingIdentifierEditValue: '[data-test-meeting-formattedMeetingIdentifier-edit-value]',
+    meetingEditIdentifierButton: '[data-test-meeting-edit-identifier-button]'
+  }
 };
 export default selectors;

--- a/cypress/support/commands/agenda-commands.js
+++ b/cypress/support/commands/agenda-commands.js
@@ -43,10 +43,11 @@ Cypress.Commands.add('createAgendaOnDate', createAgendaOnDate);
  * @param {*} plusMonths The positive amount of months from today to advance in the vl-datepicker
  * @param {*} date The cypress.moment object with the date and time to set
  * @param {string} location The location of the meeting to enter as input
- * @param {number} meetingNumber The location of the meeting to enter as input
+ * @param {number} meetingNumber The number of the meeting to enter as input
+ * @param {string} meetingNumberVisualRepresentation The visual representation of the meetingnumber to enter as input
  * @returns {Promise<String>} the id of the created agenda
  */
-function createAgenda(kind, date, location, meetingNumber ) {
+function createAgenda(kind, date, location, meetingNumber, meetingNumberVisualRepresentation ) {
   cy.route('POST', '/meetings').as('createNewMeeting');
   cy.route('POST', '/agendas').as('createNewAgenda');
   cy.route('POST', '/newsletter-infos').as('createNewsletter');
@@ -85,6 +86,16 @@ function createAgenda(kind, date, location, meetingNumber ) {
     cy.get(form.formInput).eq(0).click({force: true}).invoke('val').then(sometext => meetingNumber = sometext);
   }
 
+  //Set the meetingNumber
+  if(meetingNumberVisualRepresentation) {
+    cy.get(form.meeting.meetingEditIdentifierButton).click({force: true});
+    cy.get(form.formInput).eq(1).click().clear().type(meetingNumberVisualRepresentation);
+    cy.get(utils.saveButton).contains('Opslaan').click();
+  } else {
+    cy.get(form.meeting.meetingEditIdentifierButton).click({force: true});
+    cy.get(form.formInput).eq(1).click({force: true}).invoke('val').then(sometext => meetingNumberVisualRepresentation = sometext);
+  }
+
   //Set the location
   cy.get('@newAgendaForm').eq(2).within(() => {
     cy.get('.vl-input-field').click({force: true}).type(location);
@@ -108,7 +119,7 @@ function createAgenda(kind, date, location, meetingNumber ) {
   cy.wait('@patchMeetings', { timeout: 20000 })
     .then(() => {
       return new Cypress.Promise((resolve) => {
-        resolve({meetingId, meetingNumber, agendaId});
+        resolve({meetingId, meetingNumber, agendaId, meetingNumberVisualRepresentation});
       });
     });
 }

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -581,7 +581,7 @@
   "agenda-activity": "Agendering",
   "show-more": "Toon meer",
   "show-less": "Toon minder",
-  "meeting-number": "Nummer van de vergadering",
+  "meeting-number": "ID van de vergadering",
   "activity-phase-proposed-for-agenda": "Ingediend voor agendering op",
   "activity-phase-approved-on-agenda": "Geagendeerd op de agenda van",
   "activity-phase-postponed-on-agenda": "Uitgesteld op de agenda van",
@@ -589,5 +589,6 @@
   "activity-phase-postponed-is-decided": "Er is beslist om dit agendapunt uit te stellen",
   "loading-active-agendas": "De actieve agendas worden geladen.",
   "no-documents-to-download-warning-text": "De vergadering heeft geen documenten om te downloaden.",
-  "no-documents-to-download-warning-title": "Download afgebroken"
+  "no-documents-to-download-warning-title": "Download afgebroken",
+  "meeting-number-visual-representation": "Nummer van de vergadering"
 }


### PR DESCRIPTION
# KAS-1286: Zittingnummer

In deze PR hebben we de generatie van het zittingnummer uitgebreid na feedback van de gebruikers en een sparringsessie met het team.

## What has changed:

Voor:
![image](https://user-images.githubusercontent.com/11557630/89020049-91fd5600-d31e-11ea-863b-2089faf121a4.png)

Na
![image](https://user-images.githubusercontent.com/11557630/89019875-49de3380-d31e-11ea-9f62-fcfd413fc6d2.png)
Er is nu een bijkomende functionaliteit dat je de prefix ook kunt aanpassen door op de wijzigen knop te drukken.

![image](https://user-images.githubusercontent.com/11557630/89020113-accfca80-d31e-11ea-9afc-10e849563369.png)

## Tests
`running on jenkins`
