### PR TITLE
KAS-1818: Fix bullets on document items

### DIFF
--- a/app/styles/custom-components/_vlc-document-list.scss
+++ b/app/styles/custom-components/_vlc-document-list.scss
@@ -9,6 +9,7 @@
 }
 
 .vlc-document-list__item {
+  list-style: none;
   margin: 0.4rem 1rem 0.4rem 0;
 
   a, span {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1874332/91432842-9e63c880-e862-11ea-87c4-5026d68c4cb2.png)

![image](https://user-images.githubusercontent.com/1874332/91432890-afacd500-e862-11ea-8c75-f24267969d8b.png)

# 🐞  Bugfix: Fix bullets on the document items
It only required one CSS rule to enforce to have no list style on the document items.