### PR TITLE
bugfix: KAS-1973 Ministers zijn fout in detail view bij edits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,6 @@ lint-html:
 
 icon-font:
 	- ./generate-icon-font.sh
+
+drc-up-d:
+	- docker-compose ${COMPOSE_FILE} up -d

--- a/app/pods/components/agenda/agendaitem/agendaitem-case/agendaitem-mandatees/component.js
+++ b/app/pods/components/agenda/agendaitem/agendaitem-case/agendaitem-mandatees/component.js
@@ -67,28 +67,34 @@ export default class AgendaitemMandatees extends Component {
 
   async constructMandateeRows() {
     const subcase = await this.subcase;
-    const iseCodes = await subcase.get('iseCodes');
-    let mandatees;
-    if (this.agendaitem) {
-      mandatees = await (await this.get('agendaitem.mandatees')).sortBy('priority');
-    } else {
-      mandatees = await (await this.get('subcase.mandatees')).sortBy('priority');
-    }
-    let selectedMandatee = await subcase.get('requestedBy');
-    const mandateeLength = mandatees.get('length');
-    if (mandateeLength === 1) {
-      selectedMandatee = mandatees.get('firstObject');
-    }
-    return Promise.all(mandatees.map(async(mandatee) => {
-      const filteredIseCodes = await this.getIseCodesOfMandatee(iseCodes, mandatee);
-      const row = await this.createMandateeRow(mandatee, filteredIseCodes);
-      if (selectedMandatee && mandatee.get('id') === selectedMandatee.get('id')) {
-        row.set('isSubmitter', true);
-      } else if (mandateeLength === 0) {
-        row.set('isSubmitter', true);
+    // we hit this multiple times when loading the component, the first time subcase is null and will throw an error if we don't check ths
+    // This could possibly be fixed by adding subcase to the model in the route instead of awaiting in templates
+    if (subcase) {
+      const iseCodes = await subcase.get('iseCodes');
+      console.log('subcase', iseCodes);
+      let mandatees;
+      if (this.agendaitem) {
+        mandatees = await (await this.get('agendaitem.mandatees')).sortBy('priority');
+      } else {
+        mandatees = await (await this.get('subcase.mandatees')).sortBy('priority');
       }
-      return row;
-    }));
+      let selectedMandatee = await subcase.get('requestedBy');
+      const mandateeLength = mandatees.get('length');
+      if (mandateeLength === 1) {
+        selectedMandatee = mandatees.get('firstObject');
+      }
+      return Promise.all(mandatees.map(async(mandatee) => {
+        const filteredIseCodes = await this.getIseCodesOfMandatee(iseCodes, mandatee);
+        const row = await this.createMandateeRow(mandatee, filteredIseCodes);
+        if (selectedMandatee && mandatee.get('id') === selectedMandatee.get('id')) {
+          row.set('isSubmitter', true);
+        } else if (mandateeLength === 0) {
+          row.set('isSubmitter', true);
+        }
+        return row;
+      }));
+    }
+    return [];
   }
 
   async parseDomainsAndMandatees() {
@@ -120,7 +126,7 @@ export default class AgendaitemMandatees extends Component {
 
   @action
   async cancelEditing() {
-    this.set('mandateeRows', await this.constructMandateeRows());
+    this.notifyPropertyChange('mandateeRows');
     this.toggleProperty('isEditing');
   }
 

--- a/app/pods/components/agenda/agendaitem/agendaitem-case/agendaitem-mandatees/component.js
+++ b/app/pods/components/agenda/agendaitem/agendaitem-case/agendaitem-mandatees/component.js
@@ -71,7 +71,6 @@ export default class AgendaitemMandatees extends Component {
     // This could possibly be fixed by adding subcase to the model in the route instead of awaiting in templates
     if (subcase) {
       const iseCodes = await subcase.get('iseCodes');
-      console.log('subcase', iseCodes);
       let mandatees;
       if (this.agendaitem) {
         mandatees = await (await this.get('agendaitem.mandatees')).sortBy('priority');

--- a/app/pods/components/cases/subcase-mandatees/component.js
+++ b/app/pods/components/cases/subcase-mandatees/component.js
@@ -121,7 +121,6 @@ export default Component.extend({
         } else {
           mandateeRow.set('isSubmitter', false);
         }
-        return mandateeRow;
       });
     },
   },

--- a/app/pods/components/cases/subcase-mandatees/component.js
+++ b/app/pods/components/cases/subcase-mandatees/component.js
@@ -59,7 +59,11 @@ export default Component.extend({
             ...newRow,
           }
         ));
-        this.set('mandateeRows', mandateeRows.sortBy('mandateePriority'));
+        /*
+          There used to be a set('mandateeRows') here, this was causing bugs (KAS-1973)
+          The computed in de parent views (agendaitem-mandatees, subcase-mandatees) was being overridden with this set
+          This prevented the computed from reloading the rows after changing, showing wrong mandatees when changing detail view between agendaitems.
+        */
       }
     },
 
@@ -111,7 +115,7 @@ export default Component.extend({
 
     async valueChanged(changedMandateeRow) {
       const mandateeRows = await this.mandateeRows;
-      const newRows = mandateeRows.map((mandateeRow) => {
+      mandateeRows.map((mandateeRow) => {
         if (mandateeRow === changedMandateeRow) {
           mandateeRow.set('isSubmitter', true);
         } else {
@@ -119,7 +123,6 @@ export default Component.extend({
         }
         return mandateeRow;
       });
-      this.set('mandateeRows', newRows);
     },
   },
 });

--- a/app/pods/components/subcase/subcase-case/subcase-mandatees/component.js
+++ b/app/pods/components/subcase/subcase-case/subcase-mandatees/component.js
@@ -114,7 +114,7 @@ export default class SubcaseMandatees extends Component {
 
   @action
   async cancelEditing() {
-    this.set('mandateeRows', await this.constructMandateeRows());
+    this.notifyPropertyChange('mandateeRows');
     this.toggleProperty('isEditing');
   }
 


### PR DESCRIPTION
# KAS-1973 ministers zijn fout in detail view
## Probleem:

In detail view van een agendapunt kan je op het tab dossier wisselen van agendapunt en de ministers veranderen constant en de juiste worden in de view geladen.

Als je echter begint te editen was er iets stuk, waardoor bij wisselen van agendapunten telkens dezelfde ministers werden getoont
Dit was zo bij:
Edit en annuleren,
Edit en saven (zonder changes),
Edit en saven (met change van indiener),
Edit en nieuwe ministers toevoegen en saven
Dit was niet zo bij:
Edit en verwijderen van een minister

## Oplossing:
Na onderzoek ontdekt dat er in de parent-view (agendaitem-mandatees) een computed "mandateeRows" zit.
Deze zorgt voor het correct weergeven van de rijen bij normale view (niet editeren)
Zonder edits ging deze elke keer je van agendapunt wisselt opnieuw computed, omdat het achterliggende model (agendaitem) was veranderd.
Na het uitvoeren van 1 van bovenstaande acties gebeurde de compute niet meer, waardoor de rijen dezelfde bleven.
Gevonden dat in een sub-component (cases/subcase-mandatees) de view is voor het editeren van de rijen.
In deze component gebeurde er een set van "mandateeRows", wat ervoor zorgde dat de computed overschreven werd van de parent view (agendaitem-mandatees)
Deze set gebeurde op nog plaatsen, zowel bij value change in dezelfde component als een cancelEditing method in de parent-view.
Bij cancelEditing moeten we wel de computed terug aanroepen, omdat de effectieve rijen zijn aangepast in de sub-component en dus nu stale zijn.
Daarom de notifyPropertyChange om deze te triggeren


Testen ontbreken nog en volgen achteraf, deze fix zou asap erdoor moeten, omdat er momenteel veel kans is op foute data.

De makefile is niet per se onderdeel van het ticket, maar dit heb ik lokaal even gebruikt en leek me wel een goede toevoeging eraan (lokaal opspinnen met de testdata zonder een reset te doen, dan kan je verder werken op data van gisteren zonder manueel een drc-up te moeten doen met alle correcte .yml files)

### Opgelet
Deze branch is afgetakt van acceptance, eerst mergen in acc en daarna laten terugstromen naar development