### PR TITLE
KAS-1821: Move agendaitems if not formallyok

### DIFF
--- a/app/pods/components/agenda/agenda-header/component.js
+++ b/app/pods/components/agenda/agenda-header/component.js
@@ -601,9 +601,9 @@ export default Component.extend(FileSaverMixin, {
         .approveAgendaAndCopyToDesignAgenda(session, agendaToApprove)
         .then(async(newAgenda) => {
           const agendaitems = await agendaToLock.get('agendaitems');
-          const newNotYetOKItems = agendaitems.filter((agendaitem) => agendaitem.get('isAdded') && agendaitem.get('formallyOk') === CONFIG.notYetFormallyOk);
+          const agendaitemsWithStatusDifferentFromFormallyOk = agendaitems.filter((agendaitem) => agendaitem.get('isAdded') && (agendaitem.get('formallyOk') === CONFIG.notYetFormallyOk || agendaitem.get('formallyOk') === CONFIG.formallyNok));
           await this.reloadAgendaitemsOfSubcases(agendaitems);
-          await this.destroyAgendaitemsList(newNotYetOKItems);
+          await this.destroyAgendaitemsList(agendaitemsWithStatusDifferentFromFormallyOk);
           await agendaToLock.hasMany('agendaitems').reload();
           const agendaitemsFormallyOk = await agendaToLock.get('agendaitems');
           const actualAgendaitems = agendaitemsFormallyOk.filter((agendaitem) => !agendaitem.showAsRemark && !agendaitem.isDeleted)

--- a/app/pods/components/agenda/side-nav/template.hbs
+++ b/app/pods/components/agenda/side-nav/template.hbs
@@ -34,8 +34,8 @@
     </div>
     <div class="vlc-scroll-wrapper__body">
       <ul>
-        {{#each (await agendas) as |agenda|}}
-          <li class="vlc-side-nav-item
+        {{#each (await agendas) as |agenda index|}}
+          <li data-test-agenda-sidenav-element={{index}} class="vlc-side-nav-item
               {{active-class
                 agenda
                 currentAgenda

--- a/cypress/integration/unit/agenda.spec.js
+++ b/cypress/integration/unit/agenda.spec.js
@@ -307,7 +307,7 @@ context('Agenda tests', () => {
 
     cy.get(agendaOverview.agendaEditFormallyOkButton).should('not.exist');
   });
-  it('Should add agendaitems to an agenda and set one of them to formally NOK and approve and close the agenda', () => {
+  it.only('Should add agendaitems to an agenda and set one of them to formally NOK and approve and close the agenda', () => {
     const testId = `testId=${currentTimestamp()}: `;
     const dateToCreateAgenda = Cypress.moment().add(3, 'weeks')
       .day(1)
@@ -383,6 +383,10 @@ context('Agenda tests', () => {
 
 
     cy.get(agendaOverview.agendaEditFormallyOkButton).should('not.exist');
+    cy.get('.vl-loader', {
+      timeout: 60000,
+    }).should('not.exist');
+    cy.contains(newSubcase2TitleShort).should('not.exist');
   });
 });
 

--- a/cypress/integration/unit/agenda.spec.js
+++ b/cypress/integration/unit/agenda.spec.js
@@ -306,8 +306,13 @@ context('Agenda tests', () => {
       .click();
 
     cy.get(agendaOverview.agendaEditFormallyOkButton).should('not.exist');
+    cy.get('.vl-loader', {
+      timeout: 60000,
+    }).should('not.exist');
+    cy.contains(newSubcase2TitleShort).should('not.exist');
   });
-  it.only('Should add agendaitems to an agenda and set one of them to formally NOK and approve and close the agenda', () => {
+
+  it('Should add agendaitems to an agenda and set one of them to formally NOK and approve and close the agenda', () => {
     const testId = `testId=${currentTimestamp()}: `;
     const dateToCreateAgenda = Cypress.moment().add(3, 'weeks')
       .day(1)
@@ -387,6 +392,12 @@ context('Agenda tests', () => {
       timeout: 60000,
     }).should('not.exist');
     cy.contains(newSubcase2TitleShort).should('not.exist');
+    cy.get(`[${agenda.agendaSidenavElement}="1"]`).click();
+    cy.get('.vl-loader', {
+      timeout: 60000,
+    }).should('not.exist');
+    cy.contains(newSubcase2TitleShort)
+      .should('not.exist');
   });
 });
 

--- a/cypress/selectors/agenda.selectors.js
+++ b/cypress/selectors/agenda.selectors.js
@@ -94,5 +94,6 @@ const selectors = {
     announcementRight: '[data-test-compare-announcement-right]',
   },
   agendaOverviewItemHeader: '[data-test-agenda-overview-agenda-item-header]',
+  agendaSidenavElement: 'data-test-agenda-sidenav-element',
 };
 export default selectors;

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -364,7 +364,7 @@
   "loading-text-inactive": "Even geduld",
   "please-be-patient": "Even geduld aub...",
   "approve-agenda-warning": "Deze agenda kan niet goedgekeurd worden zolang dat niet alle agendapunten formeel OK verklaard zijn.",
-  "approve-agenda-passable": "Deze agenda bevat nieuwe agendapunten die nog niet formeel OK verklaard zijn. Als u op doorgaan klikt worden de huidige agendapunten overgezet naar de volgende ontwerpagenda.",
+  "approve-agenda-passable": "Deze agenda bevat nieuwe agendapunten die (nog) niet formeel OK verklaard zijn. Als u op doorgaan klikt worden de huidige agendapunten overgezet naar de volgende ontwerpagenda.",
   "warning-text": "Venster sluiten",
   "continue": "Doorgaan",
   "warning-title": "Opgelet!",


### PR DESCRIPTION
# KAS-1821: Move agendaitems if not formallyok
In deze PR fixen we een bug in de implementatie van KAS-1821 waar de formeel niet ok agendapunten nog geagendeerd bleven op de goedgekeurde agenda.

## ✏️ What has changed
- Agendaitems die niet formeel ok zijn worden nu naar de nieuwe designagenda verplaatst bij het goedkeuren van een agenda.

## 🧪 Tests
- Pull request gemaakt om de impact te zien op de bestaande testen.