### PR TITLE
KAS-1756: Added last login and created in user detail setting

### DIFF
--- a/app/models/account.js
+++ b/app/models/account.js
@@ -11,4 +11,6 @@ export default Model.extend({
   user: belongsTo('person'),
   gebruiker: alias('user'),
   voId: attr('string'),
+  created: attr('datetime'),
+  lastLogin: attr('datetime'),
 });

--- a/app/pods/settings/users/user/template.hbs
+++ b/app/pods/settings/users/user/template.hbs
@@ -31,6 +31,8 @@
         <pl.Body>
           <KeyValue @layout="horizontal" @key="{{t 'manage-users-void'}}" @value="{{model.account.voId}}"/>
           <KeyValue @layout="horizontal" @key="{{t 'manage-users-ovo'}}" @value="{{if model.organization.identifier model.organization.identifier "-"}}"/>
+          <KeyValue data-test-user-detail-created @layout="horizontal" @key="{{t 'manage-users-created'}}" @value="{{if model.account.created (moment-format model.account.created "DD-MM-YYYY [om] HH:mm") "-"}}"/>
+          <KeyValue data-test-user-detail-last-login @layout="horizontal" @key="{{t 'manage-users-last-login'}}" @value="{{if model.account.lastLogin (moment-format model.account.lastLogin "DD-MM-YYYY [om] HH:mm") "-"}}"/>
         </pl.Body>
       </Panel>
     </div>

--- a/cypress/integration/unit/settings/general/shouldTestSettingsOverviewPage.spec.js
+++ b/cypress/integration/unit/settings/general/shouldTestSettingsOverviewPage.spec.js
@@ -189,4 +189,30 @@ context('Settings overview page tests', () => {
       cy.contains('kabinet');
     });
   });
+
+  it('Should see created and lastLogin date as admin in overview', () => {
+    cy.route('GET', '/users?filter=**').as('filterUsers');
+    cy.get(settings.manageUsers).contains('Gebruikersbeheer')
+      .click();
+    cy.url().should('include', 'instellingen/gebruikers');
+    cy.get(settings.userSearchInput).should('exist')
+      .should('be.visible')
+      .type('Admin');
+    cy.get(settings.settingsUserTable).should('contain', 'Admin');
+    cy.get(settings.userSearchButton).click()
+      .then(() => {
+        cy.wait('@filterUsers');
+        cy.get(settings.goToUserDetail).should('exist')
+          .should('be.visible')
+          .click();
+      });
+    cy.get(settings.userDetailCreated).within(()=> {
+      cy.contains('Gebruiker aangemaakt');
+      cy.contains('-');
+    });
+    cy.get(settings.userDetailLastLogin).within(()=> {
+      cy.contains('Laatst aangemeld');
+      cy.contains('-');
+    });
+  });
 });

--- a/cypress/selectors/settings.selectors.js
+++ b/cypress/selectors/settings.selectors.js
@@ -27,5 +27,7 @@ const selectors = {
   goToUserDetail: '[data-test-agenda-overview-sub-item]',
   emberPowerSelectTrigger: '.ember-power-select-trigger',
   emberPowerSelectOption: '.ember-power-select-option',
+  userDetailCreated: '[data-test-user-detail-created]',
+  userDetailLastLogin: '[data-test-user-detail-last-login]',
 };
 export default selectors;

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -551,6 +551,8 @@
   "manage-users-group": "Groep",
   "manage-users-void": "VO-ID",
   "manage-users-ovo": "OVO-code",
+  "manage-users-created": "Gebruiker aangemaakt",
+  "manage-users-last-login": "Laatst aangemeld",
   "manage-users-general-info": "Algemene informatie",
   "manage-users-technical-info": "Technische informatie",
   "manage-user": "Gebruiker: {firstName} {lastName}",


### PR DESCRIPTION
# KAS-1756: Added first and last login to user detail setting page

## Other pull request
- acmidm-login-service: https://github.com/kanselarij-vlaanderen/acmidm-login-service/pull/7 
- kaleidos-project: https://github.com/kanselarij-vlaanderen/kaleidos-project/pull/124 

## Files modified:
- modified: app/models/account.js
- modified: app/pods/settings/users/user/template.hbs
- modified: cypress/integration/unit/settings/general/shouldTestSettingsOverviewPage.spec.js
- modified: cypress/selectors/settings.selectors.js
- modified: translations/nl-be.json
