### PR TITLE
KAS-1532: Aanpassen section header

### DIFF
--- a/app/pods/components/agenda/agenda-overview/template.hbs
+++ b/app/pods/components/agenda/agenda-overview/template.hbs
@@ -72,7 +72,7 @@
             {{!-- TODO: these triple curlies are used for displaying a computed string with br tags in it.
               These items concatenated by <br> should become a list that is iterated over in a .hbs template --}}
             {{!-- template-lint-disable no-triple-curlies  --}}
-            {{{agendaitem.groupName}}}
+            <span class="vlc-list-section-header-title">{{{agendaitem.groupName}}}</span>
             {{!-- template-lint-enable no-triple-curlies  --}}
           </div>
         {{/if}}

--- a/app/services/agenda-service.js
+++ b/app/services/agenda-service.js
@@ -204,7 +204,7 @@ export default Service.extend({
           return;
         }
         if (mandatees.length === 0) {
-          agendaitem.set('groupName', 'Geen toegekende ministers');
+          agendaitem.set('groupName', this.intl.t('no-mandatee-assigned'));
           return;
         }
         const currentAgendaitemGroupName = mandatees

--- a/app/styles/custom-components/_vlc-list-section-header.scss
+++ b/app/styles/custom-components/_vlc-list-section-header.scss
@@ -10,6 +10,10 @@
   border-bottom: 1px solid #EDD53D;
 }
 
+.vlc-list-section-header-title {
+  opacity: 0.4;
+}
+
 .vlc-list-section-header + .vlc-list-section-header {
   clear: both;
 }

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -604,5 +604,6 @@
   "approve-all-agendaitems-warning-message": "Bent u zeker dat u {amountOfAgendaitemsNotFormallyOk} agenda items formeel wil goedkeuren",
   "agenda-has-nok-agendaitems-warning": "Deze ontwerpagenda bevat agendapunten die nog niet formeel OK verklaard zijn. U kan geen (ontwerp)agenda afsluiten die formeel NOK-agendapunten bevat. Gelieve deze formeel OK te verklaren of te verwijderen",
   "approve-agenda-error": "(Ontwerp)agenda afsluiten onmogelijk",
-  "not-visible-in-newsletter": "Niet zichtbaar in Kort Bestek"
+  "not-visible-in-newsletter": "Niet zichtbaar in Kort Bestek",
+  "no-mandatee-assigned": "Geen toekenning"
 }


### PR DESCRIPTION
# 🤕 KAS-1532: Aanpassen section header
In deze PR hebben we de verschillende headers van een agendapunt gevalideerd en aangepast indien nodig.

## ✏️ What has changed:

- De header wanneer er geen minister toegekend is wordt weergeven met een opacity van `0.3`..
- De tekst die weergeven werd is toegevoegd in de `nl-be` translation file.

## Screenshot
**Before**
![image](https://user-images.githubusercontent.com/11557630/94267612-32957e00-ff3c-11ea-8252-ee9c34ba80a4.png)

**After**
![image](https://user-images.githubusercontent.com/11557630/94267559-1a256380-ff3c-11ea-9f11-f53a581e9e03.png)


