### PR TITLE
KAS-1786: Remove old css that seems not to be used

### DIFF
--- a/app/styles/custom-components/_vlc-side-nav.scss
+++ b/app/styles/custom-components/_vlc-side-nav.scss
@@ -80,12 +80,6 @@
     display: none;
   }
 
-  .vlc-side-nav-toggle{
-    .vl-vi {
-      @include vi-nav-right;
-    }
-  }
-
   .vlc-side-nav-item__meta--small {
     display: block;
     font-size: 1.3rem;

--- a/app/styles/govflanders/components/_accordion.scss
+++ b/app/styles/govflanders/components/_accordion.scss
@@ -24,13 +24,3 @@
     }
   }
 }
-
-.js-vl-accordion__toggle,
-.vl-toggle,
-[data-vl-accordion-toggle] {
-  .js-vl-accordion--open & {
-    & > .vl-vi {
-      @include vi-u-90deg;
-    }
-  }
-}


### PR DESCRIPTION
# 🧹 KAS-1786: Remove old css that seems not to be used

## ✏️ What has changed
- removed CSS that seems like not to be used

## 📝 Note:
Ik heb geen changes gezien in de applicatie waar deze css gebruikt werd.. bij deze eruit gehaald.