### PR TITLE
KAS-1915: Replaced .vl-modal in all tests by a selector

### DIFF
--- a/app/pods/components/utils/toaster/download-file-toast/template.hbs
+++ b/app/pods/components/utils/toaster/download-file-toast/template.hbs
@@ -1,5 +1,5 @@
 <ClickOutside @action={{@onClose}}>
-  <div class="vl-modal">
+  <div class="vl-modal" data-test-vl-modal>
     <WebComponents::VlAlert
       class="vl-alert-relative vl-alert-relative--center-mid"
       aria-live="assertive"

--- a/app/pods/components/utils/toaster/revert-action-toast/template.hbs
+++ b/app/pods/components/utils/toaster/revert-action-toast/template.hbs
@@ -1,4 +1,4 @@
-<div class="vl-modal">
+<div class="vl-modal" data-test-vl-modal>
   {{!-- TODO: revise custom CSS classes that get loaded on top of generic alert classes --}}
   <WebComponents::VlAlert
     class="vl-alert-relative vl-alert-relative--center-mid"

--- a/app/pods/components/utils/toaster/toast/template.hbs
+++ b/app/pods/components/utils/toaster/toast/template.hbs
@@ -1,5 +1,5 @@
 <ClickOutside @action={{@onClose}}>
-  <div class="vl-modal">
+  <div class="vl-modal" data-test-vl-modal>
       {{!-- TODO: revise custom CSS classes that get loaded on top of generic alert classes --}}
       <WebComponents::VlAlert
         class="vl-alert-relative vl-alert-relative--center-mid"

--- a/app/pods/components/web-components/vl-modal-verify/template.hbs
+++ b/app/pods/components/web-components/vl-modal-verify/template.hbs
@@ -1,4 +1,4 @@
-<div class="vl-modal" data-test-vl-modal-verify-container>
+<div class="vl-modal" data-test-vl-modal data-test-vl-modal-verify-container>
   <div class="vl-modal__backdrop">
     <div class="vl-modal-dialog {{sizeClass}}"
          style="width: 60rem;"

--- a/app/pods/components/web-components/vl-modal/template.hbs
+++ b/app/pods/components/web-components/vl-modal/template.hbs
@@ -1,4 +1,4 @@
-<div class="vl-modal" data-test-vl-modal-container>
+<div class="vl-modal" data-test-vl-modal-container data-test-vl-modal>
   <div class={{backdropClass}}>
     {{#click-outside
       action=(action "clickOutside")

--- a/cypress/integration/unit/decision.spec.js
+++ b/cypress/integration/unit/decision.spec.js
@@ -110,7 +110,7 @@ context('Add files to an agenda', () => {
           });
       });
 
-    cy.get('.vl-modal').within(() => {
+    cy.get(modal.modal).within(() => {
       cy.get('button').contains('Verwijderen')
         .click();
     });
@@ -135,7 +135,7 @@ context('Add files to an agenda', () => {
       cy.get('.vl-u-text--error').contains('Document verwijderen')
         .click();
     });
-    cy.get('.vl-modal').within(() => {
+    cy.get(modal.modal).within(() => {
       cy.get('button').contains('Verwijderen')
         .click();
     });

--- a/cypress/integration/unit/file-upload.spec.js
+++ b/cypress/integration/unit/file-upload.spec.js
@@ -1,5 +1,6 @@
 /* global context, before, it, cy,beforeEach */
 // / <reference types="Cypress" />
+import modal from '../../selectors/modal.selectors';
 
 context('Add files to an agenda', () => {
   before(() => {
@@ -126,7 +127,7 @@ context('Add files to an agenda', () => {
     cy.route('DELETE', 'pieces/*').as('deletePiece');
     cy.route('DELETE', 'document-containers/*').as('deleteDocumentContainer');
 
-    cy.get('.vl-modal').within(() => {
+    cy.get(modal.modal).within(() => {
       cy.get('button').contains('Verwijderen')
         .click();
     });
@@ -156,7 +157,7 @@ context('Add files to an agenda', () => {
     cy.route('DELETE', 'pieces/*').as('deletePiece');
     cy.route('DELETE', 'document-containers/*').as('deleteDocumentContainer');
 
-    cy.get('.vl-modal').within(() => {
+    cy.get(modal.modal).within(() => {
       cy.get('button').contains('Verwijderen')
         .click();
     });

--- a/cypress/integration/unit/meeting-actions.spec.js
+++ b/cypress/integration/unit/meeting-actions.spec.js
@@ -1,5 +1,6 @@
 /* global context, it, cy,beforeEach */
 // / <reference types="Cypress" />
+import modal from '../../selectors/modal.selectors';
 
 context('meeting actions tests', () => {
   beforeEach(() => {
@@ -81,7 +82,7 @@ context('meeting actions tests', () => {
       });
     });
 
-    cy.get('.vl-modal').within(() => {
+    cy.get(modal.modal).within(() => {
       cy.get('.vl-button').contains('Verwijderen')
         .click();
     });
@@ -97,7 +98,7 @@ context('meeting actions tests', () => {
     cy.wait('@patchSubcase', {
       timeout: 12000,
     });
-    cy.get('.vl-modal').should('not.be.visible');
+    cy.get(modal.modal).should('not.be.visible');
 
     // Verify subcase is no longer on designagenda after deleting the agendaitem
     cy.changeSelectedAgenda('Agenda A');

--- a/cypress/selectors/modal.selectors.js
+++ b/cypress/selectors/modal.selectors.js
@@ -22,5 +22,6 @@ const selectors = {
     save: '[data-test-vl-modal-verify-save]',
   },
   modalDialog: '[data-test-vl-modal-dialog]',
+  modal: '[data-test-vl-modal]',
 };
 export default selectors;

--- a/cypress/support/commands/agenda-commands.js
+++ b/cypress/support/commands/agenda-commands.js
@@ -744,7 +744,7 @@ function releaseDecisions() {
     .contains('Acties')
     .click();
   cy.get(actionModel.releaseDecisions).click();
-  cy.get('.vl-modal').within(() => {
+  cy.get(modal.modal).within(() => {
     cy.get('.vl-button').contains('Vrijgeven')
       .click();
   });
@@ -764,7 +764,7 @@ function releaseDocuments() {
     .contains('Acties')
     .click();
   cy.get(actionModel.releaseDocuments).click();
-  cy.get('.vl-modal').within(() => {
+  cy.get(modal.modal).within(() => {
     cy.get('.vl-button').contains('Vrijgeven')
       .click();
   });


### PR DESCRIPTION
# KAS-1915: Als ontwikkelaar wil ik in de testen .vl-modal als selector gebruiken

## Files Modified

- modified: app/pods/components/utils/toaster/download-file-toast/template.hbs
- modified: app/pods/components/utils/toaster/revert-action-toast/template.hbs
- modified: app/pods/components/utils/toaster/toast/template.hbs
- modified: app/pods/components/web-components/vl-modal-verify/template.hbs
- modified: app/pods/components/web-components/vl-modal/template.hbs
- modified: cypress/integration/unit/decision.spec.js
- modified: cypress/integration/unit/file-upload.spec.js
- modified: cypress/integration/unit/meeting-actions.spec.js
- modified: cypress/selectors/modal.selectors.js
- modified: cypress/support/commands/agenda-commands.js