### PR TITLE
KAS-1985 document page for publication

### DIFF
--- a/app/pods/components/web-components/au-button/template.hbs
+++ b/app/pods/components/web-components/au-button/template.hbs
@@ -1,5 +1,9 @@
+{{!-- this should be auk-button, but there is no padding between the button and the icon 
+  replacing with vlc-button class, there was padding, but the font family was wrong.
+  using both vlc-button and auk-button gave the best result...
+--}}
 {{#if @route}}
-  <LinkTo class="auk-button {{this.skin}} {{this.size}} {{this.layout}} {{this.block}} {{this.icon}}" @route={{@route}} ...attributes>
+  <LinkTo class="vlc-button auk-button {{this.skin}} {{this.size}} {{this.layout}} {{this.block}} {{this.icon}}" @route={{@route}} ...attributes>
     <Button::InnerLayout @layout={{@layout}} @icon={{@icon}}>
       {{yield}}
     </Button::InnerLayout>
@@ -7,7 +11,7 @@
 {{/if}}
 
 {{#if @href}}
-  <a class="auk-button {{this.skin}} {{this.size}} {{this.layout}} {{this.block}} {{this.icon}}" href="{{@href}}">
+  <a class="vlc-button auk-button {{this.skin}} {{this.size}} {{this.layout}} {{this.block}} {{this.icon}}" href="{{@href}}">
     <Button::InnerLayout @layout={{@layout}} @icon={{@icon}}>
       {{yield}}
     </Button::InnerLayout>
@@ -15,7 +19,7 @@
 {{/if}}
 
 {{#unless (or @href @route)}}
-  <button class="auk-button {{this.skin}} {{this.size}} {{this.layout}} {{this.block}} {{this.icon}}" type="button" ...attributes>
+  <button class="vlc-button auk-button {{this.skin}} {{this.size}} {{this.layout}} {{this.block}} {{this.icon}}" type="button" ...attributes>
     <Button::InnerLayout @layout={{@layout}} @icon={{@icon}}>
       {{yield}}
     </Button::InnerLayout>

--- a/app/pods/publications/publication/documents/template.hbs
+++ b/app/pods/publications/publication/documents/template.hbs
@@ -36,7 +36,7 @@
                   {{t "request-translations"}}
                 </button>
               </li>
-              <li class="vlc-dropdown-menu__item vlc-dropdown-menu__item--action-danger">
+              <li class="vlc-dropdown-menu__item">
                 <button class="vl-link vl-link--block" type="button"
                   {{on "click" attacher.hide}}
                 >

--- a/app/pods/publications/publication/documents/template.hbs
+++ b/app/pods/publications/publication/documents/template.hbs
@@ -1,1 +1,57 @@
-<div>{{t "documents"}}</div>
+<div class="u-mb-3">
+  <WebComponents::AuToolbar>
+    <WebComponents::AuToolbar::Group @position="left">
+      <WebComponents::AuToolbar::Item>
+        <h4 class="auk-toolbar-complex__title">{{t "documents"}}</h4>
+      </WebComponents::AuToolbar::Item>
+    </WebComponents::AuToolbar::Group>
+    {{!-- This should be the way to go (multiple toolbar items, 1 button in each), but the buttons have no padding in between them --}}
+    {{!-- <WebComponents::AuToolbar::Group @position="right">
+      <WebComponents::AuToolbar::Item>
+        <WebComponents::AuButton @skin="secondary" @icon="chevron-down">{{t "requests"}}</WebComponents::AuButton>
+      </WebComponents::AuToolbar::Item>
+      <WebComponents::AuToolbar::Item>
+        <WebComponents::AuButton @skin="primary" @icon="plus">{{t "documents-add"}}</WebComponents::AuButton>
+      </WebComponents::AuToolbar::Item>
+    </WebComponents::AuToolbar::Group> --}}
+    {{!-- This way (1 toolbar item with multiple buttons), the buttons have padding in between them for some reason --}}
+    <WebComponents::AuToolbar::Group @position="right">
+      <WebComponents::AuToolbar::Item>
+        <WebComponents::AuButton @skin="secondary" @icon="chevron-down" @layout="icon-right">
+          {{t "requests"}}
+          <AttachPopover
+              @renderInPlace={{true}}
+              @class="ember-attacher-popper"
+              @hideOn="clickout click"
+              @showOn="click"
+              @animation="shift"
+              @placement="bottom"
+              as |attacher|
+          >
+            <ul class="vlc-dropdown-menu">
+              <li class="vlc-dropdown-menu__item">
+                <button class="vl-link vl-link--block" type="button"
+                  {{on "click" attacher.hide}}
+                >
+                  {{t "request-translations"}}
+                </button>
+              </li>
+              <li class="vlc-dropdown-menu__item vlc-dropdown-menu__item--action-danger">
+                <button class="vl-link vl-link--block" type="button"
+                  {{on "click" attacher.hide}}
+                >
+                  {{t "request-publish-preview"}}
+                </button>
+              </li>
+            </ul>
+          </AttachPopover>
+
+        </WebComponents::AuButton>
+        {{!-- <WebComponents::AuButton @skin="primary" @icon="plus">{{t "documents-add"}}</WebComponents::AuButton> --}}
+      </WebComponents::AuToolbar::Item>
+    </WebComponents::AuToolbar::Group>
+  </WebComponents::AuToolbar>
+</div>
+<div class="u-mb-3">
+  <FileUploader @multipleFiles="true"></FileUploader>
+</div>

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -665,5 +665,8 @@
   "publication-from-extenso": "Extenso",
   "publication-form-by-except": "Bij uitreksel",
   "publication-form-publication-date": "PublicatieDatum BS",
-  "publication-form-numac-nummer": "Numac nummer BS"
+  "publication-form-numac-nummer": "Numac nummer BS",
+  "requests":"Aanvragen",
+  "request-translations":"Vertaling(en) aanvragen",
+  "request-publish-preview":"Drukproef aanvragen" 
 }


### PR DESCRIPTION
## What has changed:

au-button aangepast, er was geen padding tussen de tekst en het icoon, uitleg staat in de template.
Ik denk dat dit anders zou moeten, maar is dan weer side-tracking op het effectieve ticket.

Template voor publicatie documenten opgesteld met de basics die vermeld zijn in het ticket:
- Titel documenten
- Knop met 2 dropdown acties
- Upload veld voor documenten
(de 2de knop van het design (documenten toevoegen) staat in commentaar, had it al gedaan maar is geen criteria in het ticket)
De design is hier wat verwarrend, is die upload nu een pop-up modal of in de template ?

Vertalingen toegevoegd voor de knoppen

![image](https://user-images.githubusercontent.com/22245223/98963079-8f0e2600-2507-11eb-9d1d-cb46e3380b66.png)
