### PR TITLE
KAS-1884: Reset controller in route.js class

### DIFF
--- a/app/pods/search/route.js
+++ b/app/pods/search/route.js
@@ -21,8 +21,8 @@ export default class SearchRoute extends Route.extend(AuthenticatedRouteMixin) {
     },
   };
 
-  resetController(controller, isExiting, transition) {
-    if (isExiting && transition.targetName !== 'error') {
+  resetController(controller, isExiting) {
+    if (isExiting) {
       controller.set('searchText', null);
       controller.set('mandatees', null);
       controller.set('dateFrom', null);

--- a/app/pods/search/route.js
+++ b/app/pods/search/route.js
@@ -21,6 +21,15 @@ export default class SearchRoute extends Route.extend(AuthenticatedRouteMixin) {
     },
   };
 
+  resetController(controller, isExiting, transition) {
+    if (isExiting && transition.targetName !== 'error') {
+      controller.set("searchText", null);
+      controller.set("mandatees", null);
+      controller.set("dateFrom", null);
+      controller.set("dateTo", null);
+    }
+  }
+
   setupController(controller, model) {
     super.setupController(controller, model);
     const params = this.paramsFor('search');

--- a/app/pods/search/route.js
+++ b/app/pods/search/route.js
@@ -23,10 +23,10 @@ export default class SearchRoute extends Route.extend(AuthenticatedRouteMixin) {
 
   resetController(controller, isExiting, transition) {
     if (isExiting && transition.targetName !== 'error') {
-      controller.set("searchText", null);
-      controller.set("mandatees", null);
-      controller.set("dateFrom", null);
-      controller.set("dateTo", null);
+      controller.set('searchText', null);
+      controller.set('mandatees', null);
+      controller.set('dateFrom', null);
+      controller.set('dateTo', null);
     }
   }
 

--- a/cypress/integration/unit/search.spec.js
+++ b/cypress/integration/unit/search.spec.js
@@ -39,7 +39,7 @@ context('Search tests', () => {
     });
   };
 
-  it('Should change the amount of elements to every value in selectbox in agendapunten search view', () => {
+  /*it('Should change the amount of elements to every value in selectbox in agendapunten search view', () => {
     cy.visit('zoeken/agendapunten');
     searchFunction(options);
     cy.existsAndVisible('.ember-power-select-trigger')
@@ -135,7 +135,7 @@ context('Search tests', () => {
     cy.wait('@searchCall');
 
     cy.get('[data-table]').should('not.exist');
-  });
+  });*/
 
   it('Search for funky searchterms in agendaitems', () => {
     cy.visit('/zoeken/agendapunten');
@@ -156,6 +156,12 @@ context('Search tests', () => {
 
       cy.get('[data-table]').contains('korte titel for batterij');
     });
+
+    cy.get('[data-test-m-header-settings]').click();
+    cy.get('[data-test-m-header-search]').click();
+
+    cy.wait(1000);
+    cy.get('[data-test-searchfield]').should('have.value','');
   });
 
   it('Search for funky searchterms in dossiers', () => {

--- a/cypress/integration/unit/search.spec.js
+++ b/cypress/integration/unit/search.spec.js
@@ -3,6 +3,7 @@
 import search from '../../selectors/search.selectors';
 import agenda from '../../selectors/agenda.selectors';
 import form from '../../selectors/form.selectors';
+import toolbar from '../../selectors/toolbar.selectors';
 
 function currentTimestamp() {
   return Cypress.moment().unix();
@@ -166,17 +167,16 @@ context('Search tests', () => {
 
   it('Searchfield should be empty after revisting search page', () => {
     cy.visit('/zoeken/agendapunten');
-    cy.get('[data-test-searchfield]').clear();
-    cy.get('[data-test-searchfield]').type('TestSearchSet');
+    cy.get(search.searchfield).clear();
+    cy.get(search.searchfield).type('TestSearchSet');
     cy.server();
-    cy.route('GET', '/agendaitems/search?**').as('searchCall');
-    cy.get('button[data-test-trigger-search]').click();
-    cy.wait('@searchCall');
-    cy.get('[data-test-m-header-settings]').click();
+    cy.get(search.searchButtonToClick).click();
     cy.wait(1000);
-    cy.get('[data-test-m-header-search]').click();
+    cy.get(toolbar.settings).click();
     cy.wait(1000);
-    cy.get('[data-test-searchfield]').should('have.value', '');
+    cy.get(search.searchMenuLink).click();
+    cy.wait(1000);
+    cy.get(search.searchfield).should('have.value', '');
   });
 
   it('Search for funky searchterms in dossiers', () => {

--- a/cypress/integration/unit/search.spec.js
+++ b/cypress/integration/unit/search.spec.js
@@ -39,7 +39,7 @@ context('Search tests', () => {
     });
   };
 
-  /*it('Should change the amount of elements to every value in selectbox in agendapunten search view', () => {
+  it('Should change the amount of elements to every value in selectbox in agendapunten search view', () => {
     cy.visit('zoeken/agendapunten');
     searchFunction(options);
     cy.existsAndVisible('.ember-power-select-trigger')
@@ -135,7 +135,7 @@ context('Search tests', () => {
     cy.wait('@searchCall');
 
     cy.get('[data-table]').should('not.exist');
-  });*/
+  });
 
   it('Search for funky searchterms in agendaitems', () => {
     cy.visit('/zoeken/agendapunten');
@@ -158,10 +158,25 @@ context('Search tests', () => {
     });
 
     cy.get('[data-test-m-header-settings]').click();
-    cy.get('[data-test-m-header-search]').click();
-
     cy.wait(1000);
-    cy.get('[data-test-searchfield]').should('have.value','');
+    cy.get('[data-test-m-header-search]').click();
+    cy.wait(1000);
+    cy.get('[data-test-searchfield]').should('have.value', '');
+  });
+
+  it('Searchfield should be empty after revisting search page', () => {
+    cy.visit('/zoeken/agendapunten');
+    cy.get('[data-test-searchfield]').clear();
+    cy.get('[data-test-searchfield]').type('TestSearchSet');
+    cy.server();
+    cy.route('GET', '/agendaitems/search?**').as('searchCall');
+    cy.get('button[data-test-trigger-search]').click();
+    cy.wait('@searchCall');
+    cy.get('[data-test-m-header-settings]').click();
+    cy.wait(1000);
+    cy.get('[data-test-m-header-search]').click();
+    cy.wait(1000);
+    cy.get('[data-test-searchfield]').should('have.value', '');
   });
 
   it('Search for funky searchterms in dossiers', () => {

--- a/cypress/selectors/search.selectors.js
+++ b/cypress/selectors/search.selectors.js
@@ -1,5 +1,7 @@
 const selectors = {
   searchfield: '[data-test-searchfield]',
   searchButton: '[data-test-searchbutton]',
+  searchButtonToClick: 'button[data-test-trigger-search]',
+  searchMenuLink: '[data-test-m-header-search]',
 };
 export default selectors;


### PR DESCRIPTION
## KAS-1884 - Fixed query params search route
# Changes
 /pods/components/search/route.js functie "resetController" toegevoegd voor query parameters leeg te maken.