### PR TITLE
KAS-1875: rechts uitlijnen pijlen

### DIFF
--- a/app/pods/components/agenda/agenda-header/template.hbs
+++ b/app/pods/components/agenda/agenda-header/template.hbs
@@ -42,16 +42,16 @@
                     class="vl-button vl-button--icon-before"
               {{action "showAgendaActions"}}
             >
+              {{t "agendaApproveActions"}}
               {{#if (not isShowingAgendaActions)}}
-                <i class="vl-button__icon vl-button__icon--before ki-chevron-down"
+                <i class="vl-button__icon vl-button__icon--after ki-chevron-down"
                   {{action "showAgendaActions" bubbles=false}}
                 ></i>
               {{else}}
-                <i class="vl-button__icon vl-button__icon--before ki-chevron-up"
+                <i class="vl-button__icon vl-button__icon--after ki-chevron-up"
                   {{action "showAgendaActions" bubbles=false}}
                 ></i>
               {{/if}}
-              {{t "agendaApproveActions"}}
               {{#attach-popover
                 class="ember-attacher-popper vlc-hide-on-print"
                 hideOn="clickout click"
@@ -90,16 +90,16 @@
                   class="vl-button vl-button--icon-before vl-button--secondary"
             {{action "showMultipleOptions"}}
           >
+            {{t "actions"}}
             {{#if (not isShowingOptions)}}
-              <i class="vl-button__icon vl-button__icon--before ki-chevron-down"
+              <i class="vl-button__icon vl-button__icon--after ki-chevron-down"
                 {{action "showMultipleOptions" bubbles=false}}
               ></i>
             {{else}}
-              <i class="vl-button__icon vl-button__icon--before ki-chevron-up"
+              <i class="vl-button__icon vl-button__icon--after ki-chevron-up"
                 {{action "showMultipleOptions" bubbles=false}}
               ></i>
             {{/if}}
-            {{t "actions"}}
             {{#attach-popover
               class="ember-attacher-popper vlc-hide-on-print"
               hideOn="clickout click"


### PR DESCRIPTION
# KAS-1875: Rechts uitlijnen pijlen in agenda overview
In deze PR verplaatsen we de pijlen van links naar echts voor twee buttons.

## What has changed

- De pijl voor acties staat rechts
- De pijl voor agenda acties staat rechts

## 🖼 Screenshots
**Before:**
![image](https://user-images.githubusercontent.com/11557630/94257248-497fa480-ff2b-11ea-97f9-dd1d021564b9.png)

**After:**
![image](https://user-images.githubusercontent.com/11557630/94257206-3b318880-ff2b-11ea-8eda-3e0471b2e5e5.png)
