### PR TITLE
Feature/val 145 bump rdfa editor

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -24,7 +24,7 @@ module.exports = function(environment) {
       }
     ],
     featureFlags: {
-      'editor-html-paste': true,
+      'editor-html-paste': false,
     },
     EmberENV: {
       FEATURES: {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@glimmer/tracking": "^1.0.0",
     "@lblod/ember-acmidm-login": "^1.1.1",
     "@lblod/ember-mock-login": "^0.4.8",
-    "@lblod/ember-rdfa-editor": "0.40.0",
+    "@lblod/ember-rdfa-editor": "0.41.0-rc1.2",
     "@lblod/ember-rdfa-editor-plugin-system-dispatcher": "^0.5.8",
     "@lblod/ember-vo-webuniversum": "^0.19.12",
     "@lblod/ember-vo-webuniversum-data-table": "git+https://github.com/kanselarij-vlaanderen/ember-vo-webuniversum-data-table.git#abdfb0a93473ee910ebc9223b90b6d9487ed35c9",


### PR DESCRIPTION
- Bump van rdfa-editor zodanig dat delete key opnieuw ondersteund is
- Disable HTML paste: in de huidige use case van Kaleidos waar tekst voornl. gekopieerd wordt vanuit gescande PDF documenten zorgt het plakken van HTML voor meer problemen dan dat het oplost. Door gewoon platte tekst te plakken zouden een deel van de problemen ivm styling opgelost moeten zijn.