### PR TITLE
KAS-1771: Render in place

### DIFF
--- a/app/pods/cases/overview/template.hbs
+++ b/app/pods/cases/overview/template.hbs
@@ -77,6 +77,7 @@
                 <i class="vl-button__icon ki-more"
                 ></i>
                 {{#attach-popover
+                  renderInPlace=true
                   class="ember-attacher-popper"
                   hideOn="clickout click"
                   showOn="click"

--- a/app/pods/components/agenda/agenda-header/template.hbs
+++ b/app/pods/components/agenda/agenda-header/template.hbs
@@ -53,6 +53,7 @@
               {{/if}}
               {{t "agendaApproveActions"}}
               {{#attach-popover
+                renderInPlace=true
                 class="ember-attacher-popper vlc-hide-on-print"
                 hideOn="clickout click"
                 showOn="click"
@@ -76,7 +77,9 @@
                         {{action attacher.hide}}
                         {{action "approveAndCloseAgenda" currentSession}}
                       >
-                        {{await currentSession.latestAgendaName}} {{t "approve-small-and-close"}}
+                        <span>
+                          {{await currentSession.latestAgendaName}} {{t "approve-small-and-close"}}
+                        </span>
                       </button>
                     </li>
                   {{/if}}
@@ -101,6 +104,7 @@
             {{/if}}
             {{t "actions"}}
             {{#attach-popover
+              renderInPlace=true
               class="ember-attacher-popper vlc-hide-on-print"
               hideOn="clickout click"
               showOn="click"

--- a/app/pods/components/agenda/agendaitem/agendaitem-case/subcase-document/document-link/template.hbs
+++ b/app/pods/components/agenda/agendaitem/agendaitem-case/subcase-document/document-link/template.hbs
@@ -24,6 +24,7 @@
               >
                 <i class="ki-more"></i>
                 {{#attach-popover
+                  renderInPlace=true
                   class="ember-attacher-popper"
                   hideOn="clickout click"
                   showOn="click"

--- a/app/pods/components/newsletter/newsletter-header-overview/template.hbs
+++ b/app/pods/components/newsletter/newsletter-header-overview/template.hbs
@@ -86,6 +86,7 @@
             {{/if}}
             {{t "actions"}}
             {{#attach-popover
+              renderInPlace=true
               class="ember-attacher-popper vlc-hide-on-print"
               hideOn="clickout click"
               showOn="click"

--- a/app/pods/components/subcases/subcase-header/template.hbs
+++ b/app/pods/components/subcases/subcase-header/template.hbs
@@ -17,6 +17,7 @@
             {{t "propose-for-agenda"}}
           </button>
           {{#attach-popover
+            renderInPlace=true
             class="ember-attacher-popper"
             hideOn="clickout click"
             showOn="click"
@@ -68,6 +69,7 @@
           {{/if}}
           {{t "actions"}}
           {{#attach-popover
+            renderInPlace=true
             class="ember-attacher-popper"
             hideOn="clickout click"
             showOn="click"

--- a/app/pods/components/utils/agendaitem-comment/template.hbs
+++ b/app/pods/components/utils/agendaitem-comment/template.hbs
@@ -28,6 +28,7 @@
               {{t "more-options"}}
             </span>
             {{#attach-popover
+              renderInPlace=true
               class="ember-attacher-popper"
               hideOn="clickout click"
               showOn="click"

--- a/app/styles/custom-components/_vlc-dropdown-menu.scss
+++ b/app/styles/custom-components/_vlc-dropdown-menu.scss
@@ -36,6 +36,7 @@
 }
 
 .vlc-dropdown-menu__item {
+  display: flex;
   .vl-link {
     padding: .8rem 1.5rem;
     font-size: 1.5rem;

--- a/app/styles/custom-components/_vlc-dropdown-menu.scss
+++ b/app/styles/custom-components/_vlc-dropdown-menu.scss
@@ -23,7 +23,7 @@
 .vlc-dropdown-menu {
   padding: .5rem 0;
   max-height: inherit;
-  overflow-y: auto;
+  overflow-y: unset;
 }
 
 .vlc-dropdown-menu__separator {
@@ -47,6 +47,10 @@
     &:focus {
       text-decoration: underline;
     }
+  }
+  span {
+    display:block;
+    white-space: normal;
   }
 }
 

--- a/app/styles/custom-components/_vlc-panel-layout.scss
+++ b/app/styles/custom-components/_vlc-panel-layout.scss
@@ -10,6 +10,7 @@
 }
 
 .vlc-panel-layout-agenda__detail {
+  z-index: 1;
   width: 100%;
 }
 


### PR DESCRIPTION
# 🖼 KAS-1771: Render in place
In deze PR hebben we de `ember-attacher` popups laten renderen op de specifieke locatie in de dom. Dit gaf enkele `z-index issues` met zich mee.

## ✏️ What has changed

- De popups renderen nu `in-place` wat betekent dat ze nu in de dom zouden moeten staan op de positie en nesting waar ze effectief verschijnen.
- Minor CSS fixes gedaan om `z-index` issues op te lossen

Deze change zou visueel niks mogen veranderen aan de applicatie.. het kan echte zijn dat er minimale visuele changes zijn t.o.v. de vorige versie omwille van het aanpassen van minimale css.