### PR TITLE
KAS-1739: All-in-1 Formeel ok

### DIFF
--- a/app/pods/components/agenda/agenda-header/component.js
+++ b/app/pods/components/agenda/agenda-header/component.js
@@ -64,7 +64,7 @@ export default Component.extend(FileSaverMixin, {
     return true;
   }),
 
-  amountOfAgendaitemsNotFormallyOk: computed('isApprovingAllAgendaitems', async function() {
+  amountOfAgendaitemsNotFormallyOk: computed('currentAgendaItems.@each.formallyOk', async function() {
     const isNotFormallyOk = (agendaitem) => agendaitem.formallyOk !== CONFIG.formallyOk;
     const agendaitems = await this.currentAgenda.get('agendaitems');
     return agendaitems.filter(isNotFormallyOk).length;

--- a/app/pods/components/agenda/agenda-header/component.js
+++ b/app/pods/components/agenda/agenda-header/component.js
@@ -64,7 +64,7 @@ export default Component.extend(FileSaverMixin, {
     return true;
   }),
 
-  amountOfAgendaitemsNotFormallyOk: computed('currentAgenda', async function() {
+  amountOfAgendaitemsNotFormallyOk: computed('isApprovingAllAgendaitems', async function() {
     const isNotFormallyOk = (agendaitem) => agendaitem.formallyOk !== CONFIG.formallyOk;
     const agendaitems = await this.currentAgenda.get('agendaitems');
     return agendaitems.filter(isNotFormallyOk).length;

--- a/app/pods/components/agenda/agenda-header/template.hbs
+++ b/app/pods/components/agenda/agenda-header/template.hbs
@@ -397,9 +397,9 @@
 
 {{#if isApprovingAllAgendaitems}}
   <WebComponents::VlModalVerify
-    @title={{t "agenda-release-decisions"}}
+    @title={{t "approve-all-agendaitems"}}
     @buttonType="warning"
-    @verifyButtonText={{t "approve-all-agendaitems"}}
+    @verifyButtonText={{t "approve"}}
     @message={{t
       "approve-all-agendaitems-warning-message"
       amountOfAgendaitemsNotFormallyOk=(await amountOfAgendaitemsNotFormallyOk)

--- a/app/pods/components/agenda/agenda-header/template.hbs
+++ b/app/pods/components/agenda/agenda-header/template.hbs
@@ -224,6 +224,18 @@
                     {{t "download-documents"}}
                   </a>
                 </li>
+                {{#if currentAgenda.isDesignAgenda}}
+                  <li class="vlc-dropdown-menu__item">
+                    <a href=""
+                       data-test-agenda-header-approve-all-agendaitems
+                       class="vl-link vl-link--block"
+                      {{action attacher.hide}}
+                      {{action "showApproveAllAgendaitemsWarning"}}
+                    >
+                      {{t "approve-all-agendaitems"}}
+                    </a>
+                  </li>
+                {{/if}}
                 {{#if currentSessionService.isEditor}}
                   <li class="vlc-dropdown-menu__separator" aria-hidden="true"></li>
                   <li class="vlc-dropdown-menu__item">
@@ -381,4 +393,18 @@
     @title={{loaderTitle}} >
     <WebComponents::VlLoader @text={{loaderText}} />
   </WebComponents::VlModal>
+{{/if}}
+
+{{#if isApprovingAllAgendaitems}}
+  <WebComponents::VlModalVerify
+    @title={{t "agenda-release-decisions"}}
+    @buttonType="warning"
+    @verifyButtonText={{t "approve-all-agendaitems"}}
+    @message={{t
+      "approve-all-agendaitems-warning-message"
+      amountOfAgendaitemsNotFormallyOk=(await amountOfAgendaitemsNotFormallyOk)
+    }}
+    @cancel={{action "cancel"}}
+    @verify={{action "approveAllAgendaitems"}}
+  />
 {{/if}}

--- a/app/utils/agenda-item-utils.js
+++ b/app/utils/agenda-item-utils.js
@@ -25,14 +25,33 @@ export const cancelEdit = (item, propertiesToSet) => {
 };
 
 /**
- * Set an item to not yet formally ok.
- *
+ * @description Set an item to not yet formally ok.
  * @param itemToSet
  */
 export const setNotYetFormallyOk = (itemToSet) => {
   if (itemToSet.get('formallyOk') !== CONFIG.notYetFormallyOk) {
     itemToSet.set('formallyOk', CONFIG.notYetFormallyOk);
   }
+};
+
+/**
+ *@description Zet een agendapunt naar formeel Ok.
+ * @param agendaitem
+ */
+export const setAgendaitemFormallyOk = (agendaitem) => {
+  if (agendaitem.get('formallyOk') !== CONFIG.formallyOk) {
+    agendaitem.set('formallyOk', CONFIG.formallyOk);
+    agendaitem.save();
+  }
+};
+
+/**
+ *@description Return een lijst met agendaitems die nog niet formeel ok zijn.
+ * @param agendaitems
+ */
+export const getListOfAgendaitemsThatAreNotFormallyOk = (agendaitems) => {
+  const agendaitemNotFormallyOk = (agendaitem) => agendaitem.get('formallyOk') !== CONFIG.formallyOk;
+  return agendaitems.filter(agendaitemNotFormallyOk);
 };
 
 /**

--- a/app/utils/agenda-item-utils.js
+++ b/app/utils/agenda-item-utils.js
@@ -39,10 +39,10 @@ export const setNotYetFormallyOk = (itemToSet) => {
  *@description Zet een agendapunt naar formeel Ok.
  * @param agendaitem
  */
-export const setAgendaitemFormallyOk = (agendaitem) => {
+export const setAgendaitemFormallyOk = async(agendaitem) => {
   if (agendaitem.get('formallyOk') !== CONFIG.formallyOk) {
     agendaitem.set('formallyOk', CONFIG.formallyOk);
-    agendaitem.save();
+    await agendaitem.save();
   }
 };
 

--- a/app/utils/agenda-item-utils.js
+++ b/app/utils/agenda-item-utils.js
@@ -35,6 +35,7 @@ export const setNotYetFormallyOk = (itemToSet) => {
 };
 
 /**
+ *@name setAgendaitemFormallyOk
  *@description Zet een agendapunt naar formeel Ok.
  * @param agendaitem
  */

--- a/cypress/integration/unit/agenda.spec.js
+++ b/cypress/integration/unit/agenda.spec.js
@@ -167,4 +167,13 @@ context('Agenda tests', () => {
       cy.get('input[type="number"]').should('have.value', (parseInt(result.meetingNumber, 10) + 1).toString());
     });
   });
+
+  it('should add an agendaitem to an agenda', () => {
+    cy.openAgendaForDate(agendaDate);
+    cy.addAgendaitemToAgenda(false);
+    cy.addAgendaitemToAgenda(false);
+    cy.addAgendaitemToAgenda(false);
+    // 4 formeel ok's omdat er 1 nota is en 3 agendaitems
+    cy.setAllItemsFormallyOk(4);
+  });
 });

--- a/cypress/integration/unit/agenda.spec.js
+++ b/cypress/integration/unit/agenda.spec.js
@@ -168,12 +168,15 @@ context('Agenda tests', () => {
     });
   });
 
-  it('should add an agendaitem to an agenda', () => {
-    cy.openAgendaForDate(agendaDate);
-    cy.addAgendaitemToAgenda(false);
-    cy.addAgendaitemToAgenda(false);
-    cy.addAgendaitemToAgenda(false);
-    // 4 formeel ok's omdat er 1 nota is en 3 agendaitems
-    cy.setAllItemsFormallyOk(4);
+  it('Should add agendaitems to an agenda and set all of them to formally OK', () => {
+    const agendaDateSingleTest = Cypress.moment().add(2, 'weeks')
+      .day(5); // Friday in two weeks
+    cy.createAgenda('Elektronische procedure', agendaDateSingleTest, 'Zaal oxford bij Cronos Leuven').then((result) => {
+      cy.visit(`/vergadering/${result.meetingId}/agenda/${result.agendaId}/agendapunten`);
+      cy.addAgendaitemToAgenda(false);
+      cy.addAgendaitemToAgenda(false);
+      // 4 formeel ok's omdat er 1 nota is en 3 agendaitems
+      cy.setAllItemsFormallyOk(3);
+    });
   });
 });

--- a/cypress/integration/unit/agenda.spec.js
+++ b/cypress/integration/unit/agenda.spec.js
@@ -169,13 +169,34 @@ context('Agenda tests', () => {
   });
 
   it('Should add agendaitems to an agenda and set all of them to formally OK', () => {
-    const agendaDateSingleTest = Cypress.moment().add(2, 'weeks')
-      .day(5); // Friday in two weeks
-    cy.createAgenda('Elektronische procedure', agendaDateSingleTest, 'Zaal oxford bij Cronos Leuven').then((result) => {
+    const testId = `testId=${currentTimestamp()}: `;
+    const dateToCreateAgenda = Cypress.moment().add(3, 'weeks');
+
+    const case1TitleShort = `${testId}Cypress test dossier 1`;
+    const type1 = 'Nota';
+    const newSubcase1TitleShort = 'dit is de korte titel\n\n';
+    const subcase1TitleLong = 'dit is de lange titel\n\n';
+    const subcase1Type = 'In voorbereiding';
+    const subcase1Name = 'Principiële goedkeuring m.h.o. op adviesaanvraag';
+
+    const case2TitleShort = `${testId}Cypress test dossier 2`;
+    const type2 = 'Nota';
+    const newSubcase2TitleShort = `${testId} korte titel`;
+    const subcase2TitleLong = `${testId} lange titel`;
+    const subcase2Type = 'In voorbereiding';
+    const subcase2Name = 'Principiële goedkeuring m.h.o. op adviesaanvraag';
+
+    cy.createAgenda('Elektronische procedure', dateToCreateAgenda, 'Zaal oxford bij Cronos Leuven').then((result) => {
+      cy.createCase(false, case1TitleShort);
+      cy.addSubcase(type1, newSubcase1TitleShort, subcase1TitleLong, subcase1Type, subcase1Name);
+      cy.openSubcase(0);
+      cy.proposeSubcaseForAgenda(dateToCreateAgenda);
+
+      cy.createCase(false, case2TitleShort);
+      cy.addSubcase(type2, newSubcase2TitleShort, subcase2TitleLong, subcase2Type, subcase2Name);
+      cy.openSubcase(0);
+      cy.proposeSubcaseForAgenda(dateToCreateAgenda);
       cy.visit(`/vergadering/${result.meetingId}/agenda/${result.agendaId}/agendapunten`);
-      cy.addAgendaitemToAgenda(false);
-      cy.addAgendaitemToAgenda(false);
-      // 4 formeel ok's omdat er 1 nota is en 3 agendaitems
       cy.setAllItemsFormallyOk(3);
     });
   });

--- a/cypress/selectors/action-modal.selectors.js
+++ b/cypress/selectors/action-modal.selectors.js
@@ -13,5 +13,6 @@ const selectors = {
   unlockAgenda: '[data-test-agenda-header-unlockAgenda]',
   releaseDecisions: '[data-test-agenda-header-releaseDecisions]',
   releaseDocuments: '[data-test-agenda-header-releaseDocuments]',
+  approveAllAgendaitems: '[data-test-agenda-header-approve-all-agendaitems]',
 };
 export default selectors;

--- a/cypress/support/commands/agenda-commands.js
+++ b/cypress/support/commands/agenda-commands.js
@@ -371,6 +371,25 @@ function setFormalOkOnItemWithIndex(indexOfItem, fromWithinAgendaOverview = fals
 }
 
 /**
+ * @description Set all agendaitems to formallyOk
+ * @name setAllItemsFormallyOk
+ * @memberOf Cypress.Chainable#
+ * @function
+ */
+function setAllItemsFormallyOk(amountOfFormallyOks) {
+  cy.route('GET', '/agendaitems/*/modified-by').as('getModifiedByOfAgendaitems');
+  // TODO set only some items to formally ok with list as parameter
+  cy.get(actionModel.showActionOptions).click();
+  cy.route('PATCH', '/agendaitems/**').as('patchAgendaitems');
+  cy.get(actionModel.approveAllAgendaitems).click();
+  cy.contains(`Bent u zeker dat u ${amountOfFormallyOks} agenda items formeel wil goedkeuren`);
+  cy.get(modal.verify.save).click();
+  cy.wait('@patchAgendaitems');
+  cy.wait('@getModifiedByOfAgendaitems');
+}
+
+
+/**
  * @description Check all approval checkboxes of an agendaitem
  * @name approveCoAgendaitem
  * @memberOf Cypress.Chainable#
@@ -775,3 +794,4 @@ Cypress.Commands.add('openAgendaItemKortBestekTab', openAgendaItemKortBestekTab)
 Cypress.Commands.add('clickAgendaitemTab', clickAgendaitemTab);
 Cypress.Commands.add('createAgendaOnDate', createAgendaOnDate);
 Cypress.Commands.add('approveAndCloseDesignAgenda', approveAndCloseDesignAgenda);
+Cypress.Commands.add('setAllItemsFormallyOk', setAllItemsFormallyOk);

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -595,5 +595,7 @@
   "public-since": "Publiek gemaakt op",
   "approve-small-and-close": "goedkeuren en afsluiten",
   "agendaApproveActions": "Agenda goedkeuren",
-  "meeting-number-visual-representation": "Nummer van de vergadering"
+  "meeting-number-visual-representation": "Nummer van de vergadering",
+  "approve-all-agendaitems": "Alles formeel goedkeuren",
+  "approve-all-agendaitems-warning-message": "Bent u zeker dat u {amountOfAgendaitemsNotFormallyOk} agenda items formeel wil goedkeuren"
 }


### PR DESCRIPTION
# ✅ KAS-1739: All-in-1 Formeel ok
In deze PR hebben we een feature voorzien die een all-in-1 functionaliteit voorziet om alle agendaitems in 1 x formeel ok te maken.

## 🖼 Screenshot:
**Menu actie om alle agendaitems goed te keuren**
![image](https://user-images.githubusercontent.com/11557630/91056482-5193ae00-e626-11ea-885b-7b7a6ab24304.png)

**Popup die aangeeft hoeveel agendaitems je gaat goedkeuren**
![image](https://user-images.githubusercontent.com/11557630/91056761-a505fc00-e626-11ea-9c7c-efe4df5e49d3.png)

## 🧪 Tests:
`agenda.spec.js`