### PR TITLE
KAS-1871: resize tooltip tekstsize

### DIFF
--- a/app/styles/custom-application/ember-attacher.scss
+++ b/app/styles/custom-application/ember-attacher.scss
@@ -5,6 +5,7 @@
 }
 
 .ember-attacher-popper {
+  font-size: 1.3rem;
   background-color: $page-bg;
   box-shadow: 0 3px 17px rgba(#000, 0.15); // sass-lint:disable-line no-color-literals
   width: 23rem;


### PR DESCRIPTION
# ⚠️ KAS-1871: resize tooltip tekstsize
In deze PR hebben we de grootte van de tekst in de tooltip verkleind naar 1.3 rem.

## 🖼 Screenshot before:
![image](https://user-images.githubusercontent.com/11557630/94163213-dd983000-fe87-11ea-8944-a9ddb0e8fec1.png)

## 🖼 Screenshot after:
![image](https://user-images.githubusercontent.com/11557630/94163264-eab51f00-fe87-11ea-85b5-b23a17ca2a00.png)
