### PR TITLE
Kas 1823 agenda filter

### DIFF
--- a/app/pods/agenda/agendaitems/controller.js
+++ b/app/pods/agenda/agendaitems/controller.js
@@ -63,7 +63,7 @@ export default class AgendaItemsAgendaController extends Controller {
       this.filteredAnnouncements = this.model.announcements;
     } else {
       const filter = {
-        ':sqs:title,shortTitle': `${this.filter}*`, // sqs combined with asterisk suffixing as hack for accomplishing a multi-field prefix query
+        ':sqs:title,shortTitle': `${this.filter}`, // sqs can be replaced by "phrase_prefix" once a release containing https://github.com/mu-semtech/mu-search/pull/17 is available
         meetingId: this.meeting.id,
         agendaId: this.agenda.id,
       };

--- a/app/pods/agenda/agendaitems/controller.js
+++ b/app/pods/agenda/agendaitems/controller.js
@@ -67,10 +67,9 @@ export default class AgendaItemsAgendaController extends Controller {
         meetingId: this.meeting.id,
         agendaId: this.agenda.id,
       };
-      const matchingAgendaitemIds = yield search('agendaitems', 0, 500, null, filter, (agendaItem) => agendaItem.id);
-      console.log("matching ids", matchingAgendaitemIds);
-      this.filteredAgendaitems = this.model.agendaitems.filter((ai) => matchingAgendaitemIds.includes(ai.id));
-      this.filteredAnnouncements = this.model.announcements.filter((ai) => matchingAgendaitemIds.includes(ai.id));
+      const matchingIds = yield search('agendaitems', 0, 500, null, filter, (agendaItem) => agendaItem.id);
+      this.filteredAgendaitems = this.model.agendaitems.filter((ai) => matchingIds.includes(ai.id));
+      this.filteredAnnouncements = this.model.announcements.filter((ai) => matchingIds.includes(ai.id));
     }
   })) filterTask;
 

--- a/app/pods/agenda/agendaitems/controller.js
+++ b/app/pods/agenda/agendaitems/controller.js
@@ -63,7 +63,7 @@ export default class AgendaItemsAgendaController extends Controller {
       this.filteredAnnouncements = this.model.announcements;
     } else {
       const filter = {
-        ':sqs:title,shortTitle': this.filter,
+        ':sqs:title,shortTitle': `${this.filter}*`, // sqs combined with asterisk suffixing as hack for accomplishing a multi-field prefix query
         meetingId: this.meeting.id,
         agendaId: this.agenda.id,
       };

--- a/app/pods/agenda/agendaitems/controller.js
+++ b/app/pods/agenda/agendaitems/controller.js
@@ -1,58 +1,61 @@
 import Controller from '@ember/controller';
-import { computed } from '@ember/object';
-import { inject } from '@ember/service';
+import {
+  computed,
+  action
+} from '@ember/object';
+import { inject as service } from '@ember/service';
 import { alias } from '@ember/object/computed';
+import { tracked } from '@glimmer/tracking';
 
-export default Controller.extend({
-  queryParams: ['filter'],
-  routing: inject('-routing'),
-  filter: null,
-  sessionService: inject(),
-  agendaService: inject(),
-  agendaitems: alias('model.agendaitems'),
-  announcements: alias('model.announcements'),
-  selectedAgendaitem: alias('sessionService.selectedAgendaitem'),
-  currentAgenda: alias('sessionService.currentAgenda'),
-  currentSession: alias('sessionService.currentSession'),
+export default class AgendaItemsAgendaController extends Controller {
+  queryParams = ['filter'];
 
-  sortedAgendaitems: computed('agendaitems.@each.{priority,isDeleted}', async function() {
-    const actualAgendaitems = this.get('agendaitems').filter((agendaitem) => !agendaitem.showAsRemark && !agendaitem.isDeleted)
+  @service('-routing') routing;
+  @service sessionService;
+  @service agendaService;
+
+  @alias('model.agendaitems') agendaitems;
+  @alias('model.announcements') announcements;
+  @alias('sessionService.selectedAgendaitem') selectedAgendaitem;
+  @alias('sessionService.currentAgenda') currentAgenda;
+  @alias('sessionService.currentSession') currentSession;
+
+  @tracked filter;
+
+  @computed('agendaitems.@each.{priority,isDeleted}')
+  get sortedAgendaitems() {
+    const actualAgendaitems = this.agendaitems.filter((agendaitem) => !agendaitem.showAsRemark && !agendaitem.isDeleted)
       .sortBy('priority');
-    await this.agendaService.groupAgendaitemsOnGroupName(actualAgendaitems);
-    return actualAgendaitems;
-  }),
+    return this.agendaService.groupAgendaitemsOnGroupName(actualAgendaitems).then(() => actualAgendaitems);
+  }
 
-  sortedAnnouncements: computed('announcements.@each.{priority,isDeleted}', function() {
-    const announcements = this.get('announcements');
+  @computed('announcements.@each.{priority,isDeleted}')
+  get sortedAnnouncements() {
+    const announcements = this.announcements;
     if (announcements) {
       return announcements.filter((announcement) => !announcement.isDeleted).sortBy('priority');
     }
     return [];
-  }),
+  }
 
-  agendaitemsClass: computed('routing.currentRouteName', function() {
-    const {
-      routing,
-    } = this;
-    if (routing.get('currentRouteName').startsWith('agenda.agendaitems.agendaitem')) {
+  get agendaitemsClass() {
+    if (this.routing.currentRouteName.startsWith('agenda.agendaitems.agendaitem')) {
       return 'vlc-panel-layout__agenda-items';
     }
     return 'vlc-panel-layout-agenda__detail vl-u-bg-porcelain';
-  }),
+  }
 
-  isOverviewWindow: computed('routing.currentRouteName', function() {
-    const {
-      routing,
-    } = this;
-    return routing.get('currentRouteName') === 'agenda.agendaitems.index';
-  }),
+  get isOverviewWindow() {
+    return this.routing.currentRouteName === 'agenda.agendaitems.index';
+  }
 
-  actions: {
-    searchAgendaitems(value) {
-      this.set('filter', value);
-    },
-    refresh() {
-      this.send('reloadModel');
-    },
-  },
-});
+  @action
+  searchAgendaitems(value) {
+    this.filter = value;
+  }
+
+  @action
+  refresh() {
+    this.send('reloadModel');
+  }
+}

--- a/app/pods/agenda/agendaitems/controller.js
+++ b/app/pods/agenda/agendaitems/controller.js
@@ -75,9 +75,9 @@ export default class AgendaItemsAgendaController extends Controller {
   })) filterTask;
 
   @action
-  searchAgendaitems(value) {
+  async searchAgendaitems(value) {
     this.filter = value;
-    this.filterTask.perform();
+    await this.filterTask.perform();
   }
 
   @action

--- a/app/pods/agenda/agendaitems/route.js
+++ b/app/pods/agenda/agendaitems/route.js
@@ -1,18 +1,19 @@
 import Route from '@ember/routing/route';
 import { hash } from 'rsvp';
 import { isEmpty } from '@ember/utils';
-import { inject } from '@ember/service';
+import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import search from 'fe-redpencil/utils/mu-search';
 
-export default Route.extend({
-  sessionService: inject(),
-  agendaService: inject(),
-  queryParams: {
+export default class AgendaItemsAgendaRoute extends Route {
+  queryParams = {
     filter: {
       refreshModel: true,
     },
-  },
+  };
+
+  @service sessionService;
+  @service agendaService;
 
   async model(params) {
     const {
@@ -36,12 +37,12 @@ export default Route.extend({
       announcements,
       agendaitems,
     });
-  },
+  }
 
   @action
   reloadModel() {
     this.refresh();
-  },
+  }
 
   async getMatchingAgendaitems(filterText) {
     const {
@@ -59,5 +60,5 @@ export default Route.extend({
       return entry;
     });
     return matchingAgendaitems;
-  },
-});
+  }
+}

--- a/app/pods/agenda/agendaitems/route.js
+++ b/app/pods/agenda/agendaitems/route.js
@@ -28,7 +28,7 @@ export default class AgendaItemsAgendaRoute extends Route {
     this.set('sessionService.selectedAgendaitem', null);
 
     return hash({
-      currentAgenda: agenda,
+      currentAgenda: agenda, // TODO: figure out where this still gets used and remove. This can be fetched from parent routes' model
       announcements,
       agendaitems,
     });

--- a/app/pods/agenda/agendaitems/route.js
+++ b/app/pods/agenda/agendaitems/route.js
@@ -3,30 +3,25 @@ import { hash } from 'rsvp';
 import { isEmpty } from '@ember/utils';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
-import search from 'fe-redpencil/utils/mu-search';
 
 export default class AgendaItemsAgendaRoute extends Route {
   queryParams = {
     filter: {
-      refreshModel: true,
+      refreshModel: false,
     },
   };
 
   @service sessionService;
   @service agendaService;
 
-  async model(params) {
+  async model() {
     const {
       agenda,
     } = this.modelFor('agenda');
-    let agendaitems = await this.store.query('agendaitem', {
+    const agendaitems = await this.store.query('agendaitem', {
       'filter[agenda][:id:]': agenda.id,
       include: 'mandatees',
     });
-    if (!isEmpty(params.filter)) {
-      const matchingAgendaitems = await this.getMatchingAgendaitems(params.filter);
-      agendaitems = agendaitems.filter((agendaitem) => matchingAgendaitems.find((matchItem) => matchItem.id === agendaitem.id));
-    }
 
     const announcements = agendaitems.filter((agendaitem) => agendaitem.showAsRemark);
 
@@ -39,26 +34,28 @@ export default class AgendaItemsAgendaRoute extends Route {
     });
   }
 
-  @action
-  reloadModel() {
-    this.refresh();
+  afterModel(_, transition) { // eslint-disable-line
+    if (!isEmpty(transition.to.queryParams.filter)) {
+      const controller = this.controllerFor('agenda.agendaitems');
+      controller.filterTask.perform();
+    }
   }
 
-  async getMatchingAgendaitems(filterText) {
+  setupController(controller, model) {
+    super.setupController(...arguments);
     const {
       agenda,
       meeting,
     } = this.modelFor('agenda');
-    const filter = {
-      ':sqs:title,shortTitle': filterText,
-      meetingId: meeting.id,
-      agendaId: agenda.id,
-    };
-    const matchingAgendaitems = await search('agendaitems', 0, 500, null, filter, (agendaitem) => {
-      const entry = agendaitem.attributes;
-      entry.id = agendaitem.id;
-      return entry;
-    });
-    return matchingAgendaitems;
+    controller.set('meeting', meeting);
+    controller.set('agenda', agenda);
+
+    controller.set('filteredAgendaitems', model.agendaitems);
+    controller.set('filteredAnnouncements', model.announcements);
+  }
+
+  @action
+  reloadModel() {
+    this.refresh();
   }
 }

--- a/app/pods/agenda/agendaitems/template.hbs
+++ b/app/pods/agenda/agendaitems/template.hbs
@@ -9,14 +9,14 @@
         <Agenda::AgendaOverview
           @announcements={{this.sortedAnnouncements}}
           @agendaitems={{await this.sortedAgendaitems}}
-          @currentAgenda={{await this.model.currentAgenda}}
+          @currentAgenda={{this.agenda}}
           @selectedAgendaitem={{this.selectedAgendaitem}}
         />
       {{else}}
         <Agenda::AgendaDetail::Sidebar
           @announcements={{this.sortedAnnouncements}}
           @agendaitems={{await this.sortedAgendaitems}}
-          @currentAgenda={{await this.model.currentAgenda}}
+          @currentAgenda={{this.agenda}}
         />
       {{/if}}
     </div>

--- a/app/pods/agenda/agendaitems/template.hbs
+++ b/app/pods/agenda/agendaitems/template.hbs
@@ -1,23 +1,23 @@
-<div class={{agendaitemsClass}}>
+<div class={{this.agendaitemsClass}}>
   <div class="vlc-u-box-model-maximize-height vlc-scroll-wrapper">
-    {{agenda/agendaitem-search
-      searchText=(readonly filter)
-      onSearch=(action "searchAgendaitems")
-    }}
+    <Agenda::AgendaitemSearch
+      @searchText={{readonly this.filter}}
+      @onSearch={{this.searchAgendaitems}}
+    />
     <div class="vlc-scroll-wrapper__body vlc-hide-on-print">
       {{#if isOverviewWindow }}
-        {{agenda/agenda-overview
-          announcements=sortedAnnouncements
-          agendaitems=(await sortedAgendaitems)
-          currentAgenda=(await model.currentAgenda)
-          selectedAgendaitem=selectedAgendaitem
-        }}
+        <Agenda::AgendaOverview
+          @announcements={{this.sortedAnnouncements}}
+          @agendaitems={{await this.sortedAgendaitems}}
+          @currentAgenda={{await this.model.currentAgenda}}
+          @selectedAgendaitem={{this.selectedAgendaitem}}
+        />
       {{else}}
-        {{agenda/agenda-detail/sidebar
-          announcements=sortedAnnouncements
-          agendaitems=(await sortedAgendaitems)
-          currentAgenda=(await model.currentAgenda)
-        }}
+        <Agenda::AgendaDetail::Sidebar
+          @announcements={{this.sortedAnnouncements}}
+          @agendaitems={{await this.sortedAgendaitems}}
+          @currentAgenda={{await this.model.currentAgenda}}
+        />
       {{/if}}
     </div>
   </div>

--- a/app/pods/agenda/agendaitems/template.hbs
+++ b/app/pods/agenda/agendaitems/template.hbs
@@ -10,7 +10,6 @@
           @announcements={{this.sortedAnnouncements}}
           @agendaitems={{await this.sortedAgendaitems}}
           @currentAgenda={{this.agenda}}
-          @selectedAgendaitem={{this.selectedAgendaitem}}
         />
       {{else}}
         <Agenda::AgendaDetail::Sidebar

--- a/app/pods/agenda/agendaitems/template.hbs
+++ b/app/pods/agenda/agendaitems/template.hbs
@@ -5,7 +5,7 @@
       @onSearch={{this.searchAgendaitems}}
     />
     <div class="vlc-scroll-wrapper__body vlc-hide-on-print">
-      {{#if isOverviewWindow }}
+      {{#if isOverviewWindow}}
         <Agenda::AgendaOverview
           @announcements={{this.sortedAnnouncements}}
           @agendaitems={{await this.sortedAgendaitems}}

--- a/app/pods/agenda/agendaitems/template.hbs
+++ b/app/pods/agenda/agendaitems/template.hbs
@@ -11,14 +11,12 @@
           agendaitems=(await sortedAgendaitems)
           currentAgenda=(await model.currentAgenda)
           selectedAgendaitem=selectedAgendaitem
-          filteredAgendaitems=filteredAgendaitems
         }}
       {{else}}
         {{agenda/agenda-detail/sidebar
           announcements=sortedAnnouncements
           agendaitems=(await sortedAgendaitems)
           currentAgenda=(await model.currentAgenda)
-          filteredAgendaitems=filteredAgendaitems
         }}
       {{/if}}
     </div>

--- a/app/pods/agenda/agendaitems/template.hbs
+++ b/app/pods/agenda/agendaitems/template.hbs
@@ -1,9 +1,8 @@
 <div class={{agendaitemsClass}}>
   <div class="vlc-u-box-model-maximize-height vlc-scroll-wrapper">
     {{agenda/agendaitem-search
-      selectedAgenda=currentAgenda
-      value=(readonly filter)
-      search=(action "searchAgendaitems")
+      searchText=(readonly filter)
+      onSearch=(action "searchAgendaitems")
     }}
     <div class="vlc-scroll-wrapper__body vlc-hide-on-print">
       {{#if isOverviewWindow }}

--- a/app/pods/components/agenda/agenda-overview/component.js
+++ b/app/pods/components/agenda/agenda-overview/component.js
@@ -1,8 +1,5 @@
 import Component from '@ember/component';
-import {
-  computed, action
-} from '@ember/object';
-import { alias } from '@ember/object/computed';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { setAgendaitemsPriority } from 'fe-redpencil/utils/agendaitem-utils';
 
@@ -13,11 +10,7 @@ export default class AgendaOverview extends Component {
 
   @service('current-session') currentSessionService;
 
-  classNames = ['vlc-agenda-items'];
-
-  classNameBindings = ['getClassNames'];
-
-  selectedAgendaitem = alias('sessionService.selectedAgendaitem');
+  classNames = ['vlc-agenda-items', 'vl-u-spacer-extended-l', 'vlc-agenda-items--spaced'];
 
   dragHandleClass = '.vlc-agenda-items__sub-item';
 
@@ -29,14 +22,6 @@ export default class AgendaOverview extends Component {
   isShowingChanges = null;
 
   showLoader = null;
-
-  @computed('selectedAgendaitem')
-  get getClassNames() {
-    if (this.get('selectedAgendaitem')) {
-      return 'vlc-agenda-items--small';
-    }
-    return 'vl-u-spacer-extended-l vlc-agenda-items--spaced';
-  }
 
   @action
   selectAgendaitemAction(agendaitem) {

--- a/app/pods/components/agenda/agenda-overview/template.hbs
+++ b/app/pods/components/agenda/agenda-overview/template.hbs
@@ -124,19 +124,11 @@
     </ul>
   {{/if}}
 </div>
-{{#if (not selectedAgendaitem)}}
-  <div class="vlc-agenda-items-section-header">
-    <h3 class="vl-title--h3 vlc-agenda-items-section-header__title">
-      {{t "announcements-subtitle"}}
-    </h3>
-  </div>
-{{else}}
-  <div class="vlc-agenda-items-section-header">
-    <h3 class="vl-title--h3 vlc-agenda-items-section-header__title">
-      {{t "announcements-subtitle"}}
-    </h3>
-  </div>
-{{/if}}
+<div class="vlc-agenda-items-section-header">
+  <h3 class="vl-title--h3 vlc-agenda-items-section-header__title">
+    {{t "announcements-subtitle"}}
+  </h3>
+</div>
 <div class="vl-u-spacer">
   {{#if (gt (await announcements.length) 0)}}
     {{#if (and currentSessionService.isEditor currentAgenda.isDesignAgenda)}}

--- a/app/pods/components/agenda/agendaitem-search/component.js
+++ b/app/pods/components/agenda/agendaitem-search/component.js
@@ -15,7 +15,7 @@ export default class AgendaItemSearch extends Component {
 
   @(task(function *() {
     yield timeout(600);
-    this.search(this.searchText);
+    yield this.search(this.searchText);
   }).restartable()) debouncedSearchTask;
 
   @action
@@ -25,10 +25,10 @@ export default class AgendaItemSearch extends Component {
   }
 
   @action
-  search() {
+  async search() {
     const handler = this.args.onSearch;
     if (handler) {
-      handler(this.searchText);
+      await handler(this.searchText);
     }
   }
 }

--- a/app/pods/components/agenda/agendaitem-search/component.js
+++ b/app/pods/components/agenda/agendaitem-search/component.js
@@ -1,26 +1,34 @@
-import Component from '@ember/component';
-import { inject } from '@ember/service';
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import {
   task, timeout
 } from 'ember-concurrency';
 
-export default Component.extend({
-  classNames: ['vlc-scroll-wrapper__header'],
-  store: inject(),
+export default class AgendaItemSearch extends Component {
+  @tracked searchText;
 
-  searchTask: task(function *() {
+  constructor() {
+    super(...arguments);
+    this.searchText = this.args.searchText || '';
+  }
+
+  @(task(function *() {
     yield timeout(600);
-    this.search(this.get('value'));
-  }).restartable(),
+    this.search(this.searchText);
+  }).restartable()) debouncedSearchTask;
 
-  actions: {
-    search() {
-      this.searchTask.perform();
-    },
-    emptySearchTask(val) {
-      if (val === '') {
-        this.searchTask.perform();
-      }
-    },
-  },
-});
+  @action
+  debouncedSearch(event) {
+    this.searchText = event.target.value;
+    this.debouncedSearchTask.perform();
+  }
+
+  @action
+  search() {
+    const handler = this.args.onSearch;
+    if (handler) {
+      handler(this.searchText);
+    }
+  }
+}

--- a/app/pods/components/agenda/agendaitem-search/component.js
+++ b/app/pods/components/agenda/agendaitem-search/component.js
@@ -14,7 +14,7 @@ export default class AgendaItemSearch extends Component {
   }
 
   @(task(function *() {
-    yield timeout(600);
+    yield timeout(500);
     yield this.search(this.searchText);
   }).restartable()) debouncedSearchTask;
 

--- a/app/pods/components/agenda/agendaitem-search/template.hbs
+++ b/app/pods/components/agenda/agendaitem-search/template.hbs
@@ -20,7 +20,7 @@
             </button>
           </div>
         </div>
-        {{#if debouncedSearch.isRunning}}
+        {{#if this.debouncedSearchTask.isRunning}}
           <div class="vl-loader" role="alert" aria-busy="true"></div>
         {{/if}}
       </div>

--- a/app/pods/components/agenda/agendaitem-search/template.hbs
+++ b/app/pods/components/agenda/agendaitem-search/template.hbs
@@ -1,24 +1,29 @@
-<div class="vlc-navbar vlc-navbar--bordered-bottom vlc-hide-on-print">
-  <div class="vlc-toolbar vlc-toolbar--auto">
-    <div class="vlc-toolbar__justified">
-      <div class="vlc-toolbar__item vlc-u-box-model-maximize-width">
-        <div class="vl-input-field--inline vl-u-display-flex vl-u-flex-align-center vlc-u-flex-space-between"
-        >
-          {{input
-            value=value
-            placeholder=(t "search-agenda-items")
-            key-up=(action "emptySearchTask" value)
-            key-press=(perform searchTask)
-            class="vl-input-field vl-input-field__input"
-          }}
-          <button type="button" class="vl-input-field__submit vl-button" {{action "search"}}>
-            <i class="ki-search"></i>
-          </button>
+<div class="vlc-scroll-wrapper__header">
+  <div class="vlc-navbar vlc-navbar--bordered-bottom vlc-hide-on-print">
+    <div class="vlc-toolbar vlc-toolbar--auto">
+      <div class="vlc-toolbar__justified">
+        <div class="vlc-toolbar__item vlc-u-box-model-maximize-width">
+          <div class="vl-input-field--inline vl-u-display-flex vl-u-flex-align-center vlc-u-flex-space-between">
+            <Input
+              class="vl-input-field vl-input-field__input"
+              value={{this.searchText}}
+              @enter={{this.search}}
+              @placeholder={{t "search-agenda-items"}}
+              {{on "input" this.debouncedSearch}}
+            />
+            <button
+              type="button"
+              class="vl-input-field__submit vl-button"
+              {{on "click" this.search}}
+            >
+              <i class="ki-search"></i>
+            </button>
+          </div>
         </div>
+        {{#if debouncedSearch.isRunning}}
+          <div class="vl-loader" role="alert" aria-busy="true"></div>
+        {{/if}}
       </div>
-      {{#if searchTask.isRunning}}
-        <div class="vl-loader" role="alert" aria-busy="true"></div>
-      {{/if}}
     </div>
   </div>
 </div>

--- a/app/pods/search/loading/template.hbs
+++ b/app/pods/search/loading/template.hbs
@@ -1,0 +1,4 @@
+<div class="vlc-u-box-model-maximize-height vlc-u-box-model-maximize-width vlc-scroll-wrapper vl-u-no-overflow vl-loader-container--not-supported">
+  {{web-components/vl-loader}}
+</div>
+{{outlet}}

--- a/app/utils/vr-document-name.js
+++ b/app/utils/vr-document-name.js
@@ -45,7 +45,7 @@ export default class VRDocumentName {
       throw new Error(`Couldn't parse VR Document Name "${this.name}" (${this.strict ? 'strict' : 'loose'} parsing mode)`);
     }
     const meta = {
-      date: moment(match[1], 'YYYY DDMM').toDate(),
+      date: moment(match[1], 'YYYY DDMM').toDate(), // TODO set moment "strict" parsing to true + throw error when "Invalid date"
       docType: match[2],
       caseNr: parseInt(match[6], 10),
       index: parseInt(match[8], 10),


### PR DESCRIPTION
Zie [KAS-1823](https://kanselarij.atlassian.net/browse/KAS-1823)

Testing tip: Start de frontend met een proxy naar de dev server ( `ember s --proxy=https://kaleidos-dev.vlaanderen.be`) en ga naar `/vergadering/5D6BB31423AC750009000143/agenda/5D6BBB4723AC750009000165/agendapunten` voor een representatieve agenda.

Bevat naast de scope van de story (in gerelateerde stukken) ook:
- Octane refactor
- Verwijderen van ongebruikte component argumenten