### PR TITLE
KAS-1997: implementeer opmerking tooltip

### DIFF
--- a/app/pods/publications/in-progress/in-progress-not-minister/template.hbs
+++ b/app/pods/publications/in-progress/in-progress-not-minister/template.hbs
@@ -59,14 +59,20 @@
         {{/if}} --}}
       </td>
       <td>
-        {{t "dash"}}
-        {{!-- <WebComponents::AuButton @skin="borderless" @layout="icon-only" @icon="comment" /> --}}
-        {{!-- {{#if row.internalComment}}
-        <WebComponents::AuButton @skin="borderless" @layout="icon-only" @icon="comment" id="comment-{{increment index}}">Hover over mij om de comment te bekijken</WebComponents::AuButton>
-        <EmberTooltip @tooltipClass="auk-tooltip" @targetId="comment-{{increment index}}" @side="left">
-          {{row.internalComment}}
-        </EmberTooltip>
-        {{/if}} --}}
+        {{#if row.remark}}
+          <WebComponents::AuButton @skin="borderless" @layout="icon-only" @icon="comment">
+            <AttachTooltip
+              @arrow="true"
+              @animation="fade"
+              @placement="left"
+              @class="auk-tooltip"
+            >
+              <p>
+                {{row.remark}}
+              </p>
+            </AttachTooltip>
+          </WebComponents::AuButton>
+        {{/if}}
       </td>
       <td>
         <WebComponents::AuButtonToolbar>


### PR DESCRIPTION
# KAS-1997: implementeer opmerking tooltip
In deze PR, voegen we de tooltip implementatie toe bij de publicatieflow nu dat het datamodel beschikbaar is.

## ✏️ What has changed
- Er is een opmerking icon toegevoegd aan de tabel wanneer je de publicatie een opmerking heeft.
- Een tooltip is zichtbaar wanneer je over de opmerking icon hovered
## 🖼 Screenshots
![image](https://user-images.githubusercontent.com/11557630/99700322-50daae80-2a93-11eb-8144-4ceede4ca9cb.png)
