### PR TITLE
feature/KAS-1741 reset formally ok also for new documents

### DIFF
--- a/app/pods/components/agenda/agendaitem/agendaitem-case/subcase-documents/component.js
+++ b/app/pods/components/agenda/agendaitem/agendaitem-case/subcase-documents/component.js
@@ -148,14 +148,14 @@ export default Component.extend(
       return await subcase.save();
     },
 
-    async addDocumentToAnyModel(documents, item) {
-      const itemType = item.get('constructor.modelName');
-      await item.hasMany('documentVersions').reload();
-      await this.attachDocumentsToModel(documents, item);
+    async addDocumentToAgendaitemOrSubcaseOrMeeting(documents, agendaitemOrSubcaseOrMeeting) {
+      const itemType = agendaitemOrSubcaseOrMeeting.get('constructor.modelName');
+      await agendaitemOrSubcaseOrMeeting.hasMany('documentVersions').reload();
+      await this.attachDocumentsToModel(documents, agendaitemOrSubcaseOrMeeting);
       if (itemType === 'subcase' || itemType === 'agendaitem') {
-        setNotYetFormallyOk(item);
+        setNotYetFormallyOk(agendaitemOrSubcaseOrMeeting);
       }
-      return await item.save();
+      return await agendaitemOrSubcaseOrMeeting.save();
     },
 
     async linkDocumentsToAgendaitems(documents, agendaitems) {
@@ -283,7 +283,7 @@ export default Component.extend(
                 agendaitemsOnDesignAgenda
               );
             }
-            await this.addDocumentToAnyModel(documentsToAttach, item);
+            await this.addDocumentToAgendaitemOrSubcaseOrMeeting(documentsToAttach, item);
           }
         } catch (error) {
           this.deleteAll();

--- a/cypress/integration/unit/agendaitem-changes.spec.js
+++ b/cypress/integration/unit/agendaitem-changes.spec.js
@@ -20,6 +20,7 @@ context('Agendaitem changes tests', () => {
   it('should add a document to an agenda and should highlight as added', () => {
     cy.visit('/vergadering/5EBA48CF95A2760008000006/agenda/f66c6d79-6ad2-49e2-af55-702df3a936d8/agendapunten');
     cy.addDocumentsToAgendaItem(subcaseTitle1, files);
+    cy.setFormalOkOnItemWithIndex(1);
     cy.changeSelectedAgenda('Ontwerpagenda');
     cy.toggleShowChanges(true);
     cy.agendaItemExists(subcaseTitle1);

--- a/cypress/integration/unit/document-version.spec.js
+++ b/cypress/integration/unit/document-version.spec.js
@@ -211,13 +211,13 @@ context('Tests for KAS-1076', () => {
     });
   });
 
-  it('Adding new document-version to agendaitem on designagenda should reset formally ok and update the subcase', () => {
-    const caseTitle = 'Cypress test: document versions - 1589286212';
+  it('Adding new document or document-version to agendaitem on designagenda should reset formally ok and update the subcase', () => {
     const SubcaseTitleShort = 'Cypress test: new document version on agendaitem - 1589286212';
     const file = {
       folder: 'files', fileName: 'test', fileExtension: 'pdf', newFileName: 'test pdf', fileType: 'Nota',
     };
 
+    // PART 1, adding new version
     cy.visit('/vergadering/5EBA9588751CF70008000012/agenda/5EBA9589751CF70008000013/agendapunten/5EBA95A2751CF70008000016');
     cy.addNewDocumentVersionToAgendaItem(SubcaseTitleShort, file.newFileName, file);
 
@@ -234,24 +234,47 @@ context('Tests for KAS-1076', () => {
       .should('have.length', 1);
 
     // Verify subcase is updated
-    cy.openCase(caseTitle);
-    cy.openSubcase(0);
-    cy.clickReverseTab('Documenten');
-    // cy.wait(1000);
+    cy.visit('/dossiers/5EBA9548751CF7000800000D/deeldossiers/5EBA9556751CF7000800000F/documenten');
     cy.get('.vlc-scroll-wrapper__body').within(() => {
       cy.get('.vlc-document-card').eq(0)
         .within(() => {
           cy.get('.vl-title--h6 > span').contains(`${file.newFileName}BIS`);
         });
     });
+
+    // PART 2, adding new document, separate test ?
+    cy.visit('/vergadering/5EBA9588751CF70008000012/agenda/5EBA9589751CF70008000013/agendapunten/5EBA95A2751CF70008000016');
+    cy.setFormalOkOnItemWithIndex(1);
+    cy.get('.vlc-agenda-items__status').contains('Nog niet formeel OK')
+      .should('have.length', 0);
+    cy.addDocumentsToAgendaItem(SubcaseTitleShort, [file]);
+    // Verify agendaitem is updated
+    cy.get('.vlc-scroll-wrapper__body').within(() => {
+      cy.get('.vlc-document-card').eq(0)
+        .within(() => {
+          cy.get('.vl-title--h6 > span').contains(`${file.newFileName}`);
+        });
+    });
+    // Verify formally ok is reset
+    cy.get('.vlc-agenda-items__status').contains('Nog niet formeel OK')
+      .should('have.length', 1);
+    // Verify subcase is updated
+    cy.visit('/dossiers/5EBA9548751CF7000800000D/deeldossiers/5EBA9556751CF7000800000F/documenten');
+    cy.get('.vlc-scroll-wrapper__body').within(() => {
+      cy.get('.vlc-document-card').eq(0)
+        .within(() => {
+          cy.get('.vl-title--h6 > span').contains(`${file.newFileName}`);
+        });
+    });
   });
 
-  it('Adding new document-version to subcase should reset formally ok and update the agendaitem on designagendas', () => {
+  it('Adding new document or document-version to subcase should reset formally ok and update the agendaitem on designagendas', () => {
     const SubcaseTitleShort = 'Cypress test: new document version on procedurestap - 1589286338';
     const file = {
       folder: 'files', fileName: 'test', fileExtension: 'pdf', newFileName: 'test pdf', fileType: 'Nota',
     };
 
+    // PART 1, adding new version
     cy.visit('/dossiers/5EBA95CA751CF70008000018/deeldossiers/5EBA95E1751CF7000800001A/documenten');
     cy.addNewDocumentVersionToSubcase('test pdf', {
       folder: 'files', fileName: 'test', fileExtension: 'pdf',
@@ -270,6 +293,32 @@ context('Tests for KAS-1076', () => {
       cy.get('.vlc-document-card').eq(0)
         .within(() => {
           cy.get('.vl-title--h6 > span').contains(`${file.newFileName}BIS`);
+        });
+    });
+    cy.get('.vlc-agenda-items__status').contains('Nog niet formeel OK')
+      .should('have.length', 1);
+
+
+    // PART 2, adding new document
+    cy.setFormalOkOnItemWithIndex(1);
+    cy.get('.vlc-agenda-items__status').contains('Nog niet formeel OK')
+      .should('have.length', 0);
+    cy.visit('/dossiers/5EBA95CA751CF70008000018/deeldossiers/5EBA95E1751CF7000800001A/documenten');
+    cy.addDocuments([file]);
+    cy.get('.vlc-scroll-wrapper__body').within(() => {
+      cy.get('.vlc-document-card').eq(0)
+        .within(() => {
+          cy.get('.vl-title--h6 > span').contains(`${file.newFileName}`);
+        });
+    });
+
+    cy.visit('/vergadering/5EBA960A751CF7000800001D/agenda/5EBA960B751CF7000800001E/agendapunten');
+    cy.agendaItemExists(SubcaseTitleShort).click();
+    cy.openAgendaItemDocumentTab(SubcaseTitleShort, true);
+    cy.get('.vlc-scroll-wrapper__body').within(() => {
+      cy.get('.vlc-document-card').eq(0)
+        .within(() => {
+          cy.get('.vl-title--h6 > span').contains(`${file.newFileName}`);
         });
     });
     cy.get('.vlc-agenda-items__status').contains('Nog niet formeel OK')

--- a/cypress/support/commands/document-commands.js
+++ b/cypress/support/commands/document-commands.js
@@ -236,7 +236,10 @@ function openAgendaItemDocumentTab(agendaItemTitle, alreadyHasDocs = false) {
 function addDocumentsToAgendaItem(agendaItemTitle, files) {
   cy.log('addDocumentsToAgendaItem');
   openAgendaItemDocumentTab(agendaItemTitle, false);
-  return addDocuments(files);
+  addDocuments(files); // patch to subcase happens here (1 patchModel is checked)
+  cy.wait('@patchModel', { // patch to agendaitems also happens, patch route is defined in addDocuments
+    timeout: 12000 + (6000 * files.length),
+  });
 }
 
 /**


### PR DESCRIPTION
### KAS-1741 is a bug ticket, but the fix for it is technically a new feature.

The issue was that "formally ok" is not consistently reset when adding documents to agendaitems on designagenda or subcases with agendaitems on a designagenda.
It was implemented to trigger when adding new document-versions (BIS, TER)
It was NOT implemented to trigger when adding new documents (1st version of the doc)

For this case in particular, I remember a conversation with Kenny about this:
https://kanselarij.atlassian.net/browse/KAS-1076?focusedCommentId=11075

In that ticket, I fixed the implementation for new versions.
And a new feature ticket was made that would add said implementation to adding new documents.
This ticket https://kanselarij.atlassian.net/browse/KAS-1124 got pushed to the backlog, and can (finally) be resolved with this issue.

### What has changed:
`subcase-documents`

Added the resetting of formallyOk by using an existing util.

`document-version.spec.js`

Added extra steps to an existing test to verify the implementation.


