### PR TITLE
KAS-1422/KAS-1809 remove formallyOk from subcase

### DIFF
--- a/app/models/subcase.js
+++ b/app/models/subcase.js
@@ -25,7 +25,6 @@ export default ModelWithModifier.extend({
   subcaseIdentifier: attr('string'),
   showAsRemark: attr('boolean'),
   confidential: attr('boolean'),
-  formallyOk: attr('boolean'),
   isArchived: attr('boolean'),
   concluded: attr('boolean'),
   subcaseName: attr('string'),

--- a/app/pods/components/agenda/agendaitem/agendaitem-case/subcase-document/document-link/component.js
+++ b/app/pods/components/agenda/agendaitem/agendaitem-case/subcase-document/document-link/component.js
@@ -190,7 +190,6 @@ export default Component.extend({
   async addDocumentToSubcase(documents, subcase) {
     await subcase.hasMany('documentVersions').reload();
     await this.attachDocumentsToModel(documents, subcase);
-    setNotYetFormallyOk(subcase);
     return await subcase.save();
   },
 

--- a/app/pods/components/agenda/agendaitem/agendaitem-case/subcase-documents/component.js
+++ b/app/pods/components/agenda/agendaitem/agendaitem-case/subcase-documents/component.js
@@ -144,7 +144,6 @@ export default Component.extend(
 
     async addDocumentsToSubcase(documents, subcase) {
       await this.attachDocumentsToModel(documents, subcase);
-      setNotYetFormallyOk(subcase);
       return await subcase.save();
     },
 

--- a/app/pods/components/cases/new-subcase/component.js
+++ b/app/pods/components/cases/new-subcase/component.js
@@ -102,7 +102,6 @@ export default Component.extend({
       created: newDate,
       modified: newDate,
       isArchived: false,
-      formallyOk: false,
       agendaActivities: [],
     });
   },

--- a/app/utils/agenda-item-utils.js
+++ b/app/utils/agenda-item-utils.js
@@ -84,7 +84,7 @@ export const setModifiedOnAgendaOfAgendaitem = async(agendaitem) => {
  * @param agendaitemOrSubcase
  * @param propertiesToSetOnAgendaitem
  * @param propertiesToSetOnSubcase
- * @param resetFormallyOk
+ * @param resetFormallyOk  // only used for agendaitem after refactor KAS-1422
  * @returns {Promise<void>}
  */
 export const saveChanges = async(agendaitemOrSubcase, propertiesToSetOnAgendaitem, propertiesToSetOnSubcase, resetFormallyOk) => {
@@ -100,12 +100,12 @@ export const saveChanges = async(agendaitemOrSubcase, propertiesToSetOnAgendaite
     if (isDesignAgenda && agendaActivity) {
       const agendaitemSubcase = await agendaActivity.get('subcase');
       await agendaitemSubcase.preEditOrSaveCheck();
-      await setNewPropertiesToModel(agendaitemSubcase, propertiesToSetOnSubcase, resetFormallyOk);
+      await setNewPropertiesToModel(agendaitemSubcase, propertiesToSetOnSubcase, false);
     }
     await setNewPropertiesToModel(item, propertiesToSetOnAgendaitem, resetFormallyOk);
     await setModifiedOnAgendaOfAgendaitem(item);
   } else {
-    await setNewPropertiesToModel(item, propertiesToSetOnSubcase, resetFormallyOk);
+    await setNewPropertiesToModel(item, propertiesToSetOnSubcase, false);
 
     const agendaitemsOnDesignAgendaToEdit = await item.get('agendaitemsOnDesignAgendaToEdit');
     if (agendaitemsOnDesignAgendaToEdit && agendaitemsOnDesignAgendaToEdit.get('length') > 0) {


### PR DESCRIPTION
KAS-1422 
Reduce duplicate data in models agendaitem and subcase

subtask KAS-1809:
remove formallyOk from subcase model
reasoning: FormallyOk status on subcase is no longer relevant, not shown or adjustable in frontend. 

### What has changed:

subcase.js:
- remove attribute from model

/components/agenda/agendaitem/agendaitem-case/subcase-document/document-link/component.js:
- don't set formallyOk on subcase

/components/agenda/agendaitem/agendaitem-case/subcase-documents/component.js:
- don't set formallyOk on subcase

/components/cases/new-subcase/component.js:
- don't set formallyOk when creating a new subcase

utils/agenda-item-utils.js:
- don't set formallyOk on subcase

### See linked PR
https://github.com/kanselarij-vlaanderen/kaleidos-project/pull/102
