### PR TITLE
KAS-1870: Resize formeel ok label

### DIFF
--- a/app/styles/custom-components/_vlc-agenda-detail-sidebar.scss
+++ b/app/styles/custom-components/_vlc-agenda-detail-sidebar.scss
@@ -240,6 +240,7 @@ $i: 0;
   padding-top: 1.5rem;
 
   .formally-ok-icon {
+
     &::before {
       margin-right: 0.2rem;
       height: 100%;

--- a/app/styles/custom-components/_vlc-agenda-detail-sidebar.scss
+++ b/app/styles/custom-components/_vlc-agenda-detail-sidebar.scss
@@ -240,7 +240,6 @@ $i: 0;
   padding-top: 1.5rem;
 
   .formally-ok-icon {
-
     &::before {
       margin-right: 0.2rem;
       height: 100%;

--- a/app/styles/custom-components/_vlc-agenda-meta.scss
+++ b/app/styles/custom-components/_vlc-agenda-meta.scss
@@ -24,6 +24,7 @@
 }
 
 .vlc-agenda-items__status {
+  font-size: 1.4rem;
   white-space: nowrap;
 
   .formally-ok-icon {


### PR DESCRIPTION
# ✅ KAS-1870: Resize formeel ok label

## ✏️ What has been done
De label voor formeel ok was in de huidige versie iets te groot t.o.v. het design. In samenspraak met Johan Ronsse hebben we het label resized naar 1.4 rem.

## 🖼 Screenshots
![image](https://user-images.githubusercontent.com/11557630/94140757-06123100-fe6c-11ea-80a8-7217c91cabbb.png)
