### PR TITLE
Feature/kas 2020 uri too long

### DIFF
--- a/app/models/agendaitem.js
+++ b/app/models/agendaitem.js
@@ -111,13 +111,11 @@ export default ModelWithModifier.extend({
     return PromiseObject.create({
       promise: this.get('pieces').then((pieces) => {
         if (pieces && pieces.get('length') > 0) {
-          const pieceIds = pieces.map((piece) => piece.get('id')).join(',');
-
           return this.store
             .query('document-container', {
               filter: {
-                pieces: {
-                  id: pieceIds,
+                agendaitem: {
+                  id: this.get('id'),
                 },
                 type: {
                   id: CONFIG.notaID,

--- a/app/models/agendaitem.js
+++ b/app/models/agendaitem.js
@@ -114,8 +114,10 @@ export default ModelWithModifier.extend({
           return this.store
             .query('document-container', {
               filter: {
-                agendaitem: {
-                  id: this.get('id'),
+                pieces: {
+                  agendaitem: {
+                    id: this.get('id'),
+                  },
                 },
                 type: {
                   id: CONFIG.notaID,

--- a/app/models/agendaitem.js
+++ b/app/models/agendaitem.js
@@ -68,19 +68,17 @@ export default ModelWithModifier.extend({
     return getPropertyLength(this, 'documentContainers');
   }),
 
-  linkedDocumentContainersLength: computed('linkedDocumentContainers', function() {
-    return getPropertyLength(this, 'linkedDocumentContainers');
-  }),
 
   documentContainers: computed('pieces.@each.name', function() {
     return PromiseArray.create({
       promise: this.get('pieces').then((pieces) => {
         if (pieces && pieces.get('length') > 0) {
-          const pieceIds = pieces.mapBy('id').join(',');
           return this.store.query('document-container', {
             filter: {
               pieces: {
-                id: pieceIds,
+                agendaitem: {
+                  id: this.get('id'),
+                },
               },
             },
             page: {
@@ -93,26 +91,6 @@ export default ModelWithModifier.extend({
     });
   }),
 
-  linkedDocumentContainers: computed('linkedPieces.@each', function() {
-    return PromiseArray.create({
-      promise: this.get('linkedPieces').then((pieces) => {
-        if (pieces && pieces.get('length') > 0) {
-          const pieceIds = pieces.mapBy('id').join(',');
-          return this.store.query('document-container', {
-            filter: {
-              pieces: {
-                id: pieceIds,
-              },
-            },
-            page: {
-              size: pieces.get('length'), // # documentContainers will always be <= # pieces
-            },
-            include: 'type,pieces,pieces.access-level,pieces.next-piece,pieces.previous-piece',
-          }).then((containers) => sortDocumentContainers(this.get('linkedPieces'), containers));
-        }
-      }),
-    });
-  }),
 
   number: deprecatingAlias('priority', {
     id: 'agendaitem-number-deprecated',

--- a/app/models/meeting.js
+++ b/app/models/meeting.js
@@ -42,15 +42,17 @@ export default Model.extend({
     return getPropertyLength(this, 'documentContainers');
   }),
 
+  // This computed does not seem to be used anywhere
   documentContainers: computed('pieces.@each.name', function() {
     return PromiseArray.create({
       promise: this.get('pieces').then((pieces) => {
         if (pieces && pieces.get('length') > 0) {
-          const pieceIds = pieces.mapBy('id').join(',');
           return this.store.query('document-container', {
             filter: {
               pieces: {
-                id: pieceIds,
+                meeting: {
+                  id: this.get('id'),
+                },
               },
             },
             page: {

--- a/app/models/subcase.js
+++ b/app/models/subcase.js
@@ -76,19 +76,17 @@ export default ModelWithModifier.extend({
     return getPropertyLength(this, 'documentContainers');
   }),
 
-  linkedDocumentContainersLength: computed('linkedDocumentContainers', function() {
-    return getPropertyLength(this, 'linkedDocumentContainers');
-  }),
 
   documentContainers: computed('pieces.@each.name', function() {
     return PromiseArray.create({
       promise: this.get('pieces').then((pieces) => {
         if (pieces && pieces.get('length') > 0) {
-          const pieceIds = pieces.mapBy('id').join(',');
           return this.store.query('document-container', {
             filter: {
               pieces: {
-                id: pieceIds,
+                subcase: {
+                  id: this.get('id'),
+                },
               },
             },
             page: {
@@ -101,26 +99,6 @@ export default ModelWithModifier.extend({
     });
   }),
 
-  linkedDocumentContainers: computed('linkedPieces.@each', function() {
-    return PromiseArray.create({
-      promise: this.get('linkedPieces').then((pieces) => {
-        if (pieces && pieces.get('length') > 0) {
-          const pieceIds = pieces.mapBy('id').join(',');
-          return this.store.query('document-container', {
-            filter: {
-              pieces: {
-                id: pieceIds,
-              },
-            },
-            page: {
-              size: pieces.get('length'), // # documentContainers will always be <= # pieces
-            },
-            include: 'type,pieces,pieces.access-level,pieces.next-piece,pieces.previous-piece',
-          }).then((containers) => sortDocumentContainers(this.get('linkedPieces'), containers));
-        }
-      }),
-    });
-  }),
 
   nameToShow: computed('subcaseName', function() {
     const {
@@ -135,21 +113,6 @@ export default ModelWithModifier.extend({
     }
     return 'No name found.';
   }),
-
-  // TODO unused method ?
-  async documentNumberOfPiece(piece) {
-    const documentContainers = await this.get('documentContainers');
-
-    const sortedDocumentContainers = documentContainers.sortBy('created');
-    const targetDocumentContainer = await piece.get('documentContainer');
-    let foundIndex;
-    sortedDocumentContainers.map((documentContainer, index) => {
-      if (documentContainer === targetDocumentContainer) {
-        foundIndex = index;
-      }
-    });
-    return foundIndex;
-  },
 
   sortedMandatees: computed('mandatees.@each', function() {
     return this.get('mandatees').sortBy('priority');


### PR DESCRIPTION
KAS-2020 Id's niet meegeven in de query omdat deze kunnen zorgen voor een te lange URL

# :pencil2: What has changed :

In de modellen agendaitem, subcase en meeting gebruikten we een query op document-containers met elke id van de pieces erin.
Deze queries zorgde voor problemen bij agendapunten met meer dan 160-ish documenten (getest met 150 en 175, 175 gaf de fout)
Die query aangepast om dezelfde data op te halen zonder al die id's te gebruiken.
+ opgemerkt dan sommige code niet gebruikt wordt en ineens opgekuist.

note: Lokaal heb ik af en toe andere foutmeldingen gekregen omdat de backend moeite heeft met die grote calls.
Dit probleem gaat vermoedelijk ook voorvallen op accept en prod.
Echter hielp refreshen van de pagina en de data geraakte wel geladen met alle data.
