### PR TITLE
KAS-2013: Remove formeel ok from dossier view

### DIFF
--- a/app/pods/components/agenda/agendaitem/agendaitem-case/agendaitem-titles/template.hbs
+++ b/app/pods/components/agenda/agendaitem/agendaitem-case/agendaitem-titles/template.hbs
@@ -99,7 +99,9 @@
     class="pill-container vl-u-display-flex"
     data-test-agenda-subcasehidden-pill
   >
-    {{#if (and currentSession.isEditor @agendaitem.formallyOkToShow)}}
+    {{#if
+      (and @agendaitem.isDesignAgenda (and currentSession.isEditor @agendaitem.formallyOkToShow))
+    }}
       <span
         class="{{@agendaitem.formallyOkToShow.pillClassNames}}
         vl-u-spacer-extended-right-s"


### PR DESCRIPTION
# KAS-2013: Remove formeel ok from dossier view
in deze PR hebben we de formaliteit statussen verborgen wanneer we een agenda bekijken die afgesloten is.

## What has changed
- in de dossier pagina werd formeel ok nog weergeven, we hebben dat daar weggehaald.

## Screenshots
Overview
![image](https://user-images.githubusercontent.com/11557630/100442585-88a3b080-30a8-11eb-9923-bcd88d87475b.png)

Detail en dossier
![image](https://user-images.githubusercontent.com/11557630/100442615-948f7280-30a8-11eb-8892-def24ac70162.png)


