### PR TITLE
KAS-1209: Opmerking tonen in document overzicht

### DIFF
--- a/app/models/agendaitem.js
+++ b/app/models/agendaitem.js
@@ -35,6 +35,7 @@ export default ModelWithModifier.extend({
   formallyOk: attr('string'),
   isApproval: attr('boolean'),
   explanation: attr('string'),
+  // More information: https://github.com/kanselarij-vlaanderen/kaleidos-frontend/pull/469.
 
   agenda: belongsTo('agenda', {
     inverse: null,

--- a/app/pods/components/agenda/agendaitem/agendaitem-case/subcase-documents/template.hbs
+++ b/app/pods/components/agenda/agendaitem/agendaitem-case/subcase-documents/template.hbs
@@ -6,7 +6,7 @@
           {{t "documents"}}
         </h4>
         {{#if item.explanation}}
-          <pre data-test-agendaitem-explaination class="vl-u-text--muted vlc-u-flex-inline-flex vlc-u-pre-line-wrap">
+          <pre data-test-agendaitem-explanation class="vl-u-text--muted vlc-u-flex-inline-flex vlc-u-pre-line-wrap">
             {{t "remark-title"}}: {{await item.explanation}}
           </pre>
         {{/if}}

--- a/app/pods/components/agenda/agendaitem/agendaitem-case/subcase-documents/template.hbs
+++ b/app/pods/components/agenda/agendaitem/agendaitem-case/subcase-documents/template.hbs
@@ -1,9 +1,16 @@
 <div class="vl-u-spacer--large">
   <div class="vl-u-spacer">
     <div class="vl-u-display-flex vlc-u-display-flex-align-center">
-      <h4 class="vl-title vl-title--h4">
-        {{t "documents"}}
-      </h4>
+      <div>
+        <h4 class="vl-title vl-title--h4">
+          {{t "documents"}}
+        </h4>
+        {{#if item.explanation}}
+          <pre data-test-agendaitem-explaination class="vl-u-text--muted vlc-u-flex-inline-flex vlc-u-pre-line-wrap">
+            {{t "remark-title"}}: {{await item.explanation}}
+          </pre>
+        {{/if}}
+      </div>
       {{#if (and currentSession.isEditor (gt (await item.documentsLength) 0))}}
         <div class="vl-u-spacer-extended-left-s">
           <a data-test-subcase-documents-edit href="" class="vl-link" {{action "toggleIsEditing"}}>

--- a/cypress/integration/unit/agenda.spec.js
+++ b/cypress/integration/unit/agenda.spec.js
@@ -135,7 +135,7 @@ context('Agenda tests', () => {
     cy.get(agenda.agendaitemTitelsConfidential).should('exist')
       .should('be.visible');
     cy.get(agenda.agendaItemDocumentsTab).click();
-    cy.get(agenda.agendaitemExplaination).contains('Opmerking: Dit is de opmerking');
+    cy.get(agenda.agendaitemExplanation).contains('Opmerking: Dit is de opmerking');
   });
 
   it('It should be able to make a new agenda with a meetingID and another meeting will automatically get the next meetingID assigned in the UI', () => {

--- a/cypress/integration/unit/agenda.spec.js
+++ b/cypress/integration/unit/agenda.spec.js
@@ -122,14 +122,20 @@ context('Agenda tests', () => {
     cy.get(agenda.agendaitemTitlesEditTitle).clear();
     cy.get(agenda.agendaitemTitlesEditTitle).type('dit is de lange titel\n\n');
 
+    cy.get(agenda.agendaitemTitlesEditExplanation).clear();
+    cy.get(agenda.agendaitemTitlesEditExplanation).type('Dit is de opmerking');
+
     cy.get(agenda.agendaitemTitlesEditSave).should('exist')
       .should('be.visible')
       .click();
     cy.get(agenda.agendaitemTitlesEdit).scrollIntoView();
     cy.contains('dit is de korte titel');
     cy.contains('dit is de lange titel');
+    cy.contains('Dit is de opmerking');
     cy.get(agenda.agendaitemTitelsConfidential).should('exist')
       .should('be.visible');
+    cy.get(agenda.agendaItemDocumentsTab).click();
+    cy.get(agenda.agendaitemExplaination).contains('Opmerking: Dit is de opmerking');
   });
 
   it('It should be able to make a new agenda with a meetingID and another meeting will automatically get the next meetingID assigned in the UI', () => {

--- a/cypress/selectors/agenda.selectors.js
+++ b/cypress/selectors/agenda.selectors.js
@@ -73,5 +73,6 @@ const selectors = {
   agendaitemTitelsConfidential: '[data-test-agenda-subcase-confidential]',
   agendaHeaderShowAgendaOptions: '[data-test-agenda-header-showAgendaOptions]',
   agendaHeaderApproveAndCloseAgenda: '[data-test-agenda-header-approve-and-close-agenda]',
+  agendaitemExplaination: '[data-test-agendaitem-explaination]',
 };
 export default selectors;

--- a/cypress/selectors/agenda.selectors.js
+++ b/cypress/selectors/agenda.selectors.js
@@ -73,6 +73,6 @@ const selectors = {
   agendaitemTitelsConfidential: '[data-test-agenda-subcase-confidential]',
   agendaHeaderShowAgendaOptions: '[data-test-agenda-header-showAgendaOptions]',
   agendaHeaderApproveAndCloseAgenda: '[data-test-agenda-header-approve-and-close-agenda]',
-  agendaitemExplaination: '[data-test-agendaitem-explaination]',
+  agendaitemExplanation: '[data-test-agendaitem-explanation]',
 };
 export default selectors;


### PR DESCRIPTION
# 👓 KAS-1209: Opmerkingenveld tonen in doc overzicht

## 🔨 What has changed
- De opmerking wordt nu getoond in het overzicht voor documenten van een agendaitem.
- Er is een bestaande test aangepast die valideert of het veld er is.

## 🖼 Screenshots
Before:
![image](https://user-images.githubusercontent.com/11557630/89899853-28fdc400-dbe3-11ea-9bc0-104670334e1c.png)

After:
![image](https://user-images.githubusercontent.com/11557630/89899631-dde3b100-dbe2-11ea-9778-361a3c1fb8ba.png)


## 🧪 Tests:
`agenda.spec.js`