### PR TITLE
Bugfix/kas 2041 show more documents

### DIFF
--- a/app/pods/components/agenda/agenda-overview/agenda-overview-item/template.hbs
+++ b/app/pods/components/agenda/agenda-overview/agenda-overview-item/template.hbs
@@ -83,7 +83,7 @@
             {{#if (not selectedAgendaitem)}}
               {{#if overheidCanViewDocuments}}
                 {{#if renderDetails}}
-                  {{#if (await @agendaitem.documentContainers)}}
+                  {{#if (await @agendaitem.sortedPieces)}}
                     <div class="vlc-hr"></div>
                     <Utils::PiecesListForItem
                       @isClickable={{true}}
@@ -93,7 +93,7 @@
                     {{#if (await @agendaitem.pieceNames)}}
                       <div class="vlc-hr"></div>
                       <Utils::PiecesListLazyLoaded
-                       @pieceNames={{@agendaitem.pieceNames}}
+                       @pieceNames={{await @agendaitem.pieceNames}}
                       />
                     {{/if}}
                   {{/if}}
@@ -101,7 +101,7 @@
                   {{#if (await @agendaitem.pieceNames)}}
                     <div class="vlc-hr"></div>
                     <Utils::PiecesListLazyLoaded
-                            @pieceNames={{@agendaitem.pieceNames}}
+                      @pieceNames={{await @agendaitem.pieceNames}}
                     />
                   {{/if}}
                 {{/if}}

--- a/app/pods/components/item-document/template.hbs
+++ b/app/pods/components/item-document/template.hbs
@@ -1,28 +1,28 @@
 <li class="vlc-document-list__item
 {{if
-  documentContainer.checkAdded
+  this.checkAdded
   "vlc-document-list__item vlc-document-list__item--active"
 }}">
-  {{#if (is-pending lastPiece)}}
+  {{#if (is-pending @piece)}}
     <div class="skeletal-loader" role="alert" aria-busy="true"></div>
   {{else if isClickable}}
-    <a href="" {{action "showPieceViewer" lastPiece}}>
+    <a href="" {{action "showPieceViewer" @piece}}>
       <i class="vl-badge__icon
       {{if
-        (and (not documentContainer.checkAdded) (not lastPiece.confidential))
+        (and (not this.checkAdded) (not @piece.confidential))
         "ki-document"
       }}
-      {{if documentContainer.checkAdded "ki-document-added"}}
-      {{if (await lastPiece.confidential) "ki-lock-closed"}}">
+      {{if this.checkAdded "ki-document-added"}}
+      {{if (await @piece.confidential) "ki-lock-closed"}}">
       </i>
-      {{await lastPieceName}}
+      {{await @piece.name}}
     </a>
   {{else}}
     <span>
       <i class="vl-badge__icon
-        {{if documentContainer.checkAdded "ki-document-added" "ki-document"}}">
+        {{if this.checkAdded "ki-document-added" "ki-document"}}">
       </i>
-      {{await lastPieceName}}
+      {{await @piece.name}}
     </span>
   {{/if}}
 </li>

--- a/app/pods/components/utils/pieces-list-for-item/component.js
+++ b/app/pods/components/utils/pieces-list-for-item/component.js
@@ -9,22 +9,25 @@ export default class PiecesListForItem extends Component {
   // TODO: Is het echt nodig om hier een @tracked te gebruiker? We visualiseren hier enkel?
   @tracked agendaitemOrSubcase = this.args.agendaitemOrSubcase;
 
-  @tracked moreThan20 = null;
-
-  get documentContainers() {
-    if (!this.agendaitemOrSubcase) {
-      return null;
+  get moreThan20() {
+    if (this.agendaitemOrSubcase) {
+      if (this.agendaitemOrSubcase.documentContainers) {
+        if (this.agendaitemOrSubcase.documentContainers.length > 20) {
+          return true;
+        }
+      }
     }
-    if (this.agendaitemOrSubcase.documentContainers) {
-      if (this.agendaitemOrSubcase.documentContainers.length > 20) {
-        this.moreThan20 = true;
-      } else {
-        this.moreThan20 = false;
+    return false;
+  }
+
+  get documentContainersLimited() {
+    if (this.agendaitemOrSubcase) {
+      if (this.agendaitemOrSubcase.documentContainers) {
+        if (this.agendaitemOrSubcase.documentContainers.length > 20) {
+          const containers = this.agendaitemOrSubcase.documentContainers;
+          return containers.content.splice(0, 20);
+        }
       }
-      if (this.isShowingAll) {
-        return this.agendaitemOrSubcase.documentContainers;
-      }
-      return this.agendaitemOrSubcase.documentContainers;
     }
     return null;
   }

--- a/app/pods/components/utils/pieces-list-for-item/component.js
+++ b/app/pods/components/utils/pieces-list-for-item/component.js
@@ -6,13 +6,11 @@ export default class PiecesListForItem extends Component {
   @tracked isClickable = this.args.isClickable;
 
   @tracked isShowingAll = false;
-  // TODO: Is het echt nodig om hier een @tracked te gebruiker? We visualiseren hier enkel?
-  @tracked agendaitemOrSubcase = this.args.agendaitemOrSubcase;
 
   get moreThan20() {
-    if (this.agendaitemOrSubcase) {
-      if (this.agendaitemOrSubcase.documentContainers) {
-        if (this.agendaitemOrSubcase.documentContainers.length > 20) {
+    if (this.args.agendaitemOrSubcase) {
+      if (this.args.agendaitemOrSubcase.sortedPieces) {
+        if (this.args.agendaitemOrSubcase.sortedPieces.length > 20) {
           return true;
         }
       }
@@ -20,12 +18,12 @@ export default class PiecesListForItem extends Component {
     return false;
   }
 
-  get documentContainersLimited() {
-    if (this.agendaitemOrSubcase) {
-      if (this.agendaitemOrSubcase.documentContainers) {
-        if (this.agendaitemOrSubcase.documentContainers.length > 20) {
-          const containers = this.agendaitemOrSubcase.documentContainers;
-          return containers.content.splice(0, 20);
+  get piecesLimited() {
+    if (this.args.agendaitemOrSubcase) {
+      if (this.args.agendaitemOrSubcase.sortedPieces) {
+        if (this.args.agendaitemOrSubcase.sortedPieces.length > 20) {
+          const sortedPieces = this.args.agendaitemOrSubcase.sortedPieces;
+          return sortedPieces.slice(0, 20);
         }
       }
     }

--- a/app/pods/components/utils/pieces-list-for-item/template.hbs
+++ b/app/pods/components/utils/pieces-list-for-item/template.hbs
@@ -1,22 +1,22 @@
 
-{{#if (is-pending agendaitemOrSubcase.documentContainers)}}
+{{#if (is-pending @agendaitemOrSubcase.sortedPieces)}}
   {{web-components/vl-loader text=(t "documents-loading-text")}}
 {{else}}
   <div class="grid-container">
     {{#if (and this.moreThan20 (not this.isShowingAll))}}
-      {{#each (await this.documentContainersLimited) as |documentContainer|}}
+      {{#each (await this.piecesLimited) as |piece|}}
         {{item-document
           item=@agendaitemOrSubcase
-          documentContainer=documentContainer
+          piece=piece
           isClickable=@isClickable
           useNewIcons=useNewIcons
         }}
       {{/each}}
     {{else}}
-      {{#each (await @agendaitemOrSubcase.documentContainers) as |documentContainer|}}
+      {{#each (await @agendaitemOrSubcase.sortedPieces) as |piece|}}
         {{item-document
           item=@agendaitemOrSubcase
-          documentContainer=documentContainer
+          piece=piece
           isClickable=@isClickable
           useNewIcons=useNewIcons
         }}

--- a/app/pods/components/utils/pieces-list-for-item/template.hbs
+++ b/app/pods/components/utils/pieces-list-for-item/template.hbs
@@ -3,14 +3,25 @@
   {{web-components/vl-loader text=(t "documents-loading-text")}}
 {{else}}
   <div class="grid-container">
-    {{#each (await documentContainers) as |documentContainer|}}
-      {{item-document
-        item=@agendaitemOrSubcase
-        documentContainer=documentContainer
-        isClickable=@isClickable
-        useNewIcons=useNewIcons
-      }}
-    {{/each}}
+    {{#if (and this.moreThan20 (not this.isShowingAll))}}
+      {{#each (await this.documentContainersLimited) as |documentContainer|}}
+        {{item-document
+          item=@agendaitemOrSubcase
+          documentContainer=documentContainer
+          isClickable=@isClickable
+          useNewIcons=useNewIcons
+        }}
+      {{/each}}
+    {{else}}
+      {{#each (await @agendaitemOrSubcase.documentContainers) as |documentContainer|}}
+        {{item-document
+          item=@agendaitemOrSubcase
+          documentContainer=documentContainer
+          isClickable=@isClickable
+          useNewIcons=useNewIcons
+        }}
+      {{/each}}
+    {{/if}}
   </div>
   {{#if this.moreThan20}}
     <button class="vlc-document-show-more-button" type="button" {{action "toggleShowingAll"}}>

--- a/app/pods/components/utils/pieces-list-lazy-loaded/component.js
+++ b/app/pods/components/utils/pieces-list-lazy-loaded/component.js
@@ -7,10 +7,8 @@ export default class PiecesListLazyLoaded extends Component {
 
   get moreThan20() {
     if (this.args.pieceNames) {
-      if (this.args.pieceNames) {
-        if (this.args.pieceNames.length > 20) {
-          return true;
-        }
+      if (this.args.pieceNames.length > 20) {
+        return true;
       }
     }
     return false;
@@ -18,11 +16,9 @@ export default class PiecesListLazyLoaded extends Component {
 
   get pieceNamesLimited() {
     if (this.args.pieceNames) {
-      if (this.args.pieceNames) {
-        if (this.args.pieceNames.length > 20) {
-          const pieceNames = this.args.pieceNames;
-          return pieceNames.slice(0, 20);
-        }
+      if (this.args.pieceNames.length > 20) {
+        const pieceNames = this.args.pieceNames;
+        return pieceNames.slice(0, 20);
       }
     }
     return null;

--- a/app/pods/components/utils/pieces-list-lazy-loaded/component.js
+++ b/app/pods/components/utils/pieces-list-lazy-loaded/component.js
@@ -1,6 +1,35 @@
-import Component from '@ember/component';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 
-export default Component.extend({
-  tagName: 'ul',
-  isClickable: null,
-});
+export default class PiecesListLazyLoaded extends Component {
+  @tracked isShowingAll = false;
+
+  get moreThan20() {
+    if (this.args.pieceNames) {
+      if (this.args.pieceNames) {
+        if (this.args.pieceNames.length > 20) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  get pieceNamesLimited() {
+    if (this.args.pieceNames) {
+      if (this.args.pieceNames) {
+        if (this.args.pieceNames.length > 20) {
+          const pieceNames = this.args.pieceNames;
+          return pieceNames.slice(0, 20);
+        }
+      }
+    }
+    return null;
+  }
+
+  @action
+  toggleShowingAll() {
+    this.isShowingAll = !this.isShowingAll;
+  }
+}

--- a/app/pods/components/utils/pieces-list-lazy-loaded/template.hbs
+++ b/app/pods/components/utils/pieces-list-lazy-loaded/template.hbs
@@ -1,10 +1,34 @@
 <div class="grid-container">
-  {{#each (await pieceNames) as |pieceName|}}
-    <li class="vlc-document-list__item vlc-document-list__item--loading">
-      <span>
-        <i class="vl-badge__icon ki-synchronize"></i>
-        {{pieceName}}
-      </span>
-    </li>
-  {{/each}}
+  {{#if (and this.moreThan20 (not this.isShowingAll))}}
+    {{#each this.pieceNamesLimited as |pieceName|}}
+      <li class="vlc-document-list__item vlc-document-list__item--loading">
+        <span>
+          <i class="vl-badge__icon ki-synchronize"></i>
+          {{pieceName}}
+        </span>
+      </li>
+    {{/each}}
+  {{else}}
+    {{#each (await @pieceNames) as |pieceName|}}
+      <li class="vlc-document-list__item vlc-document-list__item--loading">
+        <span>
+          <i class="vl-badge__icon ki-synchronize"></i>
+          {{pieceName}}
+        </span>
+      </li>
+    {{/each}}
+  {{/if}}
 </div>
+{{#if this.moreThan20}}
+  <button class="vlc-document-show-more-button" type="button" {{action "toggleShowingAll"}}>
+    <i class="{{if this.isShowingAll "ki-remove" "ki-plus"}} vl-icon vlc-document-show-more-button__icon "/>
+    <p  class="vlc-document-show-more-button__text">
+      {{#if this.isShowingAll }}
+        {{t "show-less"}}
+      {{else}}
+        {{t "show-more"}}
+      {{/if}}
+    </p>
+  </button>
+{{/if}}
+


### PR DESCRIPTION
KAS-2041 bug: "Toon meer" werkt niet zoals verwacht
## Opgelet: Deze is afgetakt van https://github.com/kanselarij-vlaanderen/kaleidos-frontend/pull/577

# :pencil2: What has changed: 
De "Toon meer" feature gefixt zodat deze default 20 documenten toont, bij klikken wordt de rest van de documenten geladen.
De "Toon minder" feature gaat terug naar max 20 documenten

Enkele het component en de template van components/utils/pieces-list-for-item zijn aangepast in dit ticket.