### PR TITLE
KAS-2043: Bugfixes design

### DIFF
--- a/app/breakpoints.js
+++ b/app/breakpoints.js
@@ -2,4 +2,5 @@ export default {
   mobile: '(max-width: 767px)',
   tablet: '(min-width: 768px) and (max-width: 991px)',
   desktop: '(min-width: 992px) and (max-width: 1200px)',
+  bigScreen: '(min-width:1640px)',
 };

--- a/app/pods/components/web-components/au-button/component.js
+++ b/app/pods/components/web-components/au-button/component.js
@@ -44,11 +44,4 @@ export default class Button extends Component {
     }
     return null;
   }
-
-  get icon() {
-    if (this.args.icon) {
-      return 'auk-button--icon ';
-    }
-    return null;
-  }
 }

--- a/app/pods/components/web-components/au-button/template.hbs
+++ b/app/pods/components/web-components/au-button/template.hbs
@@ -1,5 +1,5 @@
 <button
-  class="auk-button {{this.skin}} {{this.size}} {{this.layout}} {{this.disabled}} {{this.block}} {{this.icon}}"
+  class="auk-button {{this.skin}} {{this.size}} {{this.layout}} {{this.disabled}} {{this.block}}"
   type="button"
   disabled={{@disabled}}
   ...attributes

--- a/app/pods/components/web-components/au-label/component.js
+++ b/app/pods/components/web-components/au-label/component.js
@@ -1,5 +1,7 @@
 import Component from '@glimmer/component';
 
 export default class Label extends Component {
-
+  get required() {
+    return this.args.isRequired === true;
+  }
 }

--- a/app/pods/components/web-components/au-label/template.hbs
+++ b/app/pods/components/web-components/au-label/template.hbs
@@ -1,3 +1,6 @@
 <label class="auk-label" ...attributes>
   {{yield}}
+  {{#if this.required}}
+    <abbr>*</abbr>
+  {{/if}}
 </label>

--- a/app/pods/publications/publication/case/template.hbs
+++ b/app/pods/publications/publication/case/template.hbs
@@ -167,7 +167,7 @@
           </WebComponents::AuToolbar::Group>
           <WebComponents::AuToolbar::Group @position="right">
             <WebComponents::AuToolbar::Item>
-              <WebComponents::AuButton {{on "click" this.showContactPersonModal}} @skin="tertiary" @icon="plus" data-test-add-contactperson>{{t "add-contact"}}</WebComponents::AuButton>
+              <WebComponents::AuButton {{on "click" this.showContactPersonModal}} @skin="tertiary" @icon="add" data-test-add-contactperson>{{t "add-contact"}}</WebComponents::AuButton>
             </WebComponents::AuToolbar::Item>
           </WebComponents::AuToolbar::Group>
         </WebComponents::AuToolbar>
@@ -253,17 +253,19 @@
       @closeModal={{this.closeContactPersonModal}} />
     <WebComponents::AuModal::Body>
       <div class="auk-form-group-layout auk-form-group-layout--standard">
-        <div class='auk-form-group'>
-          <WebComponents::AuLabel for="firstNameInput">
-            {{t "first-name"}}
-          </WebComponents::AuLabel>
-          <WebComponents::AuInput {{on "blur" this.onFirstNameChanged}} type="text" id="firstNameInput" @block="true" />
-        </div>
-        <div class='auk-form-group'>
-          <WebComponents::AuLabel for="lastNameInput">
-            {{t "name"}}
-          </WebComponents::AuLabel>
-          <WebComponents::AuInput {{on "blur" this.onLastNameChanged}} type="text" id="lastNameInput" @block="true" />
+        <div class='auk-form-group auk-form-group--grid'>
+          <div>
+            <WebComponents::AuLabel for="firstNameInput">
+              {{t "first-name"}}
+            </WebComponents::AuLabel>
+            <WebComponents::AuInput {{on "blur" this.onFirstNameChanged}} type="text" id="firstNameInput" @block="true" />
+          </div>
+          <div>
+            <WebComponents::AuLabel for="lastNameInput">
+              {{t "name"}}
+            </WebComponents::AuLabel>
+            <WebComponents::AuInput {{on "blur" this.onLastNameChanged}} type="text" id="lastNameInput" @block="true" />
+          </div>
         </div>
         <div class='auk-form-group'>
           <WebComponents::AuLabel for="emailInput">{{t "email"}}</WebComponents::AuLabel>
@@ -286,7 +288,7 @@
         </WebComponents::AuToolbar::Group>
         <WebComponents::AuToolbar::Group @position="right">
           <WebComponents::AuToolbar::Item>
-            <WebComponents::AuButton @skin="primary" @icon="plus" {{on "click" this.addNewContactPerson}} data-test-add-contactperson-submit-button>
+            <WebComponents::AuButton @skin="primary" @icon="plus" @size="small" {{on "click" this.addNewContactPerson}} data-test-add-contactperson-submit-button>
               {{t "add"}}
             </WebComponents::AuButton>
           </WebComponents::AuToolbar::Item>

--- a/app/pods/publications/publication/controller.js
+++ b/app/pods/publications/publication/controller.js
@@ -7,12 +7,13 @@ import { action } from '@ember/object';
 import moment from 'moment';
 
 export default class PublicationController extends Controller {
-  @tracked collapsed = true;
+  @tracked collapsed = this.get('media.isBigScreen');
 
 
   statusOptions = [{
     id: CONFIG.publicationStatusToPublish.id,
     label: 'Te publiceren',
+    icon: 'add',
   }, {
     id: CONFIG.publicationStatusPublished.id,
     label: 'Gepubliceerd',
@@ -127,7 +128,6 @@ export default class PublicationController extends Controller {
     yield timeout(1000);
     this.model.save();
   }
-
 
   @action
   toggleSidebar() {

--- a/app/pods/publications/publication/controller.js
+++ b/app/pods/publications/publication/controller.js
@@ -7,13 +7,12 @@ import { action } from '@ember/object';
 import moment from 'moment';
 
 export default class PublicationController extends Controller {
-  @tracked collapsed = this.get('media.isBigScreen');
+  @tracked collapsed = !this.get('media.isBigScreen');
 
 
   statusOptions = [{
     id: CONFIG.publicationStatusToPublish.id,
     label: 'Te publiceren',
-    icon: 'add',
   }, {
     id: CONFIG.publicationStatusPublished.id,
     label: 'Gepubliceerd',

--- a/app/pods/publications/publication/template.hbs
+++ b/app/pods/publications/publication/template.hbs
@@ -3,10 +3,10 @@
     <WebComponents::AuToolbar::Group @position="left">
       <WebComponents::AuToolbar::Item>
         <div class="o-flex o-flex--vertical u-mt-2">
-          <WebComponents::AuBreadcrumb
+          <span class="auk-overline auk-u-muted"
                   data-test-publication-detail-menu-publication-number>
             {{uppercase (concat (t "publication-flow") " " this.model.publicationNumber)}}
-          </WebComponents::AuBreadcrumb>
+          </span>
           <h4 class="auk-toolbar-complex__title" data-test-publication-detail-menu-short-title>{{model.case.shortTitle}}</h4>
           <WebComponents::AuTabs @reversed="true">
             <WebComponents::AuTab @isHierarchicalBack="true" @route="publications.in-progress.in-progress-not-minister" data-test-publication-detail-menu-go-back-to-overview></WebComponents::AuTab>
@@ -47,97 +47,115 @@
         </WebComponents::AuToolbar>
       </WebComponents::AuNavbar>
       {{#if (not collapsed)}}
-        <div class="u-m-3">
-          <div class="auk-form-group">
-            <WebComponents::AuLabel>{{t 'publications-number'}}</WebComponents::AuLabel>
-            <WebComponents::AuInput type="number" value={{this.model.publicationNumber}} @block="true"
-              {{on "input" (perform this.setPublicationNumber)}} />
-          </div>
-          <div class="auk-form-group">
-            <WebComponents::AuLabel for="blockInput">{{t 'status'}}</WebComponents::AuLabel>
+        <div class="auk-scroll-wrapper">
+          <div class="auk-scroll-wrapper__body">
+            <div class="u-m-3">
+              <div class="auk-form-group">
+                <WebComponents::AuLabel>{{t 'publications-number'}}</WebComponents::AuLabel>
+                <WebComponents::AuInput type="number" value={{this.model.publicationNumber}} @block="true"
+                  {{on "input" (perform this.setPublicationNumber)}} />
+              </div>
+              <div class="auk-form-group">
+                <WebComponents::AuLabel for="blockInput">{{t 'status'}}</WebComponents::AuLabel>
 
-            <PowerSelect
-                         @options={{this.statusOptions}}
-                         @searchEnabled={{false}}
-                         @selected={{this.getPublicationStatus}}
-                         @onchange={{this.setPublicationStatus}} as |status|>
-              {{status.label}}
-            </PowerSelect>
+                <PowerSelect
+                        @options={{this.statusOptions}}
+                        @searchEnabled={{false}}
+                        @selected={{this.getPublicationStatus}}
+                        @onchange={{this.setPublicationStatus}} as |status|>
+                  {{status.label}}
+                </PowerSelect>
 
-          </div>
-          <div class="auk-form-group">
-            <WebComponents::AuLabel for="blockInput">{{t "kind-of-publication"}}</WebComponents::AuLabel>
-            <PowerSelect
-                    @options={{this.typeOptions}}
-                    @searchEnabled={{false}}
-                    @selected={{this.getPublicationType}}
-                    @onchange={{this.setPublicationType}} as |type|>
-              {{type.label}}
-            </PowerSelect>
-          </div>
-          <div class="auk-form-group">
-            <WebComponents::AuLabel>{{t "publication-form-numac-nummer"}}</WebComponents::AuLabel>
-            <WebComponents::AuInput type="number" value={{this.model.numacNumber}} @block="true"
-              {{on "input" (perform this.setNumacNumber)}} />
-          </div>
-          {{#if this.model.status.isToBePublished}}
-            <div class="auk-form-group">
-              <WebComponents::AuLabel>{{t 'extreme-publication-date'}}</WebComponents::AuLabel>
-              <EmberFlatpickr class="auk-input auk-input--block"
-                              aria-activedescendent="aria-activedescendent"
-                              aria-autocomplete="aria-autocomplete"
-                              aria-describedby="described by"
-                              placeholder="Kies een datum"
-                              @date={{this.getPublicationBeforeDate}}
-                              @dateFormat="d-m-Y"
-                              @onChange={{this.setPublicationBeforeDate}} />
-              {{#if this.expiredPublicationBeforeDate}}
-                <div class="auk-form-help-text auk-form-help-text--warning">
-                  <WebComponents::AuIcon @name="alert-triangle"/>
-                  {{t "date-expired"}}
+              </div>
+              <div class="auk-form-group">
+                <WebComponents::AuLabel for="blockInput">{{t "kind-of-publication"}}</WebComponents::AuLabel>
+                <PowerSelect
+                        @options={{this.typeOptions}}
+                        @searchEnabled={{false}}
+                        @selected={{this.getPublicationType}}
+                        @onchange={{this.setPublicationType}} as |type|>
+                  {{type.label}}
+                </PowerSelect>
+              </div>
+              <div class="auk-form-group">
+                <WebComponents::AuLabel>{{t "publication-form-numac-nummer"}}</WebComponents::AuLabel>
+                <WebComponents::AuInput type="number" value={{this.model.numacNumber}} @block="true"
+                  {{on "input" (perform this.setNumacNumber)}} />
+              </div>
+              {{#if this.model.status.isToBePublished}}
+                <div class="auk-form-group">
+                  <WebComponents::AuLabel>{{t 'extreme-publication-date'}}</WebComponents::AuLabel>
+                  <EmberFlatpickr class="auk-input auk-input--block"
+                                  aria-activedescendent="aria-activedescendent"
+                                  aria-autocomplete="aria-autocomplete"
+                                  aria-describedby="described by"
+                                  placeholder="dd-mm-jj"
+                                  @date={{this.getPublicationBeforeDate}}
+                                  @dateFormat="d-m-Y"
+                                  @onChange={{this.setPublicationBeforeDate}} />
+
+                  {{#if this.expiredPublicationBeforeDate}}
+                    <div class="auk-form-help-text auk-form-help-text--warning">
+                      <WebComponents::AuIcon @name="alert-triangle"/>
+                      {{t "date-expired"}}
+                    </div>
+                  {{/if}}
+                </div>
+                <div class="auk-form-group">
+                  <WebComponents::AuLabel>{{t 'extreme-translation-date'}}</WebComponents::AuLabel>
+                  <EmberFlatpickr class="auk-input auk-input--block"
+                                  aria-activedescendent="aria-activedescendent"
+                                  aria-autocomplete="aria-autocomplete"
+                                  aria-describedby="described by"
+                                  placeholder="dd-mm-jj"
+                                  @date={{this.getTranslationDate}}
+                                  @dateFormat="d-m-Y"
+                                  @onChange={{this.setTranslationDate}} />
+                  {{#if this.expiredTranslationDate}}
+                    <div class="auk-form-help-text auk-form-help-text--warning">
+                      <WebComponents::AuIcon @name="alert-triangle"/>
+                      {{t "date-expired"}}
+                    </div>
+                  {{/if}}
                 </div>
               {{/if}}
-            </div>
-            <div class="auk-form-group">
-              <WebComponents::AuLabel>{{t 'extreme-translation-date'}}</WebComponents::AuLabel>
-              <EmberFlatpickr class="auk-input auk-input--block"
-                              aria-activedescendent="aria-activedescendent"
-                              aria-autocomplete="aria-autocomplete"
-                              aria-describedby="described by"
-                              placeholder="Kies een datum"
-                              @date={{this.getTranslationDate}}
-                              @dateFormat="d-m-Y"
-                              @onChange={{this.setTranslationDate}} />
-              {{#if this.expiredTranslationDate}}
-                <div class="auk-form-help-text auk-form-help-text--warning">
-                  <WebComponents::AuIcon @name="alert-triangle"/>
-                  {{t "date-expired"}}
+              {{#if this.model.status.isPublished}}
+                <div class="auk-form-group">
+                  <WebComponents::AuLabel for="blockInput">{{t "publication-form-publication-date"}}</WebComponents::AuLabel>
+                  <EmberFlatpickr class="auk-input auk-input--block"
+                                  aria-activedescendent="aria-activedescendent"
+                                  aria-autocomplete="aria-autocomplete"
+                                  aria-describedby="described by"
+                                  placeholder="dd-mm-jj"
+                                  @date={{this.getPublicationDate}}
+                                  @dateFormat="d-m-Y"
+                                  @onChange={{this.setPublicationDate}} />
+                  {{#if this.expiredPublicationDate}}
+                    <div class="auk-form-help-text auk-form-help-text--warning">
+                      <WebComponents::AuIcon @name="alert-triangle"/>
+                      {{t "date-expired"}}
+                    </div>
+                  {{/if}}
                 </div>
               {{/if}}
+              <div class="auk-form-group">
+                <WebComponents::AuLabel>
+                  {{t "remark-title"}}
+                  <WebComponents::AuIcon @name="circle-info"/>
+                  <AttachTooltip
+                          @arrow="true"
+                          @animation="fade"
+                          @placement="bottom"
+                          @class="auk-tooltip"
+                  >
+                    <p>
+                      {{t "publication-sidebar-tooltip"}}
+                    </p>
+                  </AttachTooltip>
+                </WebComponents::AuLabel>
+                <WebComponents::AuTextarea rows="4" type="text" value={{this.getRemark}} {{on "input" (perform this.setRemark)}}></WebComponents::AuTextarea>
+              </div>
             </div>
-          {{/if}}
-          {{#if this.model.status.isPublished}}
-            <div class="auk-form-group">
-              <WebComponents::AuLabel for="blockInput">{{t "publication-form-publication-date"}}</WebComponents::AuLabel>
-              <EmberFlatpickr class="auk-input auk-input--block"
-                              aria-activedescendent="aria-activedescendent"
-                              aria-autocomplete="aria-autocomplete"
-                              aria-describedby="described by"
-                              placeholder="Kies een datum"
-                              @date={{this.getPublicationDate}}
-                              @dateFormat="d-m-Y"
-                              @onChange={{this.setPublicationDate}} />
-              {{#if this.expiredPublicationDate}}
-                <div class="auk-form-help-text auk-form-help-text--warning">
-                  <WebComponents::AuIcon @name="alert-triangle"/>
-                  {{t "date-expired"}}
-                </div>
-              {{/if}}
-            </div>
-          {{/if}}
-          <div class="auk-form-group">
-            <WebComponents::AuLabel>{{t "remark-title"}} <WebComponents::AuIcon @name="circle-info"/></WebComponents::AuLabel>
-            <WebComponents::AuTextarea rows="4" type="text" value={{this.getRemark}} {{on "input" (perform this.setRemark)}}></WebComponents::AuTextarea>
           </div>
         </div>
       {{/if}}

--- a/app/pods/publications/template.hbs
+++ b/app/pods/publications/template.hbs
@@ -60,9 +60,8 @@
             {{/if}}
             <div class="auk-form-group-layout auk-form-group-layout--standard">
               <div class='auk-form-group {{getClassForGroupNumber}}'>
-                <WebComponents::AuLabel for="publicationNumberInput">
+                <WebComponents::AuLabel for="publicationNumberInput" @isRequired={{true}}>
                   {{t "publications-number"}}
-                  <abbr>*</abbr>
                 </WebComponents::AuLabel>
                 <WebComponents::AuInput type="text" id="publicationNumberInput" class="auk-input--max-width"
                                         @block="true"
@@ -73,9 +72,8 @@
                 {{/if}}
               </div>
               <div class='auk-form-group {{getClassForGroupShortTitle}}'>
-                <WebComponents::AuLabel for="shortTitleInput">
+                <WebComponents::AuLabel for="shortTitleInput"  @isRequired={{true}}>
                   {{t "name-subcase"}}
-                  <abbr style="opacity: 0.5">*</abbr>
                 </WebComponents::AuLabel>
                 <WebComponents::AuTextarea id="shortTitleInput" @rows="2" @value={{mut publication.shortTitle}}
                                            data-test-create-publication-modal-short-title-textarea/>

--- a/app/pods/publications/template.hbs
+++ b/app/pods/publications/template.hbs
@@ -46,8 +46,10 @@
         </Navbar> --}}
       {{#if isShowingPublicationModal}}
         <WebComponents::AuModal data-test-auk-modal-publication-new>
-          <WebComponents::AuModal::Header @title={{t "publications-new-not-minister"}}
-                                                 @closeModal={{this.closePublicationModal}} />
+          <WebComponents::AuModal::Header
+                  @title={{t "publications-new-not-minister"}}
+                  @closeModal={{this.closePublicationModal}}
+          />
           <WebComponents::AuModal::Body>
             {{#if hasError}}
               <WebComponents::AuAlert data-test-auk-alert-error @title={{t "modal-error-alert-title"}} @skin="error"
@@ -59,7 +61,8 @@
             <div class="auk-form-group-layout auk-form-group-layout--standard">
               <div class='auk-form-group {{getClassForGroupNumber}}'>
                 <WebComponents::AuLabel for="publicationNumberInput">
-                  {{t "publications-number-required"}}
+                  {{t "publications-number"}}
+                  <abbr>*</abbr>
                 </WebComponents::AuLabel>
                 <WebComponents::AuInput type="text" id="publicationNumberInput" class="auk-input--max-width"
                                         @block="true"
@@ -70,7 +73,10 @@
                 {{/if}}
               </div>
               <div class='auk-form-group {{getClassForGroupShortTitle}}'>
-                <WebComponents::AuLabel for="shortTitleInput">{{t "name-subcase-required"}}</WebComponents::AuLabel>
+                <WebComponents::AuLabel for="shortTitleInput">
+                  {{t "name-subcase"}}
+                  <abbr style="opacity: 0.5">*</abbr>
+                </WebComponents::AuLabel>
                 <WebComponents::AuTextarea id="shortTitleInput" @rows="2" @value={{mut publication.shortTitle}}
                                            data-test-create-publication-modal-short-title-textarea/>
                 {{#if getClassForGroupShortTitle}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2280,9 +2280,9 @@
       }
     },
     "@kanselarij-vlaanderen/au-kaleidos-css": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@kanselarij-vlaanderen/au-kaleidos-css/-/au-kaleidos-css-1.12.1.tgz",
-      "integrity": "sha512-pVzi1KX7To1pEN6JPkBhIimeN7ZoEaPcza+0S8l2V+8dmnITnI/IL03cd6TkbRprnmHfNyr9gIArNarOEcbuBQ=="
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/@kanselarij-vlaanderen/au-kaleidos-css/-/au-kaleidos-css-1.13.4.tgz",
+      "integrity": "sha512-8YP8EGVTkbHkzHfSJC0g5D9VRadvuAPUiLWx8iDgYe3PhRaXuclgJxZ96oE3pVgWFb1acMdoioXezxXVoTaFqQ=="
     },
     "@kanselarij-vlaanderen/au-kaleidos-icons": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "ember-qunit": "^4.6.0",
     "ember-rdfa-helpers": "^0.2.1",
     "ember-resolver": "^7.0.0",
-    "ember-responsive": "^3.0.5",
+    "ember-responsive": "^3.0.6",
     "ember-sortable": "1.12.1",
     "ember-source": "~3.17.0",
     "ember-template-lint": "^2.4.0",
@@ -124,7 +124,7 @@
   },
   "dependencies": {
     "@kanselarij-vlaanderen/au-kaleidos-icons": "^1.2.2",
-    "@kanselarij-vlaanderen/au-kaleidos-css": "^1.12.0",
+    "@kanselarij-vlaanderen/au-kaleidos-css": "^1.13.4",
     "ember-in-viewport": "^3.7.5",
     "ember-test-selectors": "^3.0.0",
     "ember-tooltips": "^3.4.5",

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -462,7 +462,7 @@
   "national-number": "VO-ID",
   "last-name": "Achternaam",
   "group": "Groep",
-  "email": "Email",
+  "email": "E-mail",
   "ovo-code": "OVO-code",
   "phone": "Telefoonnummer",
   "mail-campaign": "Email campagne",
@@ -630,12 +630,10 @@
   "publications-new-not-minister": "Nieuwe publicatie (niet via Ministerraad)",
   "publications-new-button-text": "Publicatie aanmaken",
   "publications-new-warning-message": "Deze actie dient voor publicaties van documenten die niet via de Ministerraad komen",
-  "publications-number-required": "Publicatienummer *",
   "publications-number": "Publicatienummer",
   "input-error-message": "Dit veld dient ingevuld te worden.",
   "modal-error-alert-message": "Eén of meerdere velden bevatten een fout.",
   "modal-error-alert-title": "Kijk het formulier na",
-  "name-subcase-required": "Korte titel *",
   "publications-to-in-progress": "Te behandelen",
   "via-cabinet": "Via Ministerraad",
   "not-via-cabinet": "Niet Via Ministerraad",
@@ -673,5 +671,6 @@
   "delete-folder": "Map verwijderen",
   "view-document-details": "Bekijk document details",
   "publication-number-already-taken":"Dit publicatienummer is reeds in gebruik.",
-  "date-expired": "Datum verstreken"
+  "date-expired": "Datum verstreken",
+  "publication-sidebar-tooltip": "Dit is een interne opmerking voor het OVRB-team."
 }


### PR DESCRIPTION
## KAS-2043: Design bugfixes

- asterisk is grijs (verplicht veld) ✔️
- sluiten knop incorrect ✔️
- contactpersoon toevoegen icoon te groot (niet KI-plus wel ki-add)✔️
- op samenvatting publicatie: .auk-button-icon is verkeerd✔️
- Op scherm: samenvatting van publicatie✔️in de code van deze icon only button staat 2 keer .auk--icon✔️
- In zijbalk bij een detail van een publicatie: Datepicker mist een date icoon **(Moet een apart ticket worden)**
- In zijbalk bij een detail van een publicatie: Status dropdown mist een icoon (Customizen ember power select?)  **(Moet een apart ticket worden)**
- In modal contact persoon toevoegen ✔️Voornaam en naam zouden in 2 kolommen moeten✔️
- E-mail label: niet Email, streepje gebruiken✔️
- Toevoegen knop heeft niet de juiste combinatie van klasses, ziet er niet goed uit.✔️
- lijkt zelfde issue rond add/plus icoon en verkeerd gebruik icon classes✔️
- De breedte van de zijbalk als die ingeklapt staat klopt niet helemaal, is iets te breed: In het prototype is het beter✔️
- Je kan momenteel niet scrollen in de zijbalk✔️
- WYSIWYG  Bij ingave 3 paragrafen, staan ze in de read only weergave niet als 3 paragrafen maar naast elkaar **(Moet een apart ticket worden)**
- Opmerking veld info icoon heeft geen tooltip✔️De info icoon moet ook wat grijzer staanDe tooltip klopt op prototype https:// development.kaleidos.mono.global/ app/publications/detail/summary maar is nog niet grijs genoeg bij ons
- De “overline” (de tekst boven de titel) klopt niet helemaal, dit hoeft geen link te zijn, stijl is ookanders, zie prototype.✔️
- Overzicht niet via ministerraad ❌  **(ember view maakt dit aan)**
- Te behandelen : zebra striping klopt niet ❌  **(niet gevonden door geen data)** 
- Op een groot scherm zou de zijbalk standaard uitgeklapt moeten zijn, dit is beschreven in de designsAls het scherm groot genoeg is (minimaal 1640px breed) dan komt de side panel in de content area naast de andere content.https://www.figma.com/file/ TV7uHiWOymlNTZnD1DGMiE/ %F0%9F%92%AF-Kaleidos- Grooming-Digitale-Publicaties?node- id=7%3A3860https://kanselarij.atlassian.net/ browse/KAS-1962 ✔️