### PR TITLE
KAS-1913: Alphabetical sort over numerical sort

### DIFF
--- a/app/models/agendaitem.js
+++ b/app/models/agendaitem.js
@@ -154,7 +154,7 @@ export default ModelWithModifier.extend({
   }),
 
   sortedMandatees: computed('mandatees.@each', function() {
-    return this.get('mandatees').sortBy('priority');
+    return this.get('mandatees').sortBy('priorityString');
   }),
 
   formallyOkToShow: computed('formallyOk', function() {

--- a/app/models/mandatee.js
+++ b/app/models/mandatee.js
@@ -41,4 +41,11 @@ export default Model.extend({
     }
     return `${this.get('title')}`;
   }),
+
+  /**
+   * sortby('priority') sorts numeric whereas the users expect alphabetical sort.
+   */
+  priorityString: computed('priority', function() {
+    return this.get('priority').toString();
+  }),
 });

--- a/app/models/newsletter-info.js
+++ b/app/models/newsletter-info.js
@@ -37,7 +37,7 @@ export default ModelWithModifier.extend({
     const treatment = await this.get('agendaItemTreatment');
     const subcase = await treatment.get('subcase');
     const mandatees = await subcase.get('mandatees');
-    const sortedMandatees = await mandatees.sortBy('priority');
+    const sortedMandatees = await mandatees.sortBy('priorityString');
     let proposalText = this.intl.t('proposal-text');
     const seperatorComma = ', ';
     const seperatorAnd = ' en ';

--- a/app/models/subcase.js
+++ b/app/models/subcase.js
@@ -148,7 +148,7 @@ export default ModelWithModifier.extend({
   },
 
   sortedMandatees: computed('mandatees.@each', function() {
-    return this.get('mandatees').sortBy('priority');
+    return this.get('mandatees').sortBy('priorityString');
   }),
 
   hasActivity: computed('agendaActivities', 'agendaActivities.@each', async function() {

--- a/app/services/agenda-service.js
+++ b/app/services/agenda-service.js
@@ -119,7 +119,7 @@ export default Service.extend({
     await selectedAgenda.hasMany('agendaitems').reload();
     let priorityToAssign = 0;
     const mandatees = await subcase.get('mandatees');
-    const sortedMandatees = await mandatees.sortBy('priority');
+    const sortedMandatees = await mandatees.sortBy('priorityString');
     const titles = sortedMandatees.map((mandatee) => mandatee.get('title'));
     const pressText = `${subcase.get('shortTitle')}\n${titles.join('\n')}`;
     const isAnnouncement = subcase.get('showAsRemark');


### PR DESCRIPTION
### Ministers in de verkeerde volgorde
sortby('priority') gebruikt de numerieke sort.
We willen een alfabetische sortering (1 en 12 voor 2 en 22)
Ember sort ondersteund geen custom sort callback dus vandaar een  computed field en sort op dit field.
<img width="1196" alt="Screenshot 2020-10-22 at 14 09 25" src="https://user-images.githubusercontent.com/592312/96869804-45826c00-1470-11eb-8180-58591e6f8584.png">
