### PR TITLE
KAS-1857: weergeven tooltip voor niet in kort bestek

### DIFF
--- a/app/pods/components/agenda/agenda-detail/sidebar-item/template.hbs
+++ b/app/pods/components/agenda/agenda-detail/sidebar-item/template.hbs
@@ -55,13 +55,25 @@
               {{/if}}
 
               {{#if (not newsletterInfo.inNewsletter)}}
-                <i class="ki-hide vlc-agenda-detail-sidebar-item__icon--margin-right vlc-u-opacity-50"></i>
+                <span class="added-tag vlc-agenda-meta__recently-added">
+                  <i class="ki-hide vlc-agenda-detail-sidebar-item__icon--margin-right vlc-u-opacity-50"></i>
+                  {{#attach-tooltip
+                    arrow="true"
+                    animation="shift"
+                    placement="top"
+                    class="ember-attacher-tooltip"
+                  }}
+                    <p>
+                      {{t "not-visible-in-newsletter"}}
+                    </p>
+                  {{/attach-tooltip}}
+                </span>
               {{/if}}
 
               {{#if (await subcase.confidential)}}
                 <i
-                   class="vl-icon ki-lock-closed vlc-u-opacity-50"
-                   data-test-icon-agenda-confidentiality-locked
+                 class="vl-icon ki-lock-closed vlc-u-opacity-50"
+                 data-test-icon-agenda-confidentiality-locked
                 ></i>
               {{/if}}
             </div>

--- a/app/pods/components/agenda/agenda-overview/agenda-overview-item/template.hbs
+++ b/app/pods/components/agenda/agenda-overview/agenda-overview-item/template.hbs
@@ -127,7 +127,18 @@
                 <div class="vlc-agenda-items__icons">
                   <div class="vl-u-display-flex vlc-agenda-items__icons">
                     {{#if (not newsletterInfo.inNewsletter)}}
-                      <i class="vl-button__icon ki-hide vlc-u-opacity-50 vl-u-spacer-extended-left-s opacity-lighter"></i>
+                      <i class="vl-button__icon ki-hide vlc-u-opacity-50 vl-u-spacer-extended-left-s opacity-lighter">
+                        {{#attach-tooltip
+                          arrow="true"
+                          animation="shift"
+                          placement="top"
+                          class="ember-attacher-tooltip"
+                        }}
+                          <p>
+                            {{t "not-visible-in-newsletter"}}
+                          </p>
+                        {{/attach-tooltip}}
+                      </i>
                     {{/if}}
                     {{#if (await @agendaitem.checkAdded)}}
                       <i class="vl-link__icon ki-calendar-plus vlc-agenda-item__icons--margin">

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -603,5 +603,6 @@
   "approve-all-agendaitems": "Alles formeel goedkeuren",
   "approve-all-agendaitems-warning-message": "Bent u zeker dat u {amountOfAgendaitemsNotFormallyOk} agenda items formeel wil goedkeuren",
   "agenda-has-nok-agendaitems-warning": "Deze ontwerpagenda bevat agendapunten die nog niet formeel OK verklaard zijn. U kan geen (ontwerp)agenda afsluiten die formeel NOK-agendapunten bevat. Gelieve deze formeel OK te verklaren of te verwijderen",
-  "approve-agenda-error": "(Ontwerp)agenda afsluiten onmogelijk"
+  "approve-agenda-error": "(Ontwerp)agenda afsluiten onmogelijk",
+  "not-visible-in-newsletter": "Niet zichtbaar in Kort Bestek"
 }


### PR DESCRIPTION
# KAS-1857: weergeven tooltip voor niet in kort bestek
In deze PR hebben we een tooltip toegevoegd voor het tonen van een de message `Niet zichtbaar in Kort Bestek` 

## Screenshots
![image](https://user-images.githubusercontent.com/11557630/93351802-6b499f00-f83a-11ea-9c54-ad788b8f3c73.png)
