### PR TITLE
Page-title for a document that is being viewed

### DIFF
--- a/app/pods/document-viewer/template.hbs
+++ b/app/pods/document-viewer/template.hbs
@@ -1,3 +1,4 @@
+{{page-title this.model.name}}
 <div class="vlc-u-box-model-maximize-height vlc-scroll-wrapper">
   <div class="vlc-scroll-wrapper__body full-height">
     {{#if (eq this.model.file.extension "pdf")}}


### PR DESCRIPTION
Bij het viewen van pdf-documenten staat de naam van het document nu in de titel van de window. Dit helpt editors van kort-bestek die vele documenten in browser-tabs open hebben staan om snel terug te vinden wat ze zoeken.