### PR TITLE
Refactor ids in config

### DIFF
--- a/app/models/agenda.js
+++ b/app/models/agenda.js
@@ -30,8 +30,8 @@ export default Model.extend(LoadableModel, {
     return this.get('status.isDesignAgenda');
   }),
 
-  isClosed: computed('status.isClosed', function() {
-    return this.get('status.isClosed');
+  isApproved: computed('status.isApproved', function() {
+    return this.get('status.isApproved');
   }),
 
   async asyncCheckIfDesignAgenda() {

--- a/app/models/agendastatus.js
+++ b/app/models/agendastatus.js
@@ -1,5 +1,6 @@
 import DS from 'ember-data';
 import { computed } from '@ember/object';
+import CONFIG from 'fe-redpencil/utils/config';
 
 const {
   Model, attr,
@@ -9,12 +10,12 @@ export default Model.extend({
   uri: attr('string'),
   label: attr('string'),
   isDesignAgenda: computed('uri', function() {
-    return this.uri === 'http://kanselarij.vo.data.gift/id/agendastatus/2735d084-63d1-499f-86f4-9b69eb33727f';
+    return this.uri === CONFIG.agendaStatusDesignAgenda.uri;
   }),
   isFinal: computed('uri', function() {
-    return this.uri === 'http://kanselarij.vo.data.gift/id/agendastatus/f06f2b9f-b3e5-4315-8892-501b00650101';
+    return this.uri === CONFIG.agendaStatusClosed.uri;
   }),
-  isClosed: computed('uri', function() {
-    return this.uri === 'http://kanselarij.vo.data.gift/id/agendastatus/ff0539e6-3e63-450b-a9b7-cc6463a0d3d1';
+  isApproved: computed('uri', function() {
+    return this.uri === CONFIG.agendaStatusApproved.uri;
   }),
 });

--- a/app/models/subcase.js
+++ b/app/models/subcase.js
@@ -174,7 +174,7 @@ export default ModelWithModifier.extend({
         },
         agenda: {
           status: {
-            id: '2735d084-63d1-499f-86f4-9b69eb33727f',
+            id: CONFIG.agendaStatusDesignAgenda.id,
           },
         },
       },

--- a/app/pods/components/access-level-pill/component.js
+++ b/app/pods/components/access-level-pill/component.js
@@ -5,6 +5,7 @@ import EmberObject, {
 
 import { inject as service } from '@ember/service';
 import DS from 'ember-data';
+import CONFIG from 'fe-redpencil/utils/config';
 
 export default class AccessLevelPill extends Component {
   confidential = false;
@@ -48,11 +49,11 @@ export default class AccessLevelPill extends Component {
   @computed('accessLevelId')
   get accessLevelClass() {
     switch (this.accessLevelId) {
-      case '6ca49d86-d40f-46c9-bde3-a322aa7e5c8e':
+      case CONFIG.publiekAccessLevelId:
         return 'vlc-pill--success';
-      case 'abe4c18d-13a9-45f0-8cdd-c493eabbbe29':
+      case CONFIG.internOverheidAccessLevelId:
         return 'vlc-pill--warning';
-      case 'd335f7e3-aefd-4f93-81a2-1629c2edafa3':
+      case CONFIG.internRegeringAccessLevelId:
         return 'vlc-pill--error';
       default:
         return '';

--- a/app/pods/components/agenda/agenda-header/component.js
+++ b/app/pods/components/agenda/agenda-header/component.js
@@ -99,7 +99,7 @@ export default Component.extend(FileSaverMixin, {
     await session.save();
     const definiteAgendas = await this.get('definiteAgendas');
     const lastDefiniteAgenda = await definiteAgendas.get('firstObject');
-    const approved = await this.store.findRecord('agendastatus', CONFIG.agendaStatusApprovedId);
+    const approved = await this.store.findRecord('agendastatus', CONFIG.agendaStatusApproved.id);
     lastDefiniteAgenda.set('status', approved);
     await lastDefiniteAgenda.save();
     this.get('agendaService')
@@ -167,7 +167,7 @@ export default Component.extend(FileSaverMixin, {
     meetingOfAgenda.set('agenda', lastAgenda);
     await meetingOfAgenda.save();
 
-    const closed = await this.store.findRecord('agendastatus', CONFIG.agendaStatusClosedId);
+    const closed = await this.store.findRecord('agendastatus', CONFIG.agendaStatusClosed.id);
     lastAgenda.set('status', closed);
     await lastAgenda.save();
     this.set('sessionService.currentSession.agendas', meetingOfAgenda.agendas);
@@ -296,7 +296,7 @@ export default Component.extend(FileSaverMixin, {
       session.set('agenda', lastAgenda);
 
       await session.save();
-      const closed = await this.store.findRecord('agendastatus', CONFIG.agendaStatusClosedId); // Async call
+      const closed = await this.store.findRecord('agendastatus', CONFIG.agendaStatusClosed.id); // Async call
       lastAgenda.set('status', closed);
       await lastAgenda.save();
 

--- a/app/pods/components/agenda/agenda-header/component.js
+++ b/app/pods/components/agenda/agenda-header/component.js
@@ -99,7 +99,7 @@ export default Component.extend(FileSaverMixin, {
     await session.save();
     const definiteAgendas = await this.get('definiteAgendas');
     const lastDefiniteAgenda = await definiteAgendas.get('firstObject');
-    const approved = await this.store.findRecord('agendastatus', 'ff0539e6-3e63-450b-a9b7-cc6463a0d3d1');
+    const approved = await this.store.findRecord('agendastatus', CONFIG.agendaStatusApprovedId);
     lastDefiniteAgenda.set('status', approved);
     await lastDefiniteAgenda.save();
     this.get('agendaService')
@@ -167,7 +167,7 @@ export default Component.extend(FileSaverMixin, {
     meetingOfAgenda.set('agenda', lastAgenda);
     await meetingOfAgenda.save();
 
-    const closed = await this.store.findRecord('agendastatus', 'f06f2b9f-b3e5-4315-8892-501b00650101');
+    const closed = await this.store.findRecord('agendastatus', CONFIG.agendaStatusClosedId);
     lastAgenda.set('status', closed);
     await lastAgenda.save();
     this.set('sessionService.currentSession.agendas', meetingOfAgenda.agendas);
@@ -296,7 +296,7 @@ export default Component.extend(FileSaverMixin, {
       session.set('agenda', lastAgenda);
 
       await session.save();
-      const closed = await this.store.findRecord('agendastatus', 'f06f2b9f-b3e5-4315-8892-501b00650101'); // Async call
+      const closed = await this.store.findRecord('agendastatus', CONFIG.agendaStatusClosedId); // Async call
       lastAgenda.set('status', closed);
       await lastAgenda.save();
 

--- a/app/pods/components/sessions/forms/new-session/component.js
+++ b/app/pods/components/sessions/forms/new-session/component.js
@@ -46,7 +46,7 @@ export default Component.extend({
   },
 
   async createAgenda(meeting, date) {
-    const status = await this.store.findRecord('agendastatus', CONFIG.agendaStatusDesignAgendaId);
+    const status = await this.store.findRecord('agendastatus', CONFIG.agendaStatusDesignAgenda.id);
     const fallBackDate = this.formatter.formatDate(null);
     const agenda = this.store.createRecord('agenda', {
       serialnumber: 'A',

--- a/app/pods/components/sessions/forms/new-session/component.js
+++ b/app/pods/components/sessions/forms/new-session/component.js
@@ -46,7 +46,7 @@ export default Component.extend({
   },
 
   async createAgenda(meeting, date) {
-    const status = await this.store.findRecord('agendastatus', '2735d084-63d1-499f-86f4-9b69eb33727f');
+    const status = await this.store.findRecord('agendastatus', CONFIG.agendaStatusDesignAgendaId);
     const fallBackDate = this.formatter.formatDate(null);
     const agenda = this.store.createRecord('agenda', {
       serialnumber: 'A',

--- a/app/pods/mock-login-route/controller.js
+++ b/app/pods/mock-login-route/controller.js
@@ -2,6 +2,7 @@ import Controller from '@ember/controller';
 import {
   task, timeout
 } from 'ember-concurrency';
+import CONFIG from 'fe-redpencil/utils/config';
 
 export default Controller.extend({
   queryParams: ['role', 'page'],
@@ -11,7 +12,7 @@ export default Controller.extend({
 
   queryStore: task(function *() {
     const filter = {
-      provider: 'https://github.com/kanselarij-vlaanderen/mock-login-service',
+      provider: CONFIG.mockLoginServiceProvider,
     };
     if (this.role) {
       filter.user = {

--- a/app/pods/mock-login-route/route.js
+++ b/app/pods/mock-login-route/route.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import CONFIG from 'fe-redpencil/utils/config';
 
 export default Route.extend({
   queryParams: {
@@ -22,7 +23,7 @@ export default Route.extend({
   },
   model(params) {
     const filter = {
-      provider: 'https://github.com/kanselarij-vlaanderen/mock-login-service',
+      provider: CONFIG.mockLoginServiceProvider,
     };
     if (params.role) {
       filter.user = {

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -123,9 +123,9 @@ export default Service.extend({
     // They are not used, but use them to describe who the id belongs to
     // Get these from https://kaleidos.vlaanderen.be, and then check the user id via the ember data tab
     const whitelist = {
-      frederik: 'fa59bba0-52e3-11ea-8bfc-e35431e140ef',
-      ben: '58177460-4e4a-11ea-a1d0-a99143fe0685',
-      rafael: 'cbdd9b60-3b97-11ea-a194-f970e0c7187e',
+      frederik: CONFIG.frederik,
+      ben: CONFIG.ben,
+      rafael: CONFIG.rafael,
     };
 
     const user = this.get('user');

--- a/app/utils/config.js
+++ b/app/utils/config.js
@@ -136,6 +136,6 @@ export default EmberObject.create({
   },
   agendaStatusApproved: {
     id: 'ff0539e6-3e63-450b-a9b7-cc6463a0d3d1',
-    uri: 'http://kanselarij.vo.data.gift/id/agendastatus/2735d084-63d1-499f-86f4-9b69eb33727f',
+    uri: 'http://kanselarij.vo.data.gift/id/agendastatus/ff0539e6-3e63-450b-a9b7-cc6463a0d3d1',
   },
 });

--- a/app/utils/config.js
+++ b/app/utils/config.js
@@ -120,4 +120,6 @@ export default EmberObject.create({
   internRegeringAccessLevelId: 'd335f7e3-aefd-4f93-81a2-1629c2edafa3',
   internOverheidAccessLevelId: 'abe4c18d-13a9-45f0-8cdd-c493eabbbe29',
   publiekAccessLevelId: '6ca49d86-d40f-46c9-bde3-a322aa7e5c8e',
+  agendaStatusApprovedId: 'ff0539e6-3e63-450b-a9b7-cc6463a0d3d1',
+  agendaStatusClosedId: 'f06f2b9f-b3e5-4315-8892-501b00650101',
 });

--- a/app/utils/config.js
+++ b/app/utils/config.js
@@ -123,4 +123,5 @@ export default EmberObject.create({
   agendaStatusApprovedId: 'ff0539e6-3e63-450b-a9b7-cc6463a0d3d1',
   agendaStatusClosedId: 'f06f2b9f-b3e5-4315-8892-501b00650101',
   agendaStatusDesignAgendaId: '2735d084-63d1-499f-86f4-9b69eb33727f',
+  mockLoginServiceProvider: 'https://github.com/kanselarij-vlaanderen/mock-login-service',
 });

--- a/app/utils/config.js
+++ b/app/utils/config.js
@@ -118,4 +118,6 @@ export default EmberObject.create({
   kabinetId: '7e8c0c9c-05ec-49fd-9e96-fc54ebf3f9eb',
   usersId: '450915b2-4c64-4b03-9caa-71180400f831',
   internRegeringAccessLevelId: 'd335f7e3-aefd-4f93-81a2-1629c2edafa3',
+  internOverheidAccessLevelId: 'abe4c18d-13a9-45f0-8cdd-c493eabbbe29',
+  publiekAccessLevelId: '6ca49d86-d40f-46c9-bde3-a322aa7e5c8e',
 });

--- a/app/utils/config.js
+++ b/app/utils/config.js
@@ -122,4 +122,5 @@ export default EmberObject.create({
   publiekAccessLevelId: '6ca49d86-d40f-46c9-bde3-a322aa7e5c8e',
   agendaStatusApprovedId: 'ff0539e6-3e63-450b-a9b7-cc6463a0d3d1',
   agendaStatusClosedId: 'f06f2b9f-b3e5-4315-8892-501b00650101',
+  agendaStatusDesignAgendaId: '2735d084-63d1-499f-86f4-9b69eb33727f',
 });

--- a/app/utils/config.js
+++ b/app/utils/config.js
@@ -120,8 +120,22 @@ export default EmberObject.create({
   internRegeringAccessLevelId: 'd335f7e3-aefd-4f93-81a2-1629c2edafa3',
   internOverheidAccessLevelId: 'abe4c18d-13a9-45f0-8cdd-c493eabbbe29',
   publiekAccessLevelId: '6ca49d86-d40f-46c9-bde3-a322aa7e5c8e',
-  agendaStatusApprovedId: 'ff0539e6-3e63-450b-a9b7-cc6463a0d3d1',
-  agendaStatusClosedId: 'f06f2b9f-b3e5-4315-8892-501b00650101',
-  agendaStatusDesignAgendaId: '2735d084-63d1-499f-86f4-9b69eb33727f',
   mockLoginServiceProvider: 'https://github.com/kanselarij-vlaanderen/mock-login-service',
+  developerWhitelistIds: {
+    frederik: 'fa59bba0-52e3-11ea-8bfc-e35431e140ef',
+    ben: '58177460-4e4a-11ea-a1d0-a99143fe0685',
+    rafael: 'cbdd9b60-3b97-11ea-a194-f970e0c7187e',
+  },
+  agendaStatusDesignAgenda: {
+    id: '2735d084-63d1-499f-86f4-9b69eb33727f',
+    uri: 'http://kanselarij.vo.data.gift/id/agendastatus/2735d084-63d1-499f-86f4-9b69eb33727f',
+  },
+  agendaStatusClosed: {
+    id: 'f06f2b9f-b3e5-4315-8892-501b00650101',
+    uri: 'http://kanselarij.vo.data.gift/id/agendastatus/f06f2b9f-b3e5-4315-8892-501b00650101',
+  },
+  agendaStatusApproved: {
+    id: 'ff0539e6-3e63-450b-a9b7-cc6463a0d3d1',
+    uri: 'http://kanselarij.vo.data.gift/id/agendastatus/2735d084-63d1-499f-86f4-9b69eb33727f',
+  },
 });


### PR DESCRIPTION
# 🧹🧹  Refactor ids in config
In deze PR hebben we de applicatie overlopen waar ID's hardcoded in staan. Deze hebben we herwerkt in de configfile.

## ✏️ What has been done
De rewrites kwamen voor in onderstaande files en zijn gedefineerd in `app/utils/config.js`
- `app/pods/components/access-level-pill/component.js`
- `app/pods/components/agenda/agenda-header/component.js`
- `app/pods/components/sessions/forms/new-session/component.js`
- `app/pods/mock-login-route/controller.js`

## 🧪 Tests:
`Dit zou niks mogen breken in de applicatie, de huidige testen dienen dus gewoon te slagen.`