### PR TITLE
KAS-1674: .hbs lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
   },
   plugins: [
     'ember',
+    'hbs'
   ],
   extends: [
     'eslint:recommended',
@@ -162,16 +163,6 @@ module.exports = {
       env: {
         browser: false,
         node: true,
-      },
-      rules: {
-        'ember/no-on-calls-in-components': 'off',
-        'attribute-indentation': 'off',
-        'block-indentation': 'off',
-        'no-invalid-interactive': 'off',
-        'no-mixed-spaces-and-tabs': 'off',
-        'ember/use-brace-expansion': 'off',
-        'table-groups': 'off',
-        'no-triple-curlies': 'off',
       },
     },
   ],

--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -7,7 +7,10 @@ module.exports = {
       indentation: 2,
     },
     'no-inline-styles': false,
-    'block-indentation': false,
+    'block-indentation': {
+      indentation: 2,
+      ignoreComments: true,
+    },
     quotes: false,
     'no-unnecessary-concat': false,
     'no-nested-interactive': false,

--- a/app/pods/components/access-level-pill/template.hbs
+++ b/app/pods/components/access-level-pill/template.hbs
@@ -4,9 +4,9 @@
   {{#if (not item.confidential)}}
     {{#if (not editing)}}
       <div class="pill-wrap" data-test-access-level-pill {{action "toggleEdit"}}>
-      <span class="vlc-pill {{accessLevelClass}}">
-        {{accessLevelLabel}}
-      </span>
+        <span class="vlc-pill {{accessLevelClass}}">
+          {{accessLevelLabel}}
+        </span>
       </div>
     {{else}}
       <div class="vl-form__input" style="width:75%">

--- a/app/pods/components/agenda/agenda-detail/sidebar-item/template.hbs
+++ b/app/pods/components/agenda/agenda-detail/sidebar-item/template.hbs
@@ -3,22 +3,22 @@
   is set rigth from the beginning and the component is rendered only once, scrolling on "did-insert" works just fine --}}
 <a href="#" {{ on "click" this.openDetailPage }} class={{ classNameBindings }}>
   <div class="vl-u-display-flex" {{in-viewport onEnter=( fn conditionallyScrollIntoView ) }}>
-  <span class="vlc-agenda-detail-sidebar-sub-item__numbering">
-    {{#if @agendaitem.number}}
-      {{@agendaitem.number}}.
-    {{else}}
-      {{add index 1}}.
-    {{/if}}
-  </span>
+    <span class="vlc-agenda-detail-sidebar-sub-item__numbering">
+      {{#if @agendaitem.number}}
+        {{@agendaitem.number}}.
+      {{else}}
+        {{add index 1}}.
+      {{/if}}
+    </span>
     <div class="vlc-agenda-detail-sidebar__text-container">
       <h4 class="vlc-agenda-detail-sidebar__subject">
-    <pre class="vl-u-text-color-agenda-list">
-      {{#if @agendaitem.shortTitle}}
-        {{@agendaitem.shortTitle}}
-      {{else}}
-        {{@agendaitem.title}} {{!-- Fallback for legacy data that doesn't have a short title --}}
-      {{/if}}
-    </pre>
+        <pre class="vl-u-text-color-agenda-list">
+          {{#if @agendaitem.shortTitle}}
+            {{@agendaitem.shortTitle}}
+          {{else}}
+            {{@agendaitem.title}} {{!-- Fallback for legacy data that doesn't have a short title --}}
+          {{/if}}
+        </pre>
       </h4>
       {{#if (not @agendaitem.aboutToDelete)}}
         {{#if (not selectedAgendaItem)}}
@@ -36,7 +36,7 @@
             <div class="vl-u-display-flex vlc-u-display-flex-align-items-flex-end vlc-agenda-detail-sidebar-item__icon">
               {{#if (await @agendaitem.checkAdded)}}
                 <span class="added-tag vlc-agenda-meta__recently-added">
-                   <i class="vl-vi ki-calendar-plus"></i>
+                  <i class="vl-vi ki-calendar-plus"></i>
                   {{#attach-tooltip
                     arrow="true"
                     animation="shift"
@@ -54,13 +54,13 @@
                 <i class="vl-vi ki-hide vlc-agenda-detail-sidebar-item__icon--margin-right vlc-u-opacity-50"></i>
               {{/if}}
 
-            {{#if (await subcase.confidential)}}
-             <i
-               class="vl-icon vl-vi ki-lock-closed vl-vi-no-font-weight vlc-u-opacity-50"
-               data-test-icon-agenda-confidentiality-locked
-             ></i>
-            {{/if}}
-          </div>
+              {{#if (await subcase.confidential)}}
+                <i
+                   class="vl-icon vl-vi ki-lock-closed vl-vi-no-font-weight vlc-u-opacity-50"
+                   data-test-icon-agenda-confidentiality-locked
+                ></i>
+              {{/if}}
+            </div>
 
             <div class="vlc-agenda-detail-sidebar__formally-ok-label vlc-u-display-flex-align-items-flex-end">
               {{#if

--- a/app/pods/components/agenda/agenda-header/template.hbs
+++ b/app/pods/components/agenda/agenda-header/template.hbs
@@ -7,9 +7,9 @@
         {{moment-format currentSession.plannedStart "DD MMMM YYYY"}}
         {{t "at"}}
         {{moment-format currentSession.plannedStart "HH:mm"}}
-        <span class="vlc-page-header__subtitle vl-u-text vl-u-text--muted" style="font-size:1.6rem;"> - {{await
-          currentSession.kindToShow.label
-        }}</span>
+        <span class="vlc-page-header__subtitle vl-u-text vl-u-text--muted" style="font-size:1.6rem;">
+          - {{await currentSession.kindToShow.label}}
+        </span>
       </h1>
       <div class="vlc-page-header__sub">
         <div class="vlc-toolbar vlc-toolbar--auto">

--- a/app/pods/components/agenda/agenda-overview/agenda-overview-item/template.hbs
+++ b/app/pods/components/agenda/agenda-overview/agenda-overview-item/template.hbs
@@ -1,13 +1,13 @@
 <div {{ in-viewport onEnter=this.onEnter onExit=this.onExit }} class={{classNameBindings}}>
   <div class="vlc-agenda-items__body ">
     <h4 class="vlc-agenda-items__subject">
-    <span class="vlc-agenda-items-sub-item__numbering">
-      {{#if @agendaitem.number}}
-        {{@agendaitem.number}}.
-      {{else}}
-        {{add index 1}}.
-      {{/if}}
-    </span>
+      <span class="vlc-agenda-items-sub-item__numbering">
+        {{#if @agendaitem.number}}
+          {{@agendaitem.number}}.
+        {{else}}
+          {{add index 1}}.
+        {{/if}}
+      </span>
     </h4>
     <div class="vlc-agenda-items__text">
       <h4 class="vlc-agenda-items__subject">
@@ -43,8 +43,7 @@
                   {{subcase.subcaseName}}
                 </span>
               {{else}}
-                <span class="vlc-agenda-meta__times-passed  vl-u-text--capitalize">
-            </span>
+                <span class="vlc-agenda-meta__times-passed  vl-u-text--capitalize"></span>
               {{/if}}
             {{/if}}
             <div class="vlc-agenda-meta__status-holder">
@@ -81,17 +80,17 @@
               {{#if renderDetails}}
                 {{#if (await @agendaitem.documents)}}
                   <div class="vlc-hr"></div>
-                    <Components::Utils::DocumentsListForItem
-                            @isClickable={{true}}
-                            @item={{@agendaitem}}
-                            @document={{@agendaitem.document}}
-                    />
+                  <Components::Utils::DocumentsListForItem
+                    @isClickable={{true}}
+                    @item={{@agendaitem}}
+                    @document={{@agendaitem.document}}
+                  />
 
                 {{else}}
                   {{#if (await @agendaitem.documentNames)}}
                     <div class="vlc-hr"></div>
                     <Components::Utils::DocumentsListLazyLoaded
-                            @documentNames={{@agendaitem.documentNames}}
+                     @documentNames={{@agendaitem.documentNames}}
                     />
                   {{/if}}
                 {{/if}}
@@ -115,8 +114,9 @@
               <div class="vlc-agenda-items__remarks">
                 <div>
                   {{#if @agendaitem.explanation}}
-                    <span class="vl-u-text--bold">{{ t "remark-title" }}
-                      : </span> {{@agendaitem.explanation}}
+                    <span class="vl-u-text--bold">
+                      {{ t "remark-title" }}:
+                    </span> {{@agendaitem.explanation}}
                   {{/if}}
                 </div>
                 <div class="vlc-agenda-items__icons">
@@ -141,11 +141,11 @@
                   </div>
                   {{#if subcase.confidential}}
                     <span type="button" class="vlc-agenda-items__confidentiality-button vlc-pill vlc-pill--error">
-                  <i class="vl-icon vl-vi ki-lock-closed vlc-agenda-items__icons"
-                     data-test-icon-agenda-confidentiality-locked
-                  ></i>
+                      <i class="vl-icon vl-vi ki-lock-closed vlc-agenda-items__icons"
+                         data-test-icon-agenda-confidentiality-locked
+                      ></i>
                       {{t "confidential"}}
-                  </span>
+                    </span>
                   {{/if}}
                 </div>
               </div>

--- a/app/pods/components/agenda/agenda-overview/template.hbs
+++ b/app/pods/components/agenda/agenda-overview/template.hbs
@@ -35,15 +35,15 @@
           )
         }}
           {{#if overviewEnabled}}
-          <div class="vl-u-spacer-extended-left-s">
-            <a href=""
-               data-test-agenda-edit-formally-ok-button
-               class="vlc-agenda-items-section-header__link"
-              {{action "toggleIsEditingOverview"}}
-            >
-              {{t "edit"}}
-            </a>
-          </div>
+            <div class="vl-u-spacer-extended-left-s">
+              <a href=""
+                 data-test-agenda-edit-formally-ok-button
+                 class="vlc-agenda-items-section-header__link"
+                {{action "toggleIsEditingOverview"}}
+              >
+                {{t "edit"}}
+              </a>
+            </div>
           {{/if}}
         {{/if}}
       </div>

--- a/app/pods/components/agenda/agendaitem/agendaitem-case/agendaitem-approvals/template.hbs
+++ b/app/pods/components/agenda/agendaitem/agendaitem-case/agendaitem-approvals/template.hbs
@@ -21,62 +21,60 @@
   <div class="vl-u-spacer">
     <table class="vl-data-table">
       <thead>
-      <tr>
-        <th>
-          {{t "name"}}
-        </th>
-        <th>
-          {{t "function-mandatee"}}
-        </th>
-        <th>
-          {{t "approval-mandatee"}}
-        </th>
-      </tr>
+        <tr>
+          <th>
+            {{t "name"}}
+          </th>
+          <th>
+            {{t "function-mandatee"}}
+          </th>
+          <th>
+            {{t "approval-mandatee"}}
+          </th>
+        </tr>
       </thead>
       <tbody>
-      {{#each (await mandateeApprovals) as |mandateeApproval|}}
-        <tr>
-          <td>
-            <h6 class="vl-title vl-title--h6">
-              {{await mandateeApproval.mandatee.person.nameToDisplay}}
-            </h6>
-          </td>
-          <td>
-            {{await mandateeApproval.mandatee.title}}
-          </td>
-          <td>
-            {{#if (not isEditing)}}
-              {{#if (await mandateeApproval.approval)}}
-                <p class="vl-icon-wrapper vl-u-text--success">
-                    <span class="vl-icon vl-icon--before vl-vi vl-vi-check"
-                          aria-hidden="true"
-                    ></span>
-                  <span class="vl-annotation">
-                    {{t "approval-mandatee"}}
-                  </span>
-                </p>
-              {{else}}
-                <p class="vl-icon-wrapper vl-u-text--muted">
+        {{#each (await mandateeApprovals) as |mandateeApproval|}}
+          <tr>
+            <td>
+              <h6 class="vl-title vl-title--h6">
+                {{await mandateeApproval.mandatee.person.nameToDisplay}}
+              </h6>
+            </td>
+            <td>
+              {{await mandateeApproval.mandatee.title}}
+            </td>
+            <td>
+              {{#if (not isEditing)}}
+                {{#if (await mandateeApproval.approval)}}
+                  <p class="vl-icon-wrapper vl-u-text--success">
+                    <span class="vl-icon vl-icon--before vl-vi vl-vi-check" aria-hidden="true"></span>
+                    <span class="vl-annotation">
+                      {{t "approval-mandatee"}}
+                    </span>
+                  </p>
+                {{else}}
+                  <p class="vl-icon-wrapper vl-u-text--muted">
                     <span class="vl-icon vl-icon--before vl-vi vl-vi-minus"
                           aria-hidden="true"
                     ></span>
-                  <span>
-                    {{t "not-yet-approval-mandatee"}}
-                  </span>
-                </p>
+                    <span>
+                      {{t "not-yet-approval-mandatee"}}
+                    </span>
+                  </p>
+                {{/if}}
+              {{else}}
+                <div class="vlc-input-field-block">
+                  {{web-components/vl-checkbox
+                    value=(not (is-empty mandateeApproval.approval))
+                    label=(t "approval-mandatee")
+                    toggle=(action "toggleApproved" mandateeApproval.mandatee mandateeApproval.approval)
+                  }}
+                </div>
               {{/if}}
-            {{else}}
-              <div class="vlc-input-field-block">
-                {{web-components/vl-checkbox
-                  value=(not (is-empty mandateeApproval.approval))
-                  label=(t "approval-mandatee")
-                  toggle=(action "toggleApproved" mandateeApproval.mandatee mandateeApproval.approval)
-                }}
-              </div>
-            {{/if}}
-          </td>
-        </tr>
-      {{/each}}
+            </td>
+          </tr>
+        {{/each}}
       </tbody>
     </table>
   </div>

--- a/app/pods/components/agenda/agendaitem/agendaitem-case/agendaitem-titles/template.hbs
+++ b/app/pods/components/agenda/agendaitem/agendaitem-case/agendaitem-titles/template.hbs
@@ -81,20 +81,20 @@
         {{if agendaitem.showInNewsletter "vlc-pill--success" "vlc-pill--error"}}
         vl-u-spacer-extended-right-s"
       >
-      {{#if agendaitem.showInNewsletter}}
-        <span>
-          {{t "visible-in-newsletter"}}
-        </span>
-        <i
-          class="vl-button__icon vl-vi vl-vi-view-add vl-u-spacer-extended-left-s"
-        ></i>
+        {{#if agendaitem.showInNewsletter}}
+          <span>
+            {{t "visible-in-newsletter"}}
+          </span>
+          <i
+            class="vl-button__icon vl-vi vl-vi-view-add vl-u-spacer-extended-left-s"
+          ></i>
         {{else}}
           <span>
             {{t "hidden-in-newsletter"}}
           </span>
-        <i
-          class="vl-button__icon vl-vi vl-vi-hide vl-u-spacer-extended-left-s"
-        ></i>
+          <i
+            class="vl-button__icon vl-vi vl-vi-hide vl-u-spacer-extended-left-s"
+          ></i>
         {{/if}}
       </span>
     </div>

--- a/app/pods/components/agenda/agendaitem/agendaitem-case/edit-subcase-documents/template.hbs
+++ b/app/pods/components/agenda/agendaitem/agendaitem-case/edit-subcase-documents/template.hbs
@@ -2,30 +2,30 @@
   <div class="vl-u-spacer">
     <table class="vl-data-table vl-data-table--align-middle">
       <thead>
-      <tr>
-        <th class="vl-data-table-col-4">
-          {{web-components/vl-form-label value=(t "document-name")}}
-        </th>
-        <th class="vl-data-table-col-3">
-          {{web-components/vl-form-label value=(t "file-type")}}
-        </th>
-        <th class="vl-data-table-col-3">
-          {{web-components/vl-form-label value=(t "publicity")}}
-        </th>
-        <th class="vl-data-table-col-1">
-          {{web-components/vl-form-label value=(t "confidential")}}
-        </th>
-        <th class="vl-data-table-col-1"></th>
-      </tr>
+        <tr>
+          <th class="vl-data-table-col-4">
+            {{web-components/vl-form-label value=(t "document-name")}}
+          </th>
+          <th class="vl-data-table-col-3">
+            {{web-components/vl-form-label value=(t "file-type")}}
+          </th>
+          <th class="vl-data-table-col-3">
+            {{web-components/vl-form-label value=(t "publicity")}}
+          </th>
+          <th class="vl-data-table-col-1">
+            {{web-components/vl-form-label value=(t "confidential")}}
+          </th>
+          <th class="vl-data-table-col-1"></th>
+        </tr>
       </thead>
       <tbody>
-      {{#each (await documents) as |documentContainer|}}
-        {{#if
-          (and (not documentContainer.deleted) (await documentContainer.lastDocumentVersion))
-        }}
-          {{edit-document-version documentContainer=documentContainer item=item}}
-        {{/if}}
-      {{/each}}
+        {{#each (await documents) as |documentContainer|}}
+          {{#if
+            (and (not documentContainer.deleted) (await documentContainer.lastDocumentVersion))
+          }}
+            {{edit-document-version documentContainer=documentContainer item=item}}
+          {{/if}}
+        {{/each}}
       </tbody>
     </table>
   </div>

--- a/app/pods/components/agenda/agendaitem/agendaitem-case/subcase-document/document-link/template.hbs
+++ b/app/pods/components/agenda/agendaitem/agendaitem-case/subcase-document/document-link/template.hbs
@@ -146,10 +146,10 @@
         {{#if isShowingVersions}}
           <div class="vl-accordion__content js-vl-accordion__content">
             <div class="vl-accordion__panel">
-               {{#each
-                 (await myReverseSortedVersions)
-               as |documentVersion|
-               }}
+              {{#each
+                (await myReverseSortedVersions)
+              as |documentVersion|
+              }}
                 <WebComponents::VlDocument
                   @documentVersion={{documentVersion}}
                   @item={{item}} />

--- a/app/pods/components/agenda/agendaitem/agendaitem-case/subcase-documents/template.hbs
+++ b/app/pods/components/agenda/agendaitem/agendaitem-case/subcase-documents/template.hbs
@@ -5,11 +5,11 @@
         {{t "documents"}}
       </h4>
       {{#if (and currentSession.isEditor (gt (await item.documentsLength) 0))}}
-          <div class="vl-u-spacer-extended-left-s">
-            <a data-test-subcase-documents-edit href="" class="vl-link" {{action "toggleIsEditing"}}>
-              {{t "edit"}}
-            </a>
-          </div>
+        <div class="vl-u-spacer-extended-left-s">
+          <a data-test-subcase-documents-edit href="" class="vl-link" {{action "toggleIsEditing"}}>
+            {{t "edit"}}
+          </a>
+        </div>
       {{/if}}
     </div>
   </div>
@@ -19,8 +19,8 @@
     {{else if (gt (await item.documentsLength) 0)}}
       {{#each (await item.documents) as |document|}}
         <Agenda::Agendaitem::AgendaitemCase::SubcaseDocument::DocumentLink
-          @document={{document}}
-          @item={{item}} />
+                @document={{document}}
+                @item={{item}} />
       {{/each}}
     {{else}}
       <div class="vl-u-spacer-extended-top-s">
@@ -29,9 +29,9 @@
     {{/if}}
   {{else}}
     <Agenda::Agendaitem::AgendaitemCase::EditSubcaseDocuments
-      @documents={{await item.documents}}
-      @item={{item}}
-      @cancelForm={{action "cancelEditing"}} />
+            @documents={{await item.documents}}
+            @item={{item}}
+            @cancelForm={{action "cancelEditing"}} />
   {{/if}}
   {{#if (is-pending item.documents)}}
     <button type="button" class="vl-button vl-button--loading" disabled>
@@ -59,8 +59,8 @@
     {{else if (gt (await item.linkedDocumentsLength) 0)}}
       {{#each (await item.linkedDocuments) as |document|}}
         <Agenda::Agendaitem::AgendaitemCase::SubcaseDocument::LinkedDocumentLink
-          @document={{document}}
-          @item={{item}} />
+                @document={{document}}
+                @item={{item}} />
       {{/each}}
     {{else}}
       <div class="vl-u-spacer-extended-top-s">
@@ -86,17 +86,17 @@
 </div>
 {{#if isAddingNewDocument}}
   <WebComponents::VlModal
-    @closeModal={{action "deleteAll"}}
-    @isOverlay={{true}}
-    @large={{true}}
-    @title={{t "document-add"}} >
+          @closeModal={{action "deleteAll"}}
+          @isOverlay={{true}}
+          @large={{true}}
+          @title={{t "document-add"}} >
     <div class="vl-modal-dialog__content">
       {{#if showDetail}}
         <div class="vl-u-align-right vl-u-spacer-extended-s">
           <LinkTo
-            @route="cases.case.subcases.subcase.overview"
-            @model={{item.id}}
-            @target="_blank" >
+                  @route="cases.case.subcases.subcase.overview"
+                  @model={{item.id}}
+                  @target="_blank">
             {{t "to-subcase"}}
           </LinkTo>
         </div>
@@ -125,20 +125,23 @@
                 <div class="vlc-input-field-block">
                   <WebComponents::VlFormLabel @value={{t "document-name"}} />
                   <WebComponents::VlFormInput
-                    @width="4"
-                    @value={{mut doc.name}} />
+                          @width="4"
+                          @value={{mut doc.name}} />
                 </div>
                 <div class="vlc-input-field-block">
                   <WebComponents::VlFormLabel @value={{t "document-type"}} />
                   {{#if
                     (and
-                    (is-fulfilled doc.documentContainer.type)
-                    this.documentTypes)
+                            (is-fulfilled doc.documentContainer.type)
+                            this.documentTypes)
                   }}
                     <Utils::RadioDropdownComboSelect
                       @options={{this.documentTypes}}
                       @onSelect={{action "chooseDocumentType" doc.documentContainer}}
-                      @selected={{get doc.documentContainer.type "content"}} {{!-- content getter and if-fulfilled condition because of computeds retruning promise-proxies --}}
+                      @selected={{get
+                        doc.documentContainer.type
+                        "content"
+                      }} {{!-- content getter and if-fulfilled condition because of computeds retruning promise-proxies --}}
                     />
                   {{/if}}
                 </div>

--- a/app/pods/components/agenda/agendaitem/agendaitem-news-item/template.hbs
+++ b/app/pods/components/agenda/agendaitem/agendaitem-news-item/template.hbs
@@ -10,78 +10,78 @@
     @clearAction={{action "clearTimestampForMostRecentNota"}} />
 {{/if}}
 {{#if (not isEditing)}}
-<div data-test-agenda-news-item-view>
-  <div class="vl-u-spacer">
-    <div class="vl-u-display-flex vlc-u-flex-align-baseline">
-      <h3 class="vl-title vl-title--h3">
-        {{t "newsletter-title"}}
+  <div data-test-agenda-news-item-view>
+    <div class="vl-u-spacer">
+      <div class="vl-u-display-flex vlc-u-flex-align-baseline">
+        <h3 class="vl-title vl-title--h3">
+          {{t "newsletter-title"}}
+        </h3>
+        {{#if currentSession.isEditor}}
+          <div class="vl-u-spacer-extended-left-s">
+            <a href="" data-test-newsletter-edit class="vl-link" {{action "toggleIsEditing"}}>
+              {{t "edit"}}
+            </a>
+          </div>
+        {{/if}}
+      </div>
+    </div>
+    <div class="vl-u-spacer-extended-bottom-s">
+      <h3 class="vl-title vl-title--h6">
+        {{await subcase.newsletterInfo.title}}
       </h3>
-      {{#if currentSession.isEditor}}
-        <div class="vl-u-spacer-extended-left-s">
-          <a href="" data-test-newsletter-edit class="vl-link" {{action "toggleIsEditing"}}>
-            {{t "edit"}}
-          </a>
+    </div>
+    <div class="vl-u-spacer-extended-bottom-s">
+      <div class="vl-typography">
+        <p class="vl-u-text--italic">
+          {{await subcase.newsletterInfo.newsletterProposal}}
+        </p>
+        <p>
+          {{sanitize-html
+            raw=true
+            value=(await subcase.newsletterInfo.richtext)
+          }}
+        </p>
+      </div>
+    </div>
+    <p class="vl-u-text--muted vl-u-text--capitalize vl-u-text--small">
+      {{await subcase.newsletterInfo.displayRemark}}
+    </p>
+    <div
+            class="vl-u-spacer-extended-bottom-s vl-u-spacer-extended-top-s"
+            data-test-agenda-news-item-themes>
+      {{#if (is-pending subcase.newsletterInfo.themes)}}
+        <WebComponents::VlLoader @text={{t "themes-loading-text"}} />
+      {{else if (gt (await subcase.newsletterInfo.themes.length) 0)}}
+        <ul>
+          {{#each
+            (await subcase.newsletterInfo.themes)
+          as |theme|
+          }}
+            <li class="vl-pill" data-test-agenda-news-item-theme>
+              {{theme.label}}
+            </li>
+          {{/each}}
+        </ul>
+      {{else}}
+        <div class="vl-u-spacer-extended-top-s">
+          <WebComponents::VlAlert @message={{t "no-themes-yet"}} />
+        </div>
+      {{/if}}
+    </div>
+
+    <hr/>
+    <div class="vl-u-spacer vl-u-spacer-extended-top-s">
+      {{#if (await subcase.newsletterInfo.finished)}}
+        <div class="vlc-pill vlc-pill--success">
+          {{t "finished"}}
+        </div>
+      {{else}}
+        <div class="vlc-pill vlc-pill--warning">
+          {{t "not-finished"}}
         </div>
       {{/if}}
     </div>
   </div>
-  <div class="vl-u-spacer-extended-bottom-s">
-    <h3 class="vl-title vl-title--h6">
-      {{await subcase.newsletterInfo.title}}
-    </h3>
-  </div>
-  <div class="vl-u-spacer-extended-bottom-s">
-    <div class="vl-typography">
-      <p class="vl-u-text--italic">
-        {{await subcase.newsletterInfo.newsletterProposal}}
-      </p>
-      <p>
-        {{sanitize-html
-          raw=true
-          value=(await subcase.newsletterInfo.richtext)
-        }}
-      </p>
-    </div>
-  </div>
-  <p class="vl-u-text--muted vl-u-text--capitalize vl-u-text--small">
-    {{await subcase.newsletterInfo.displayRemark}}
-  </p>
-  <div
-          class="vl-u-spacer-extended-bottom-s vl-u-spacer-extended-top-s"
-          data-test-agenda-news-item-themes>
-    {{#if (is-pending subcase.newsletterInfo.themes)}}
-      <WebComponents::VlLoader @text={{t "themes-loading-text"}} />
-    {{else if (gt (await subcase.newsletterInfo.themes.length) 0)}}
-      <ul>
-        {{#each
-          (await subcase.newsletterInfo.themes)
-        as |theme|
-        }}
-          <li class="vl-pill" data-test-agenda-news-item-theme>
-            {{theme.label}}
-          </li>
-        {{/each}}
-      </ul>
-    {{else}}
-      <div class="vl-u-spacer-extended-top-s">
-        <WebComponents::VlAlert @message={{t "no-themes-yet"}} />
-      </div>
-    {{/if}}
-  </div>
-
-  <hr/>
-  <div class="vl-u-spacer vl-u-spacer-extended-top-s">
-    {{#if (await subcase.newsletterInfo.finished)}}
-      <div class="vlc-pill vlc-pill--success">
-        {{t "finished"}}
-      </div>
-    {{else}}
-      <div class="vlc-pill vlc-pill--warning">
-        {{t "not-finished"}}
-      </div>
-    {{/if}}
-  </div>
-</div>
 {{else}}
   <NewsItem::EditItem
     @subcase={{await subcase}}

--- a/app/pods/components/agenda/compare-agenda-list/template.hbs
+++ b/app/pods/components/agenda/compare-agenda-list/template.hbs
@@ -1,3 +1,4 @@
+{{!-- template-lint-disable  --}}
 <div class="vl-u-display-flex vlc-u-flex-space-between vl-u-spacer-extended-bottom-s">
   <div class="compare-left-column">
     {{utils/agenda-selector
@@ -64,17 +65,12 @@
       </div>
     </div>
   {{/each}}
-{{else}}
-  {{#if
-    (or this.isLoadingAgendaOne this.isLoadingAgendaTwo this.isLoadingComparison)
-  }}
-    {{web-components/vl-loader text=(t "please-be-patient")}}
-  {{else}}
-    {{#if (and this.agendaOne this.agendaTwo)}}
-      <div class="vl-u-spacer-extended-top-s">
-        {{web-components/vl-alert message=(t "no-agendaitems-yet")}}
-      </div>
-      {{if}}
-    {{/if}}
-  {{/if}}
+{{else if
+  (or this.isLoadingAgendaOne this.isLoadingAgendaTwo this.isLoadingComparison)
+}}
+  {{web-components/vl-loader text=(t "please-be-patient")}}
+{{else if (and this.agendaOne this.agendaTwo)}}
+  <div class="vl-u-spacer-extended-top-s">
+    {{web-components/vl-alert message=(t "no-agendaitems-yet")}}
+  </div>
 {{/if}}

--- a/app/pods/components/agenda/compare-agenda-list/template.hbs
+++ b/app/pods/components/agenda/compare-agenda-list/template.hbs
@@ -64,12 +64,17 @@
       </div>
     </div>
   {{/each}}
-{{else if
-  (or this.isLoadingAgendaOne this.isLoadingAgendaTwo this.isLoadingComparison)
-}}
-  {{web-components/vl-loader text=(t "please-be-patient")}}
-{{else if (and this.agendaOne this.agendaTwo)}}
-  <div class="vl-u-spacer-extended-top-s">
-    {{web-components/vl-alert message=(t "no-agendaitems-yet")}}
-  </div>
+{{else}}
+  {{#if
+    (or this.isLoadingAgendaOne this.isLoadingAgendaTwo this.isLoadingComparison)
+  }}
+    {{web-components/vl-loader text=(t "please-be-patient")}}
+  {{else}}
+    {{#if (and this.agendaOne this.agendaTwo)}}
+      <div class="vl-u-spacer-extended-top-s">
+        {{web-components/vl-alert message=(t "no-agendaitems-yet")}}
+      </div>
+      {{if}}
+    {{/if}}
+  {{/if}}
 {{/if}}

--- a/app/pods/components/agenda/future-agendas/template.hbs
+++ b/app/pods/components/agenda/future-agendas/template.hbs
@@ -6,108 +6,108 @@
     <table class="data-table vl-data-table vl-data-table--zebra vl-data-table--align-middle"
            data-test-future-agenda-table>
       <thead>
-      <tr>
-        <th class="vl-data-table-col-3 vl-data-table__header-title table-header-unsortable">
-          <div class="vl-u-display-flex vl-u-flex-align-center">
-            <span>
-              {{t "agenda"}}
-            </span>
-          </div>
-        </th>
-        <th class="vl-data-table-col-2 vl-data-table__header-title table-header-unsortable"
-        >
-          <div class="vl-u-display-flex vl-u-flex-align-center">
-            <span>
-              {{t "agenda-version"}}
-            </span>
-          </div>
-        </th>
-        <th class="vl-data-table-col-2 vl-data-table__header-title table-header-unsortable"
-        >
-          <div class="vl-u-display-flex vl-u-flex-align-center">
-            <span>
-              {{t "latest-modified"}}
-            </span>
-          </div>
-        </th>
-        <th class="vl-data-table-col-2 vl-data-table__header-title table-header-unsortable"
-        >
-          <div class="vl-u-display-flex vl-u-flex-align-center">
-            <span>
-              {{t "status"}}
-            </span>
-          </div>
-        </th>
-        <th class="vl-data-table-col-2 vl-data-table__header-title table-header-unsortable"
-        >
-          <div class="vl-u-display-flex vl-u-flex-align-center">
-            <span>
-              {{t "kind"}}
-            </span>
-          </div>
-        </th>
-        <th class="vl-data-table-col-1"></th>
-      </tr>
+        <tr>
+          <th class="vl-data-table-col-3 vl-data-table__header-title table-header-unsortable">
+            <div class="vl-u-display-flex vl-u-flex-align-center">
+              <span>
+                {{t "agenda"}}
+              </span>
+            </div>
+          </th>
+          <th class="vl-data-table-col-2 vl-data-table__header-title table-header-unsortable"
+          >
+            <div class="vl-u-display-flex vl-u-flex-align-center">
+              <span>
+                {{t "agenda-version"}}
+              </span>
+            </div>
+          </th>
+          <th class="vl-data-table-col-2 vl-data-table__header-title table-header-unsortable"
+          >
+            <div class="vl-u-display-flex vl-u-flex-align-center">
+              <span>
+                {{t "latest-modified"}}
+              </span>
+            </div>
+          </th>
+          <th class="vl-data-table-col-2 vl-data-table__header-title table-header-unsortable"
+          >
+            <div class="vl-u-display-flex vl-u-flex-align-center">
+              <span>
+                {{t "status"}}
+              </span>
+            </div>
+          </th>
+          <th class="vl-data-table-col-2 vl-data-table__header-title table-header-unsortable"
+          >
+            <div class="vl-u-display-flex vl-u-flex-align-center">
+              <span>
+                {{t "kind"}}
+              </span>
+            </div>
+          </th>
+          <th class="vl-data-table-col-1"></th>
+        </tr>
       </thead>
       <tbody class="tr-hover" data-test-future-agenda-table-body>
-      {{#each (await items) as |meeting|}}
-        {{#link-to
-          "agenda.agendaitems"
-          meeting.id
-          meeting.latestAgenda.id
-          tagName="tr"
-          classNames="tr-hover"
-        }}
-          <td>
-            {{#if (is-pending meeting)}}
-              <div class="skeletal-loader" role="alert" aria-busy="true"></div>
-            {{else}}
-              {{t "agenda-for"}}
-              {{moment-format meeting.plannedStart "DD.MM.YYYY"}}
-            {{/if}}
-          </td>
-          <td>
-            {{#if (is-pending meeting.latestAgendaName)}}
-              <div class="skeletal-loader" role="alert" aria-busy="true"></div>
-            {{else if (await meeting.latestAgendaName)}}
-              {{await meeting.latestAgendaName}}
-            {{else}}
-              {{t "no-agenda"}}
-            {{/if}}
-          </td>
-          <td>
-            {{#if (is-pending meeting.latestAgenda)}}
-              <div class="skeletal-loader" role="alert" aria-busy="true"></div>
-            {{else}}
-              {{moment-format
-                (await meeting.latestAgenda.modified)
-                "DD-MM-YYYY HH:mm"
+        {{#each (await items) as |meeting|}}
+          {{#link-to
+            "agenda.agendaitems"
+            meeting.id
+            meeting.latestAgenda.id
+            tagName="tr"
+            classNames="tr-hover"
+          }}
+            <td>
+              {{#if (is-pending meeting)}}
+                <div class="skeletal-loader" role="alert" aria-busy="true"></div>
+              {{else}}
+                {{t "agenda-for"}}
+                {{moment-format meeting.plannedStart "DD.MM.YYYY"}}
+              {{/if}}
+            </td>
+            <td>
+              {{#if (is-pending meeting.latestAgendaName)}}
+                <div class="skeletal-loader" role="alert" aria-busy="true"></div>
+              {{else if (await meeting.latestAgendaName)}}
+                {{await meeting.latestAgendaName}}
+              {{else}}
+                {{t "no-agenda"}}
+              {{/if}}
+            </td>
+            <td>
+              {{#if (is-pending meeting.latestAgenda)}}
+                <div class="skeletal-loader" role="alert" aria-busy="true"></div>
+              {{else}}
+                {{moment-format
+                  (await meeting.latestAgenda.modified)
+                  "DD-MM-YYYY HH:mm"
+                }}
+              {{/if}}
+            </td>
+            <td>
+              {{#if meeting.isFinal}}
+                {{t "closed"}}
+              {{else}}
+                {{t "opened"}}
+              {{/if}}
+            </td>
+            <td>
+              {{meeting.kindToShow.label}}
+            </td>
+            <td class="vl-u-align-right">
+              {{#link-to
+                "agenda.agendaitems"
+                meeting.id
+                meeting.latestAgenda.id
+                class="vl-button vl-button--link vl-button--icon"
+                bubbles=false
               }}
-            {{/if}}
-          </td>
-          <td>
-            {{#if meeting.isFinal}}
-              {{t "closed"}}
-            {{else}}
-              {{t "opened"}}
-            {{/if}}
-          </td>
-          <td>
-            {{meeting.kindToShow.label}}
-          </td>
-          <td class="vl-u-align-right">
-            {{#link-to
-              "agenda.agendaitems"
-              meeting.id
-              meeting.latestAgenda.id
-              class="vl-button vl-button--link vl-button--icon"
-              bubbles=false
-            }}
-              <i class="vl-button__icon vl-vi vl-vi-nav-right"></i>
-            {{/link-to}}
-          </td>
-        {{/link-to}}
-      {{/each}}
+                <i class="vl-button__icon vl-vi vl-vi-nav-right"></i>
+              {{/link-to}}
+            </td>
+          {{/link-to}}
+        {{/each}}
       </tbody>
     </table>
   {{else}}

--- a/app/pods/components/agenda/printable-agenda/list-section/item-group/item/template.hbs
+++ b/app/pods/components/agenda/printable-agenda/list-section/item-group/item/template.hbs
@@ -3,15 +3,19 @@
     <div class="vlc-printable-agenda-list__item-number">
       {{item.number}}.
     </div>
-    <h4 class="vlc-printable-agenda-list__title vlc-u-no-margin">{{sanitize-html
-      raw=true
-      value=(if this.item.shortTitle this.item.shortTitle this.item.title)
-    }}</h4>{{!-- Fallback for legacy data that doesn't have a short title --}}
+    <h4 class="vlc-printable-agenda-list__title vlc-u-no-margin">
+      {{sanitize-html
+        raw=true
+        value=(if this.item.shortTitle this.item.shortTitle this.item.title)
+      }}
+    </h4>{{!-- Fallback for legacy data that doesn't have a short title --}}
   </div>
-  <p class="vlc-printable-agenda-list__description indented">{{sanitize-html
-    raw=true
-    value=this.item.title
-  }}</p>
+  <p class="vlc-printable-agenda-list__description indented">
+    {{sanitize-html
+      raw=true
+      value=this.item.title
+    }}
+  </p>
 </div>
 <ul class="vlc-printable-agenda-list__document-list indented">
   {{#each this.item.sortedDocumentVersions as |document|}}

--- a/app/pods/components/cases/new-subcase/template.hbs
+++ b/app/pods/components/cases/new-subcase/template.hbs
@@ -13,7 +13,8 @@
                 "copyFullSubcase"}}>
           <i class="vl-button__icon vl-button__icon--before vl-vi vl-vi-copy-paste" aria-hidden="true"></i>{{t
             "clone-previous-subcase"
-          }}</button>
+          }}
+        </button>
       </div>
     </div>
     <div class="vlc-input-field-block">

--- a/app/pods/components/cases/subcase-mandatees/template.hbs
+++ b/app/pods/components/cases/subcase-mandatees/template.hbs
@@ -2,69 +2,69 @@
   <div class="vl-u-spacer-extended-bottom-l">
     <table class="vl-data-table vl-data-table--align-middle">
       <thead>
-      <tr>
-        <th class="vl-data-table-col-2">
-          {{t "minister"}}
-        </th>
-        <th class="vl-data-table-col-3">
-          {{t "government-domain"}}
-        </th>
-        <th class="vl-data-table-col-5">
-          {{t "government-field"}}
-        </th>
-        <th class="vl-data-table-col-1">
-          {{t "submitter"}}
-        </th>
-        <th class="vl-data-table-col-1"></th>
-      </tr>
+        <tr>
+          <th class="vl-data-table-col-2">
+            {{t "minister"}}
+          </th>
+          <th class="vl-data-table-col-3">
+            {{t "government-domain"}}
+          </th>
+          <th class="vl-data-table-col-5">
+            {{t "government-field"}}
+          </th>
+          <th class="vl-data-table-col-1">
+            {{t "submitter"}}
+          </th>
+          <th class="vl-data-table-col-1"></th>
+        </tr>
       </thead>
       <tbody>
-      {{#each mandateeRows as |mandateeRow|}}
-        <tr>
-          <td>
-            {{await mandateeRow.mandatee.person.nameToDisplay}}
-          </td>
-          <td>
-            {{await mandateeRow.domainsToShow}}
-          </td>
-          <td>
-            {{await mandateeRow.fieldsToShow}}
-          </td>
-          <td>
-            {{web-components/vl-toggle
-              valueChanged=(action "valueChanged" mandateeRow)
-              value=(await mandateeRow.isSubmitter)
-            }}
-          </td>
-          <td class="vl-u-align-right vl-u-flex-align-center">
-            {{#if isLoading}}
+        {{#each mandateeRows as |mandateeRow|}}
+          <tr>
+            <td>
+              {{await mandateeRow.mandatee.person.nameToDisplay}}
+            </td>
+            <td>
+              {{await mandateeRow.domainsToShow}}
+            </td>
+            <td>
+              {{await mandateeRow.fieldsToShow}}
+            </td>
+            <td>
+              {{web-components/vl-toggle
+                valueChanged=(action "valueChanged" mandateeRow)
+                value=(await mandateeRow.isSubmitter)
+              }}
+            </td>
+            <td class="vl-u-align-right vl-u-flex-align-center">
+              {{#if isLoading}}
+                <button type="button"
+                        class="vl-button vl-button--link vl-button--icon"
+                        disabled>
+                  <div class="vl-loader" role="alert" aria-busy="true"></div>
+                </button>
+              {{else}}
+                <button type="button"
+                        class="vl-button vl-button--link vl-button--icon"
+                  {{action "editRow" mandateeRow}}
+                >
+                  <i class="vl-vi vl-vi-pencil" aria-hidden="true"></i>
+                  <span class="vl-u-visually-hidden">
+                    {{t "edit"}}
+                  </span>
+                </button>
+              {{/if}}
               <button type="button"
                       class="vl-button vl-button--link vl-button--icon"
-                      disabled>
-                <div class="vl-loader" role="alert" aria-busy="true"></div>
-              </button>
-            {{else}}
-              <button type="button"
-                      class="vl-button vl-button--link vl-button--icon"
-                {{action "editRow" mandateeRow}}
-              >
-                <i class="vl-vi vl-vi-pencil" aria-hidden="true"></i>
+                {{action "deleteRow" mandateeRow}}>
+                <i class="vl-vi vl-vi-trash" aria-hidden="true"></i>
                 <span class="vl-u-visually-hidden">
-                  {{t "edit"}}
+                  {{t "delete"}}
                 </span>
               </button>
-            {{/if}}
-            <button type="button"
-                    class="vl-button vl-button--link vl-button--icon"
-              {{action "deleteRow" mandateeRow}}>
-              <i class="vl-vi vl-vi-trash" aria-hidden="true"></i>
-              <span class="vl-u-visually-hidden">
-                {{t "delete"}}
-              </span>
-            </button>
-          </td>
-        </tr>
-      {{/each}}
+            </td>
+          </tr>
+        {{/each}}
       </tbody>
     </table>
   </div>

--- a/app/pods/components/item-document/template.hbs
+++ b/app/pods/components/item-document/template.hbs
@@ -3,27 +3,27 @@
   document.checkAdded
   "vlc-document-list__item vlc-document-list__item--active"
 }}">
-{{#if (is-pending lastDocumentVersion)}}
-  <div class="skeletal-loader" role="alert" aria-busy="true"></div>
-{{else if isClickable}}
-  <a href="" {{action "showDocumentVersionViewer" lastDocumentVersion}}>
-    <i class="vl-badge__icon
-    {{if
-      (and (not document.checkAdded) (not lastDocumentVersion.confidential))
-      "ki-document"
-    }}
-    {{if document.checkAdded "ki-document-added"}}
-    {{if (await lastDocumentVersion.confidential) "ki-lock-closed"}}">
-    </i>
-    {{await lastDocumentVersionName}}
-  </a>
-{{else}}
-  <span>
-    <i class="vl-badge__icon
-      {{if document.checkAdded "ki-document-added" "ki-document"}}">
-    </i>
-    {{await lastDocumentVersionName}}
-  </span>
-{{/if}}
+  {{#if (is-pending lastDocumentVersion)}}
+    <div class="skeletal-loader" role="alert" aria-busy="true"></div>
+  {{else if isClickable}}
+    <a href="" {{action "showDocumentVersionViewer" lastDocumentVersion}}>
+      <i class="vl-badge__icon
+      {{if
+        (and (not document.checkAdded) (not lastDocumentVersion.confidential))
+        "ki-document"
+      }}
+      {{if document.checkAdded "ki-document-added"}}
+      {{if (await lastDocumentVersion.confidential) "ki-lock-closed"}}">
+      </i>
+      {{await lastDocumentVersionName}}
+    </a>
+  {{else}}
+    <span>
+      <i class="vl-badge__icon
+        {{if document.checkAdded "ki-document-added" "ki-document"}}">
+      </i>
+      {{await lastDocumentVersionName}}
+    </span>
+  {{/if}}
 </li>
 {{yield}}

--- a/app/pods/components/newsletter/newsletter-header-overview/template.hbs
+++ b/app/pods/components/newsletter/newsletter-header-overview/template.hbs
@@ -20,7 +20,7 @@
               {{!-- template-lint-disable no-bare-strings  --}}
                 &#8629;
               {{!-- template-lint-enable no-bare-strings  --}}
-            </LinkTo>
+              </LinkTo>
             </div>
             {{#if currentSession.isEditor}}
               <div class="vlc-toolbar__item">

--- a/app/pods/components/subcases/subcase-description/template.hbs
+++ b/app/pods/components/subcases/subcase-description/template.hbs
@@ -77,20 +77,20 @@
             <div class="vl-loader"></div>
           {{else}}
             {{#if (await subcase.onAgendaInfo)}}
-              {{#if  
+              {{#if
                 (await isRetracted)
               }}
                 {{t "postponed-subcase"}}
               {{/if}}
-                {{#link-to
-                  "agenda.agendaitems.agendaitem"
-                  (await latestMeetingId)
-                  (await latestAgendaId)
-                  (await latestAgendaItemId)
-                  class="vl-link"
-                }}
-                  {{moment-format (await subcase.onAgendaInfo)  "DD MMMM YYYY"}}
-                {{/link-to}}
+              {{#link-to
+                "agenda.agendaitems.agendaitem"
+                (await latestMeetingId)
+                (await latestAgendaId)
+                (await latestAgendaItemId)
+                class="vl-link"
+              }}
+                {{moment-format (await subcase.onAgendaInfo)  "DD MMMM YYYY"}}
+              {{/link-to}}
             {{else}}
               {{t "not-yet-on-agenda"}}
             {{/if}}

--- a/app/pods/components/utils/case-search/template.hbs
+++ b/app/pods/components/utils/case-search/template.hbs
@@ -13,32 +13,32 @@
     {{else}}
       <table class="vl-data-table tr-hover vl-data-table--zebra">
         <thead>
-        <tr>
-          <th class="vl-data-table-col-9 vl-data-table__header-title">
-            {{t "case-name"}}
-          </th>
-          <th class="vl-data-table-col-2 vl-data-table__header-title">
-            {{t "created-on"}}
-          </th>
-        </tr>
+          <tr>
+            <th class="vl-data-table-col-9 vl-data-table__header-title">
+              {{t "case-name"}}
+            </th>
+            <th class="vl-data-table-col-2 vl-data-table__header-title">
+              {{t "created-on"}}
+            </th>
+          </tr>
         </thead>
         <tbody>
-        {{#each (await results) as |row|}}
-          <tr>
-            <td onclick={{action "selectCase" row}}>
-              <p>
-                {{#if row.shortTitle}}
-                  {{row.shortTitle}}
-                {{else}}
-                  {{row.title}}
-                {{/if}}
-              </p>
-            </td>
-            <td onclick={{action "selectCase" row}}>
-              {{moment-format row.created "DD-MM-YYYY HH:mm"}}
-            </td>
-          </tr>
-        {{/each}}
+          {{#each (await results) as |row|}}
+            <tr>
+              <td onclick={{action "selectCase" row}}>
+                <p>
+                  {{#if row.shortTitle}}
+                    {{row.shortTitle}}
+                  {{else}}
+                    {{row.title}}
+                  {{/if}}
+                </p>
+              </td>
+              <td onclick={{action "selectCase" row}}>
+                {{moment-format row.created "DD-MM-YYYY HH:mm"}}
+              </td>
+            </tr>
+          {{/each}}
         </tbody>
       </table>
       <div class="vl-u-spacer--small"></div>

--- a/app/pods/components/utils/documents-list-for-item/template.hbs
+++ b/app/pods/components/utils/documents-list-for-item/template.hbs
@@ -2,16 +2,14 @@
   {{web-components/vl-loader text=(t "documents-loading-text")}}
 {{else}}
   <div class="grid-container">
-
-      {{#each (await documents) as |document|}}
-        {{item-document
-          item=@item
-          document=document
-          isClickable=@isClickable
-          useNewIcons=useNewIcons
-        }}
-      {{/each}}
-
+    {{#each (await documents) as |document|}}
+      {{item-document
+        item=@item
+        document=document
+        isClickable=@isClickable
+        useNewIcons=useNewIcons
+      }}
+    {{/each}}
   </div>
   {{#if this.moreThan20}}
     <button class="vlc-document-show-more-button" type="button" {{action "toggleShowingAll"}}>

--- a/app/pods/components/utils/documents-list-lazy-loaded/template.hbs
+++ b/app/pods/components/utils/documents-list-lazy-loaded/template.hbs
@@ -2,7 +2,7 @@
   {{#each (await documentNames) as |documentName|}}
     <li class="vlc-document-list__item vlc-document-list__item--loading">
       <span>
-          <i class="vl-badge__icon vl-vi vl-vi-synchronize"></i>
+        <i class="vl-badge__icon vl-vi vl-vi-synchronize"></i>
         {{documentName}}
       </span>
     </li>

--- a/app/pods/components/utils/documents-selector-of-agendaitem/template.hbs
+++ b/app/pods/components/utils/documents-selector-of-agendaitem/template.hbs
@@ -5,47 +5,47 @@
     </h2>
     <table class="vl-data-table vl-data-table--align-middle">
       <thead>
-      <tr>
-        <th class="vl-data-table-col-6">
-          {{web-components/vl-form-label value=(t "document-name")}}
-        </th>
-        <th class="vl-data-table-col-4">
-          {{web-components/vl-form-label value=(t "file-type")}}
-        </th>
-        <th class="vl-data-table-col-2">
-          {{web-components/vl-form-label value=(t "select")}}
-        </th>
-      </tr>
+        <tr>
+          <th class="vl-data-table-col-6">
+            {{web-components/vl-form-label value=(t "document-name")}}
+          </th>
+          <th class="vl-data-table-col-4">
+            {{web-components/vl-form-label value=(t "file-type")}}
+          </th>
+          <th class="vl-data-table-col-2">
+            {{web-components/vl-form-label value=(t "select")}}
+          </th>
+        </tr>
       </thead>
       <tbody>
-      {{#each (await lastDocumentVersions) as |documentVersion|}}
-        {{#if (not documentVersion.deleted)}}
-          <tr>
-            <td class="vl-u-display-flex vlc-document-list__item">
-              <a href="" {{action "downloadFile" documentVersion}}>
-                <div class="vl-badge vl-badge--icon vl-badge--small-medium vl-badge--alt"
-                >
-                  <i class="vl-badge__icon vl-vi vl-vi-document"
-                     aria-hidden="true"
-                  ></i>
-                </div>
-                <p>
-                  {{await documentVersion.name}}
-                </p>
-              </a>
-            </td>
-            <td>
-              {{await documentVersion.typeLabel}}
-            </td>
-            <td>
-              {{web-components/vl-checkbox
-                value=documentVersion.selected
-                toggle=(action "selectForPublication")
-              }}
-            </td>
-          </tr>
-        {{/if}}
-      {{/each}}
+        {{#each (await lastDocumentVersions) as |documentVersion|}}
+          {{#if (not documentVersion.deleted)}}
+            <tr>
+              <td class="vl-u-display-flex vlc-document-list__item">
+                <a href="" {{action "downloadFile" documentVersion}}>
+                  <div class="vl-badge vl-badge--icon vl-badge--small-medium vl-badge--alt"
+                  >
+                    <i class="vl-badge__icon vl-vi vl-vi-document"
+                       aria-hidden="true"
+                    ></i>
+                  </div>
+                  <p>
+                    {{await documentVersion.name}}
+                  </p>
+                </a>
+              </td>
+              <td>
+                {{await documentVersion.typeLabel}}
+              </td>
+              <td>
+                {{web-components/vl-checkbox
+                  value=documentVersion.selected
+                  toggle=(action "selectForPublication")
+                }}
+              </td>
+            </tr>
+          {{/if}}
+        {{/each}}
       </tbody>
     </table>
   </div>

--- a/app/pods/components/utils/minister-modal/template.hbs
+++ b/app/pods/components/utils/minister-modal/template.hbs
@@ -7,19 +7,19 @@
     <label>{{t "select-minister"}}</label>
     <div class="vl-u-spacer-extended-bottom-l">
       {{#if isAddingMinister}}
-          {{utils/mandatee-selector
-            data-test-mandatee-selector
-            singleSelect=true
-            selectedMandatees=selectedMandatee
-            chooseMandatee=(action "mandateeSelected")
-          }}
-        {{else}}
-          {{utils/mandatee-selector
-            singleSelect=true
-            readOnly=true
-            selectedMandatees=selectedMandatee
-          }}
-        {{/if}}
+        {{utils/mandatee-selector
+          data-test-mandatee-selector
+          singleSelect=true
+          selectedMandatees=selectedMandatee
+          chooseMandatee=(action "mandateeSelected")
+        }}
+      {{else}}
+        {{utils/mandatee-selector
+          singleSelect=true
+          readOnly=true
+          selectedMandatees=selectedMandatee
+        }}
+      {{/if}}
     </div>
     {{#if (and isLoading and isAddingMinister)}}
       {{web-components/vl-loader text=(t "please-be-patient")}}
@@ -51,7 +51,7 @@
         </ul>
       {{/each}}
     {{/if}}
-</div>
+  </div>
   {{web-components/vl-modal-footer
     isLoading=isLoading
     nonBordered=true

--- a/app/pods/components/utils/search-legend/template.hbs
+++ b/app/pods/components/utils/search-legend/template.hbs
@@ -1,44 +1,44 @@
 <table class="vl-data-table vlc-u-cursor-default">
   <thead>
-  <tr>
-    <th class="vl-data-table-col-2 vl-data-table__header-title">
-      {{t "search-legend-header-example"}}
-    </th>
-    <th class="vl-data-table-col-9 vl-data-table__header-title">
-      {{t "search-legend-header-explanation"}}
-    </th>
-    <th class="vl-data-table-col-9 vl-data-table__header-title">
-      <button type="button" class="vl-button vl-button--link-muted vl-button--icon vlc-u-cursor-pointer" {{action "close"}}>
-        <i class="vl-button__icon vl-vi vl-vi-close-light" aria-hidden="true"></i>
-        <span class="vl-u-visually-hidden">
-          {{t "close"}}
-        </span>
-      </button>
-    </th>
-  </tr>
+    <tr>
+      <th class="vl-data-table-col-2 vl-data-table__header-title">
+        {{t "search-legend-header-example"}}
+      </th>
+      <th class="vl-data-table-col-9 vl-data-table__header-title">
+        {{t "search-legend-header-explanation"}}
+      </th>
+      <th class="vl-data-table-col-9 vl-data-table__header-title">
+        <button type="button" class="vl-button vl-button--link-muted vl-button--icon vlc-u-cursor-pointer" {{action "close"}}>
+          <i class="vl-button__icon vl-vi vl-vi-close-light" aria-hidden="true"></i>
+          <span class="vl-u-visually-hidden">
+            {{t "close"}}
+          </span>
+        </button>
+      </th>
+    </tr>
   </thead>
   <tbody>
-  <tr>
-    <td class="vl-data-table-col-1">{{t "search-legend-and-example"}}</td>
-    <td class="vl-data-table-col-12">{{t "search-legend-and-explanation"}}</td>
-  </tr>
+    <tr>
+      <td class="vl-data-table-col-1">{{t "search-legend-and-example"}}</td>
+      <td class="vl-data-table-col-12">{{t "search-legend-and-explanation"}}</td>
+    </tr>
   {{!-- Disabled this for now, because this doesn't actually work yet
   <tr>
     <td class="vl-data-table-col-1">{{t "search-legend-or-example"}}</td>
     <td class="vl-data-table-col-12">{{t "search-legend-or-explanation"}}</td>
   </tr>
   --}}
-  <tr>
-    <td class="vl-data-table-col-1">{{t "search-legend-not-example"}}</td>
-    <td class="vl-data-table-col-12">{{t "search-legend-not-explanation"}}</td>
-  </tr>
-  <tr>
-    <td class="vl-data-table-col-1">{{t "search-legend-order-example"}}</td>
-    <td class="vl-data-table-col-12">{{t "search-legend-order-explanation"}}</td>
-  </tr>
-  <tr>
-    <td class="vl-data-table-col-1">{{t "search-legend-wildcard-example"}}</td>
-    <td class="vl-data-table-col-12">{{t "search-legend-wildcard-explanation"}}</td>
-  </tr>
+    <tr>
+      <td class="vl-data-table-col-1">{{t "search-legend-not-example"}}</td>
+      <td class="vl-data-table-col-12">{{t "search-legend-not-explanation"}}</td>
+    </tr>
+    <tr>
+      <td class="vl-data-table-col-1">{{t "search-legend-order-example"}}</td>
+      <td class="vl-data-table-col-12">{{t "search-legend-order-explanation"}}</td>
+    </tr>
+    <tr>
+      <td class="vl-data-table-col-1">{{t "search-legend-wildcard-example"}}</td>
+      <td class="vl-data-table-col-12">{{t "search-legend-wildcard-explanation"}}</td>
+    </tr>
   </tbody>
 </table>

--- a/app/pods/components/utils/simple-file-uploader/template.hbs
+++ b/app/pods/components/utils/simple-file-uploader/template.hbs
@@ -1,12 +1,13 @@
 <FileUpload
-        @name="files"
-        @accept=".csv"
-        @onfileadd={{action "uploadFile"}} as |queue|>
+  @name="files"
+  @accept=".csv"
+  @onfileadd={{action "uploadFile"}} as |queue|>
 
   <span class="vl-button vl-button--tertiary vl-button--icon-before">
     {{#if queue.files.length}}
       <a href="javascript://" class="vl-button vl-button--tertiary vl-button--icon-before">
-        {{t "import-users-text"}}</a>
+        {{t "import-users-text"}}
+      </a>
     {{else}}
       <i class="vl-button__icon vl-button__icon--before vl-vi vl-vi-cloud-upload"></i>
       {{t "import-users"}}

--- a/app/pods/components/web-components/light-table/vl-delete-user/template.hbs
+++ b/app/pods/components/web-components/light-table/vl-delete-user/template.hbs
@@ -1,8 +1,8 @@
 <button type="button" data-test-delete-user class="vl-button vl-button--link vl-button--icon vlc-link-pointer" {{action "toggleIsVerifying" bubbles=false}}>
-    <i class="vl-vi vl-vi-trash" aria-hidden="true"></i>
-    <span class="vl-u-visually-hidden">
-      {{t "delete"}}
-    </span>
+  <i class="vl-vi vl-vi-trash" aria-hidden="true"></i>
+  <span class="vl-u-visually-hidden">
+    {{t "delete"}}
+  </span>
 </button>
 {{#if isVerifying}}
   {{web-components/vl-modal-verify

--- a/app/pods/components/web-components/vl-modal/template.hbs
+++ b/app/pods/components/web-components/vl-modal/template.hbs
@@ -16,19 +16,19 @@
             </div>
             <div class="vlc-toolbar__right">
               {{#if showCloseButton}}
-              <div class="vlc-toolbar__item">
-                <button type="button" data-test-vl-modal-close
-                        class="vl-button vl-button--link-muted vl-button--icon"
-                  {{action "close"}}
-                >
-                  <i class="vl-button__icon vl-vi vl-vi-close-light"
-                     aria-hidden="true"
-                  ></i>
-                  <span class="vl-u-visually-hidden">
-                    {{t "close"}}
-                  </span>
-                </button>
-              </div>
+                <div class="vlc-toolbar__item">
+                  <button type="button" data-test-vl-modal-close
+                          class="vl-button vl-button--link-muted vl-button--icon"
+                    {{action "close"}}
+                  >
+                    <i class="vl-button__icon vl-vi vl-vi-close-light"
+                       aria-hidden="true"
+                    ></i>
+                    <span class="vl-u-visually-hidden">
+                      {{t "close"}}
+                    </span>
+                  </button>
+                </div>
               {{/if}}
             </div>
           </div>

--- a/app/pods/mock-login-route/template.hbs
+++ b/app/pods/mock-login-route/template.hbs
@@ -9,7 +9,9 @@
             <div class="content-header__logo-wrapper">
               <a href="#"
                  class="content-header__entity-logo content-header__entity-logo--lowercase">
-                <span class="content-header__entity-logo__prefix">Kanselarij</span></a></div>
+                <span class="content-header__entity-logo__prefix">Kanselarij</span>
+              </a>
+            </div>
           </div>
         </div>
       </div>

--- a/app/pods/not-supported/template.hbs
+++ b/app/pods/not-supported/template.hbs
@@ -5,8 +5,8 @@
     recente PC, Mac en Linux versies van:
     <br/>
     <strong>
-      <a href="https://www.google.com/intl/nl/chrome/">Download Google Chrome</a> of <a
-            href="https://www.mozilla.org/nl/firefox/new/">Download Mozilla Firefox</a>
+      <a href="https://www.google.com/intl/nl/chrome/">Download Google Chrome</a> of
+      <a href="https://www.mozilla.org/nl/firefox/new/">Download Mozilla Firefox</a>
     </strong>
     <br/>
     Tot nader bericht kan je Kaleidos niet gebruiken met Internet Explorer, Microsoft Edge en andere browsers. Kadeidos

--- a/app/pods/search/template.hbs
+++ b/app/pods/search/template.hbs
@@ -99,7 +99,7 @@
             aria-hidden="true"
           ></i>
           {{t "search"}}
-      </button>
+        </button>
       </div>
     </div>
 

--- a/app/pods/settings/ministers/template.hbs
+++ b/app/pods/settings/ministers/template.hbs
@@ -1,184 +1,184 @@
 <div class="vl-u-spacer-extended-l">
-{{title (t "manage-ministers")}}
-<div class="vl-u-display-flex vlc-u-flex-space-between">
-  <h4 class="vl-title vl-title--h4"></h4>
-  <button data-test-minister-add
-          type="button"
-          class="vl-button vl-button--icon-before"
-    {{action "toggleIsAdding"}}
-  >
-    <i class="vl-button__icon vl-button__icon--before vl-vi vl-vi-add"></i>
-    {{t "create-mandatee"}}
-  </button>
-</div>
-{{#if (await model)}}
-{{!-- "tbody" tagname in the "sortable-group"-helper --}}
-{{!-- template-lint-disable table-groups  --}}
-  <table class="vl-data-table vl-data-table--zebra vl-data-table--align-middle">
-    <thead>
-    <tr>
-      <th class="vl-data-table-col-6 vl-data-table__header-title">
-        <a class="vl-data-table__header-title--sortable vl-data-table__header-title--sortable-active"
-           href="#"
-        ></a>
-        <a class="vl-data-table__header-title--sortable" href="#">
-          <div class="vl-u-display-flex vl-u-flex-align-center">
-              <span>
-                {{t "minister"}}
-              </span>
-          </div>
-        </a>
-      </th>
-      <th class="vl-data-table-col-3 vl-data-table__header-title">
-        <a class="vl-data-table__header-title--sortable vl-data-table__header-title--sortable-active"
-           href="#"
-        ></a>
-        <a class="vl-data-table__header-title--sortable" href="#">
-          <div class="vl-u-display-flex vl-u-flex-align-center">
-              <span>
-                {{t "nick-name"}}
-              </span>
-          </div>
-        </a>
-      </th>
-      <th class="vl-data-table-col-1 vl-data-table__header-title">
-        <a class="vl-data-table__header-title--sortable vl-data-table__header-title--sortable-active"
-           href="#"
-        ></a>
-        <a class="vl-data-table__header-title--sortable" href="#">
-          <div class="vl-u-display-flex vl-u-flex-align-center">
-              <span>
-                {{t "priority"}}
-              </span>
-          </div>
-        </a>
-      </th>
-      <th class="vl-data-table-col-2"></th>
-    </tr>
-    </thead>
-    {{#sortable-group
-      data-test-ministers-sortable-group
-      tagName="tbody"
-      onChange=(action "reorderItems" model)
-    as |sortableGroup|
-    }}
-      {{#each
-        model
-      as |mandatee index|
+  {{title (t "manage-ministers")}}
+  <div class="vl-u-display-flex vlc-u-flex-space-between">
+    <h4 class="vl-title vl-title--h4"></h4>
+    <button data-test-minister-add
+            type="button"
+            class="vl-button vl-button--icon-before"
+      {{action "toggleIsAdding"}}
+    >
+      <i class="vl-button__icon vl-button__icon--before vl-vi vl-vi-add"></i>
+      {{t "create-mandatee"}}
+    </button>
+  </div>
+  {{#if (await model)}}
+  {{!-- "tbody" tagname in the "sortable-group"-helper --}}
+  {{!-- template-lint-disable table-groups  --}}
+    <table class="vl-data-table vl-data-table--zebra vl-data-table--align-middle">
+      <thead>
+        <tr>
+          <th class="vl-data-table-col-6 vl-data-table__header-title">
+            <a class="vl-data-table__header-title--sortable vl-data-table__header-title--sortable-active"
+               href="#"
+            ></a>
+            <a class="vl-data-table__header-title--sortable" href="#">
+              <div class="vl-u-display-flex vl-u-flex-align-center">
+                <span>
+                  {{t "minister"}}
+                </span>
+              </div>
+            </a>
+          </th>
+          <th class="vl-data-table-col-3 vl-data-table__header-title">
+            <a class="vl-data-table__header-title--sortable vl-data-table__header-title--sortable-active"
+               href="#"
+            ></a>
+            <a class="vl-data-table__header-title--sortable" href="#">
+              <div class="vl-u-display-flex vl-u-flex-align-center">
+                <span>
+                  {{t "nick-name"}}
+                </span>
+              </div>
+            </a>
+          </th>
+          <th class="vl-data-table-col-1 vl-data-table__header-title">
+            <a class="vl-data-table__header-title--sortable vl-data-table__header-title--sortable-active"
+               href="#"
+            ></a>
+            <a class="vl-data-table__header-title--sortable" href="#">
+              <div class="vl-u-display-flex vl-u-flex-align-center">
+                <span>
+                  {{t "priority"}}
+                </span>
+              </div>
+            </a>
+          </th>
+          <th class="vl-data-table-col-2"></th>
+        </tr>
+      </thead>
+      {{#sortable-group
+        data-test-ministers-sortable-group
+        tagName="tbody"
+        onChange=(action "reorderItems" model)
+      as |sortableGroup|
       }}
-        {{#sortable-item
-          tagName="tr"
-          model=mandatee
-          data-test-ministers-sortable-group-row=index
-          group=sortableGroup
-          handle=".mandatee-draggable-row"
+        {{#each
+          model
+        as |mandatee index|
         }}
-          <td data-test-mandatee-fullDisplayName={{index}} class="mandatee-draggable-row">
-            {{#if (is-pending mandatee.fullDisplayName)}}
-              <div class="skeletal-loader" role="alert" aria-busy="true"></div>
-            {{else}}
-              {{await mandatee.fullDisplayName}}
-            {{/if}}
-          </td>
-          <td data-test-mandatee-nickName={{index}} class="mandatee-draggable-row">
-            {{#if (is-pending mandatee.nickName)}}
-              <div class="skeletal-loader" role="alert" aria-busy="true"></div>
-            {{else}}
-              {{await mandatee.nickName}}
-            {{/if}}
-          </td>
-          <td data-test-mandatee-priority={{index}} class="mandatee-draggable-row">
-            {{await mandatee.priority}}
-          </td>
-          <td class="vl-u-align-center">
-            <div class="vl-action-group vl-action-group--align-center">
-              <button data-test-mandatee-edit={{index}}
-                      type="button"
-                      class="vl-button vl-button--link vl-button--icon"
-                {{action "toggleProperty" "isEditingMandatee" mandatee}}
-              >
-                <i class="vl-button__icon vl-vi vl-vi-edit"></i>
-              </button>
-              <button type="button"
-                      data-test-mandatee-resign={{index}}
-                      class="vl-button vl-button--link vl-button--icon"
-                {{action "toggleProperty" "isResigningMandatee" mandatee}}
-              >
-                <i class="vl-button__icon vl-vi vl-vi-cog"></i>
-                {{#attach-tooltip
-                  arrow="true"
-                  animation="shift"
-                  placement="bottom"
-                  class="ember-attacher-tooltip"
-                }}
-                  {{t "resign"}}
-                {{/attach-tooltip}}
-              </button>
-              <button type="button"
-                      data-test-mandatee-delete={{index}}
-                      class="vl-button vl-button--link vl-button--icon vl-u-text--error"
-                {{action "toggleProperty" "isDeletingMandatee" mandatee}}
-              >
-                <i class="vl-button__icon vl-vi vl-vi-trash"></i>
-              </button>
-            </div>
-          </td>
-        {{/sortable-item}}
-      {{/each}}
-    {{/sortable-group}}
-  </table>
-{{!-- template-lint-enable table-groups --}}
-{{/if}}
-{{#if isEditingMandatee}}
-  {{#web-components/vl-modal
-    isOverlay=true
-    title=(t "manage-ministers")
-    closeModal=(action "toggleProperty" "isEditingMandatee" mandateeToEdit)
-  }}
-    {{utils/manage-mandatees
-      mandateeToEdit=mandateeToEdit
-      mandateesUpdated=(action "mandateesUpdated")
-      isEditing=isEditingMandatee
+          {{#sortable-item
+            tagName="tr"
+            model=mandatee
+            data-test-ministers-sortable-group-row=index
+            group=sortableGroup
+            handle=".mandatee-draggable-row"
+          }}
+            <td data-test-mandatee-fullDisplayName={{index}} class="mandatee-draggable-row">
+              {{#if (is-pending mandatee.fullDisplayName)}}
+                <div class="skeletal-loader" role="alert" aria-busy="true"></div>
+              {{else}}
+                {{await mandatee.fullDisplayName}}
+              {{/if}}
+            </td>
+            <td data-test-mandatee-nickName={{index}} class="mandatee-draggable-row">
+              {{#if (is-pending mandatee.nickName)}}
+                <div class="skeletal-loader" role="alert" aria-busy="true"></div>
+              {{else}}
+                {{await mandatee.nickName}}
+              {{/if}}
+            </td>
+            <td data-test-mandatee-priority={{index}} class="mandatee-draggable-row">
+              {{await mandatee.priority}}
+            </td>
+            <td class="vl-u-align-center">
+              <div class="vl-action-group vl-action-group--align-center">
+                <button data-test-mandatee-edit={{index}}
+                        type="button"
+                        class="vl-button vl-button--link vl-button--icon"
+                  {{action "toggleProperty" "isEditingMandatee" mandatee}}
+                >
+                  <i class="vl-button__icon vl-vi vl-vi-edit"></i>
+                </button>
+                <button type="button"
+                        data-test-mandatee-resign={{index}}
+                        class="vl-button vl-button--link vl-button--icon"
+                  {{action "toggleProperty" "isResigningMandatee" mandatee}}
+                >
+                  <i class="vl-button__icon vl-vi vl-vi-cog"></i>
+                  {{#attach-tooltip
+                    arrow="true"
+                    animation="shift"
+                    placement="bottom"
+                    class="ember-attacher-tooltip"
+                  }}
+                    {{t "resign"}}
+                  {{/attach-tooltip}}
+                </button>
+                <button type="button"
+                        data-test-mandatee-delete={{index}}
+                        class="vl-button vl-button--link vl-button--icon vl-u-text--error"
+                  {{action "toggleProperty" "isDeletingMandatee" mandatee}}
+                >
+                  <i class="vl-button__icon vl-vi vl-vi-trash"></i>
+                </button>
+              </div>
+            </td>
+          {{/sortable-item}}
+        {{/each}}
+      {{/sortable-group}}
+    </table>
+  {{!-- template-lint-enable table-groups --}}
+  {{/if}}
+  {{#if isEditingMandatee}}
+    {{#web-components/vl-modal
+      isOverlay=true
+      title=(t "manage-ministers")
       closeModal=(action "toggleProperty" "isEditingMandatee" mandateeToEdit)
     }}
-  {{/web-components/vl-modal}}
-{{/if}}
-{{#if isResigningMandatee}}
-  {{#web-components/vl-modal
-    isOverlay=true
-    title=(t "manage-ministers")
-    closeModal=(action "toggleProperty" "isResigningMandatee" mandateeToEdit)
-  }}
-    {{utils/manage-mandatees
-      mandateeToEdit=mandateeToEdit
-      mandateesUpdated=(action "mandateesUpdated")
-      isResigning=isResigningMandatee
+      {{utils/manage-mandatees
+        mandateeToEdit=mandateeToEdit
+        mandateesUpdated=(action "mandateesUpdated")
+        isEditing=isEditingMandatee
+        closeModal=(action "toggleProperty" "isEditingMandatee" mandateeToEdit)
+      }}
+    {{/web-components/vl-modal}}
+  {{/if}}
+  {{#if isResigningMandatee}}
+    {{#web-components/vl-modal
+      isOverlay=true
+      title=(t "manage-ministers")
       closeModal=(action "toggleProperty" "isResigningMandatee" mandateeToEdit)
     }}
-  {{/web-components/vl-modal}}
-{{/if}}
-{{#if isAddingMandatee}}
-  {{#web-components/vl-modal
-    isOverlay=true
-    title=(t "manage-ministers")
-    closeModal=(action "toggleIsAdding")
-  }}
-  {{utils/create-mandatee
-    model=model
-    closeModal=(action "toggleIsAdding")
-    mandateesUpdated=(action "mandateesUpdated")
-  }}
-  {{/web-components/vl-modal}}
-{{/if}}
-{{#if isDeletingMandatee}}
-  {{web-components/vl-modal-verify
-    title=(t "warning-title")
-    verifyButtonText=(t "delete")
-    message=(t "delete-mandatee-message")
-    cancel=(action "cancel")
-    verify=(action "deleteMandatee")
-    mandateesUpdated=(action "mandateesUpdated")
-  }}
-{{/if}}
-{{outlet}}
+      {{utils/manage-mandatees
+        mandateeToEdit=mandateeToEdit
+        mandateesUpdated=(action "mandateesUpdated")
+        isResigning=isResigningMandatee
+        closeModal=(action "toggleProperty" "isResigningMandatee" mandateeToEdit)
+      }}
+    {{/web-components/vl-modal}}
+  {{/if}}
+  {{#if isAddingMandatee}}
+    {{#web-components/vl-modal
+      isOverlay=true
+      title=(t "manage-ministers")
+      closeModal=(action "toggleIsAdding")
+    }}
+      {{utils/create-mandatee
+        model=model
+        closeModal=(action "toggleIsAdding")
+        mandateesUpdated=(action "mandateesUpdated")
+      }}
+    {{/web-components/vl-modal}}
+  {{/if}}
+  {{#if isDeletingMandatee}}
+    {{web-components/vl-modal-verify
+      title=(t "warning-title")
+      verifyButtonText=(t "delete")
+      message=(t "delete-mandatee-message")
+      cancel=(action "cancel")
+      verify=(action "deleteMandatee")
+      mandateesUpdated=(action "mandateesUpdated")
+    }}
+  {{/if}}
+  {{outlet}}
 </div>

--- a/app/pods/settings/users/user/template.hbs
+++ b/app/pods/settings/users/user/template.hbs
@@ -21,7 +21,7 @@
             <div class="vlc-key-value-item__value">{{web-components/light-table/vl-group-column user=model}}</div>
           </div>
         </pl.Body>
-    </Panel>
+      </Panel>
     </div>
     <div class="vl-u-spacer-extended">
       <Panel as |pl|>

--- a/app/pods/styleguide/typography/template.hbs
+++ b/app/pods/styleguide/typography/template.hbs
@@ -11,7 +11,8 @@
       <p>
         This longer body text where we show a bit more content in a paragraph is set as <strong>body 1</strong>,
         and it
-        contains <em>italic</em> text.</p>
+        contains <em>italic</em> text.
+      </p>
     </div>
   </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19856,6 +19856,15 @@
         }
       }
     },
+    "eslint-plugin-hbs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-hbs/-/eslint-plugin-hbs-1.0.0.tgz",
+      "integrity": "sha512-UaJYgG1xP6Mr/VuPO9G/tbReiavs8lmTUInwbomQ+FtA7C22AlDZK08FH4aRloKo70GyeJLm+SYSF6QtM/QZhQ==",
+      "dev": true,
+      "requires": {
+        "requireindex": "^1.2.0"
+      }
+    },
     "eslint-plugin-jsx-a11y": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
@@ -27076,6 +27085,12 @@
       "version": "0.8.7",
       "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
       "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+      "dev": true
+    },
+    "requireindex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
       "dev": true
     },
     "requires-port": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "ember-template-lint": "^2.4.0",
     "eslint": "^6.8.0",
     "eslint-plugin-ember": "^7.10.1",
+    "eslint-plugin-hbs": "^1.0.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-node": "^11.0.0",
     "icon-font-generator": "^2.1.10",


### PR DESCRIPTION
# KAS-1674: .hbs lint

In deze PR hebben we de huidige versie van Kaleidos op development gelint voor de `.hbs` files, dit zal ervoor zorgen dat we de ember-template-lint mee kunnen laten valideren met de toekomstige builds..

Deze PR zou geen functionele changes moeten hebben, we dienen wel te kijken of er visueel geen belangrijke zaken veranderd zijn door het zetten van enters op sommige stukken in de code.

## ✏️ What has changed:

- Rules verplaatst van de `eslint.rc` file naar de `eslint-template` file..
- Single rule verder gespecifieerd
- `.hbs` files zijn geformat volgens de specificaties van de linter.

# 🧪 Tests
`Running on jenkins`