### PR TITLE
KAS-1776: Use AU input for search component

### DIFF
--- a/app/pods/components/agenda/agendaitem-search/template.hbs
+++ b/app/pods/components/agenda/agendaitem-search/template.hbs
@@ -4,13 +4,15 @@
       <div class="vlc-toolbar__justified">
         <div class="vlc-toolbar__item vlc-u-box-model-maximize-width">
           <div class="vl-input-field--inline vl-u-display-flex vl-u-flex-align-center vlc-u-flex-space-between">
-            <Input
-              class="vl-input-field vl-input-field__input"
-              value={{this.searchText}}
-              data-test-trigger-search-input
-              @enter={{this.search}}
-              @placeholder={{t "search-agenda-items"}}
-              {{on "input" this.debouncedSearch}}
+            <AuInput @icon="search"
+                   class="au2-input--block"
+                   type="text"
+                   data-test-trigger-search-input
+                   id="defaultInput"
+                   @placeholder={{t "search-agenda-items"}}
+                   value={{this.searchText}}
+                   {{on "input" this.debouncedSearch}}
+                   @enter={{this.search}}
             />
             <button
               type="button"

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -193,3 +193,6 @@ $icon-font-location: '/fonts/';
 @import 'custom-application/icons-overview';
 @import 'custom-application/extra-fonts';
 @import 'custom-application/loader';
+
+// AU
+@import 'appuniversum/au2-input';

--- a/app/styles/appuniversum/_au2-input.scss
+++ b/app/styles/appuniversum/_au2-input.scss
@@ -1,0 +1,45 @@
+/* ==========================================================================
+  c-input
+   ========================================================================== */
+
+.au2-input {
+  border: 0.1rem solid $au-gray-300;
+  padding: .7rem;
+  font-family: "Flanders Art Sans", sans-serif;
+  font-size: 1.6rem;
+}
+
+.au2-input:focus {
+  outline: 0;
+  border-color: $au-yellow-400;
+  box-shadow: inset 0 0 0 0.1rem $au-yellow-400;
+}
+
+.au2-input--block {
+  display: block;
+  width: 100%;
+}
+
+.au2-input--error {
+  border: .1rem solid $au-red-500;
+}
+
+.au2-input-with-icon {
+  display: block;
+  position: relative;
+  width: 100%;
+  height: 3.6rem;
+
+  .au2-input {
+    padding-left: 3rem;
+  }
+
+  svg {
+    left: 0.8rem;
+    opacity: 0.75;
+    position: absolute;
+    top: 0.9rem;
+    width: 1.8rem;
+    height: 1.8rem;
+  }
+}


### PR DESCRIPTION
# 🔎 KAS-1776: Use AU input for search component
In deze PR hebben we het input element in het agendaitem-search component vervangen door de AU versie van input.
Het component was er al, enkel styling toegevoegd.

## ✏️ What has changed
- Styling file toegevoegd voor de AU component
- Prefix aangepast van `c` naar `au2` op vraag van Johan Ronsse

## 🖼 Screenshots
### Before
Overview:
![image](https://user-images.githubusercontent.com/11557630/94916422-f2d81480-04ae-11eb-8883-58def61a1aad.png)

Detail:
![image](https://user-images.githubusercontent.com/11557630/94916471-05eae480-04af-11eb-9600-1fdf78ad4f2c.png)


### After
Overview:
![image](https://user-images.githubusercontent.com/11557630/94916523-1b600e80-04af-11eb-9edf-d9b3ec717c1e.png)

Detail:
![image](https://user-images.githubusercontent.com/11557630/94916497-100ce300-04af-11eb-8d72-168d1ef7390c.png)
