### PR TITLE
KAS-1420: Fetch newsletter rich text from correct property path

### DIFF
--- a/app/pods/components/news-item/edit-item/component.js
+++ b/app/pods/components/news-item/edit-item/component.js
@@ -88,7 +88,8 @@ export default Component.extend({
       window.open(`/document/${documentVersion.get('id')}`);
     },
     async handleRdfaEditorInit(editorInterface) {
-      const newsLetterInfoText = await this.get('agendaitem.agendaActivity.subcase.newsletterInfo.richtext');
+      const newsletterInfo = await this.get('newsletterInfo');
+      const newsLetterInfoText = newsletterInfo.get('richtext');
       editorInterface.setHtmlContent(newsLetterInfoText);
       this.set('editor', editorInterface);
     },


### PR DESCRIPTION
Fixes a bug caused in KAS-1420 by not adapting the property path to new component arguments. This made that already-existing text didn't get loaded in the editor properly.