### PR TITLE
KAS-1828: Disable detail drag

### DIFF
--- a/app/pods/components/agenda/agenda-detail/sidebar/component.js
+++ b/app/pods/components/agenda/agenda-detail/sidebar/component.js
@@ -3,7 +3,6 @@ import { action } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import { setAgendaitemsPriority } from 'fe-redpencil/utils/agendaitem-utils';
 
 export default class AgendaSidebar extends Component {
   @service sessionService;
@@ -15,7 +14,6 @@ export default class AgendaSidebar extends Component {
   @tracked isReAssigningPriorities = false;
 
   classNames = ['vlc-agenda-items'];
-  dragHandleClass = '.vlc-agenda-detail-sidebar__sub-item';
 
   @action
   selectAgendaitemAction(agendaitem) {
@@ -25,14 +23,5 @@ export default class AgendaSidebar extends Component {
   @action
   toggleChangesOnly() {
     this.isShowingChanges = !this.isShowingChanges;
-  }
-
-  @action
-  async reorderItems(itemModels) {
-    const isEditor = this.currentSessionService.isEditor;
-    const isDesignAgenda = this.args.currentAgenda.isDesignAgenda;
-    this.isReAssigningPriorities = true;
-    await setAgendaitemsPriority(itemModels, isEditor, isDesignAgenda);
-    this.isReAssigningPriorities = false;
   }
 }

--- a/app/pods/components/agenda/agenda-detail/sidebar/component.js
+++ b/app/pods/components/agenda/agenda-detail/sidebar/component.js
@@ -11,7 +11,6 @@ export default class AgendaSidebar extends Component {
   @alias('sessionService.selectedAgendaitem') selectedAgendaitem;
 
   @tracked isShowingChanges = false;
-  @tracked isReAssigningPriorities = false;
 
   classNames = ['vlc-agenda-items'];
 

--- a/app/pods/components/agenda/agenda-detail/sidebar/template.hbs
+++ b/app/pods/components/agenda/agenda-detail/sidebar/template.hbs
@@ -119,19 +119,3 @@
     </div>
   {{/if}}
 </div>
-
-{{#if (await isReAssigningPriorities)}}
-  <WebComponents::VlModal
-    @isOverlay={{true}}
-    @showCloseButton={{false}}
-    @title={{t "saving-agendaitem-title-message"}}
-  >
-    <WebComponents::VlLoader
-      @text={{concat
-        (t "saving-change-message")
-        " "
-        (t "please-be-patient")
-      }}
-    />
-  </WebComponents::VlModal>
-{{/if}}

--- a/app/pods/components/agenda/agenda-detail/sidebar/template.hbs
+++ b/app/pods/components/agenda/agenda-detail/sidebar/template.hbs
@@ -29,37 +29,25 @@
 {{/if}}
 <div class="{{spacerClass}}">
   {{#if (and currentSessionService.isEditor (not isShowingChanges))}}
-    {{#sortable-group
-      tagName="ul"
-      onChange=(action "reorderItems")
-    as |sortableGroup|
+    {{#each
+      @agendaitems
+    as |agendaitem|
     }}
-      {{#each
-        @agendaitems
-      as |agendaitem|
-      }}
-        {{#if agendaitem.groupName}}
-          <div class="vlc-list-section-header">
-            {{!-- TODO: these triple curlies are used for displaying a computed string with br tags in it.
-              These items concatenated by <br> should become a list that is iterated over in a .hbs template --}}
-            {{!-- template-lint-disable no-triple-curlies  --}}
-            {{{agendaitem.groupName}}}
-            {{!-- template-lint-enable no-triple-curlies  --}}
-          </div>
-        {{/if}}
-        {{#sortable-item
-          data-test-agenda-detail-sidebar-sub-item
-          tagName="li"
-          class="vlc-agenda-detail-sidebar__sub-item"
-          model=agendaitem
-          group=sortableGroup
-          distance=30
-          handle=dragHandleClass
-        }}
-          <Agenda::AgendaDetail::SidebarItem @agendaitem={{agendaitem}} @selectAgendaitem={{action "selectAgendaitemAction"}}  />
-        {{/sortable-item}}
-      {{/each}}
-    {{/sortable-group}}
+      {{#if agendaitem.groupName}}
+        <div class="vlc-list-section-header">
+          {{!-- TODO: these triple curlies are used for displaying a computed string with br tags in it.
+            These items concatenated by <br> should become a list that is iterated over in a .hbs template --}}
+          {{!-- template-lint-disable no-triple-curlies  --}}
+          {{{agendaitem.groupName}}}
+          {{!-- template-lint-enable no-triple-curlies  --}}
+        </div>
+      {{/if}}
+      <div
+        data-test-agenda-detail-sidebar-sub-item
+        class="vlc-agenda-detail-sidebar__sub-item">
+        <Agenda::AgendaDetail::SidebarItem @agendaitem={{agendaitem}} @selectAgendaitem={{action "selectAgendaitemAction"}}  />
+      </div>
+    {{/each}}
   {{else}}
     <ul>
       {{#each

--- a/app/pods/components/agenda/agenda-detail/sidebar/template.hbs
+++ b/app/pods/components/agenda/agenda-detail/sidebar/template.hbs
@@ -91,27 +91,14 @@
 <div class="vl-u-spacer">
   {{#if (gt (await @announcements.length) 0)}}
     {{#if (and currentSessionService.isEditor (not isShowingChanges))}}
-      {{#sortable-group
-        tagName="ul"
-        onChange=(action "reorderItems")
-      as |sortableAnnouncements|
+      {{#each
+        (await @announcements)
+      as |announcement|
       }}
-        {{#each
-          (await @announcements)
-        as |announcement|
-        }}
-          {{#sortable-item
-            tagName="li"
-            class="vlc-agenda-detail-sidebar__sub-item"
-            model=announcement
-            group=sortableAnnouncements
-            distance=30
-            handle=dragHandleClass
-          }}
-            <Agenda::AgendaDetail::SidebarItem @agendaitem={{announcement}} @selectAgendaitem={{action "selectAgendaitemAction"}}/>
-          {{/sortable-item}}
-        {{/each}}
-      {{/sortable-group}}
+        <div class="vlc-agenda-detail-sidebar__sub-item">
+          <Agenda::AgendaDetail::SidebarItem @agendaitem={{announcement}} @selectAgendaitem={{action "selectAgendaitemAction"}}/>
+        </div>
+      {{/each}}
     {{else}}
       {{#each
         (await @announcements)

--- a/app/styles/custom-components/_vlc-agenda-detail-sidebar.scss
+++ b/app/styles/custom-components/_vlc-agenda-detail-sidebar.scss
@@ -52,6 +52,7 @@
 
 a.vlc-agenda-detail-sidebar__sub-item--active,
 a.vlc-agenda-detail-sidebar__sub-item--active:hover,
+a.vlc-agenda-detail-sidebar__sub-item--active:focus,
 a.vlc-agenda-detail-sidebar__sub-item--active:active {
   background: $science-blue;
   border: none;
@@ -127,6 +128,7 @@ a.vlc-agenda-detail-sidebar__sub-item--active:focus {
   text-align: right;
   margin-right: 0.5rem;
   line-height: 140%;
+  color: #333332;
 }
 
 // 'No items available' item


### PR DESCRIPTION
# 🔒 KAS-1828: Disable dragging in detail view of agenda
Deze PR zorgt ervoor dat je de volgorde van agendaitems niet meer kunt aanpassen vanuit de agenda-detail view.

## 📝 What has changed
- We hebben de sortable-group weggenomen uit de detail view om ervoor te zorgen dat je items niet meer kunt verslepen.
- Cleanup van ongebruikte code die ontstaan is door het wegnemen van de functionaliteit.

## 🖼 Screenshots
![image](https://user-images.githubusercontent.com/11557630/99400609-7034d880-28e7-11eb-8e5f-744f7a1cda5d.png)
