### PR TITLE
KAS-1188: add tooltips voor vertrouwelijk en niet consulteerbaar

### DIFF
--- a/app/pods/components/access-level-pill/template.hbs
+++ b/app/pods/components/access-level-pill/template.hbs
@@ -39,16 +39,50 @@
       </button>
     {{/if}}
   {{/if}}
-  <button type="button" class="vl-button vl-button--link-muted vl-button--icon vlc-toolbar__item"
-          disabled={{if session.isEditor undefined "true"}}
-    {{action "toggleConfidential"}}
-  >
-    {{#if lastDocumentVersion.confidential}}
-      <i class="vl-icon ki-lock-closed vl-u-text--error"
-      ></i>
-    {{else}}
-      <i class="vl-icon ki-lock-open"></i>
-    {{/if}}
-  </button>
+
+  {{#if (and session.isEditor undefined "true")}}
+    <button type="button" class="vl-button vl-button--link-muted vl-button--icon vlc-toolbar__item"
+            disabled={{if session.isEditor undefined "true"}}
+      {{action "toggleConfidential"}}
+    >
+      {{#if lastDocumentVersion.confidential}}
+        {{#attach-tooltip
+          arrow="true"
+          animation="shift"
+          placement="top"
+          class="ember-attacher-tooltip"
+        }}
+          <p>
+            {{t "document-is-confidential"}}
+          </p>
+        {{/attach-tooltip}}
+        <i class="vl-icon ki-lock-closed vl-u-text--error"
+        ></i>
+      {{else}}
+        <i class="vl-icon ki-lock-open"></i>
+      {{/if}}
+    </button>
+  {{else}}
+    <button type="button" class="vl-button vl-button--link-muted vl-button--icon vlc-toolbar__item"
+      {{action "toggleConfidential"}}
+    >
+      {{#if lastDocumentVersion.confidential}}
+        {{#attach-tooltip
+          arrow="true"
+          animation="shift"
+          placement="top"
+          class="ember-attacher-tooltip"
+        }}
+          <p>
+            {{t "document-is-confidential"}}
+          </p>
+        {{/attach-tooltip}}
+        <i class="vl-icon ki-lock-closed vl-u-text--error"
+        ></i>
+      {{else}}
+        <i class="vl-icon ki-lock-open"></i>
+      {{/if}}
+    </button>
+  {{/if}}
   {{yield}}
 {{/if}}

--- a/app/pods/components/web-components/vl-document/template.hbs
+++ b/app/pods/components/web-components/vl-document/template.hbs
@@ -1,5 +1,15 @@
 <div class="vlc-document-card-item__title">
   <h6 class="vl-title vl-title--h6">
+    {{#if (not (await documentVersion.file.downloadLink))}}
+      {{#attach-tooltip
+        arrow="true"
+        animation="shift"
+        placement="top"
+        class="ember-attacher-tooltip"
+      }}
+        {{t "document-not-consultable"}}
+      {{/attach-tooltip}}
+    {{/if}}
     {{await documentVersion.name}}
   </h6>
   {{access-level-pill lastDocumentVersion=documentVersion}}

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -620,5 +620,7 @@
   "newsletter-update-notas-agendaitem-short-title": "Agendapunt (korte titel)",
   "newsletter-update-notas-documentname": "Documentnaam",
   "newsletter-update-notas-edited-on": "Gewijzigd op",
-  "newsletter-update-notas-edited-text": "Geüpload op {date} om {time}"
+  "newsletter-update-notas-edited-text": "Geüpload op {date} om {time}",
+  "document-not-consultable": "Dit document is niet consulteerbaar voor uw profiel",
+  "document-is-confidential": "Dit document is vertrouwelijk"
 }


### PR DESCRIPTION
# 🖌 KAS-1188: Add tooltips voor vertrouwelijk en niet consulteerbaar
In deze PR voegen we enkele popups toe in de applicatie ter informatie van de gebruiker.

## ✏️  What has changed
- Wanneer een document vertrouwelijk is zie je als gebruiker de tekst: `Dit document is vertrouwelijk`
- Wanneer een document niet consulteerbaar is als die gebruiker en je hovert over de documentnaam zie je de tekst: `Dit document is niet consulteerbaar voor uw profiel`

## 🖼 Screenshots
###  🔒  Vertrouwelijk
![image](https://user-images.githubusercontent.com/11557630/94570891-9e932180-026f-11eb-8772-9cc062ef38e5.png)
![image](https://user-images.githubusercontent.com/11557630/94570923-a94db680-026f-11eb-8fea-19adacf813fd.png)

###  ❌   Niet consulteerbaar
![image](https://user-images.githubusercontent.com/11557630/94570991-bcf91d00-026f-11eb-9017-97c3388e0373.png)

