### PR TITLE
KAS-2045: kort bestek scroll ondersteuning

### DIFF
--- a/app/pods/newsletter/nota-updates/template.hbs
+++ b/app/pods/newsletter/nota-updates/template.hbs
@@ -1,14 +1,15 @@
-<div class="vl-u-spacer-extended-l">
+<div class="vl-u-spacer-extended-l--padding vl-u-scroll-scrollable">
   <div class="vl-u-spacer--large">
     <div>
-      {{#if this.model.notas.length}}
+      {{!-- Indien er geen resultaten gevonden zijn, komt dit doordat er geen documenten als type 'nota' bij agendapunten staan --}}
+      {{!-- {{#if this.model.notas.length}} --}}
         <DataTable
           @content={{this.model.notas}}
           @page={{this.page}}
           @noDataMessage={{t "no-results-found"}}
           @size={{this.size}}
           @sort={{this.sort}}
-          @class="vl-data-table vl-data-table--zebra vl-data-table--align-middle"
+          @class="vl-data-table vl-data-table--zebra vl-data-table--align-middle vl-data-table--no-scroll"
           @isLoading={{this.isLoadingModel}}
           as |table|
         >
@@ -73,7 +74,7 @@
             </c.body>
           </table.content>
         </DataTable>
-      {{/if}}
+      {{!-- {{/if}} --}}
     </div>
   </div>
 </div>

--- a/app/pods/newsletter/nota-updates/template.hbs
+++ b/app/pods/newsletter/nota-updates/template.hbs
@@ -1,8 +1,7 @@
 <div class="vl-u-spacer-extended-l--padding vl-u-scroll-scrollable">
   <div class="vl-u-spacer--large">
     <div>
-      {{!-- Indien er geen resultaten gevonden zijn, komt dit doordat er geen documenten als type 'nota' bij agendapunten staan --}}
-      {{!-- {{#if this.model.notas.length}} --}}
+      {{!-- Indien er geen resultaten gevonden worden, komt dit doordat er geen documenten als type 'nota' bij agendapunten staan --}}
         <DataTable
           @content={{this.model.notas}}
           @page={{this.page}}
@@ -74,7 +73,6 @@
             </c.body>
           </table.content>
         </DataTable>
-      {{!-- {{/if}} --}}
     </div>
   </div>
 </div>

--- a/app/styles/custom-utilities/_extended-spacer.scss
+++ b/app/styles/custom-utilities/_extended-spacer.scss
@@ -23,6 +23,10 @@ $vl-u-spacer-extended-unit: 1rem !default;
   margin: $vl-u-spacer-extended-unit * 4 !important;
 }
 
+.vl-u-spacer-extended-l--padding {
+  padding: $vl-u-spacer-extended-unit * 4 !important;
+}
+
 /* Top
    ========================================================================== */
 

--- a/app/styles/govflanders/components/_data-table.scss
+++ b/app/styles/govflanders/components/_data-table.scss
@@ -199,6 +199,12 @@ $pad-tiny: 0.3rem;
     }
   }
 
+  &--no-scroll {
+    .data-table-content {
+      overflow: hidden;
+    }
+  }
+
   .vl-pill {
     vertical-align: middle;
 


### PR DESCRIPTION
# KAS-2045: kort bestek scroll ondersteuning

## 👷  Wat is er veranderd
- Geen interne scroll op ember data tabel
- Padding ipv margin gebruikt op de algemene div, zodanig dat het scrollen op de volledige pagina is ipv in de div zelf.
- Empty state toegevoegd, zodanig dat het duidelijk is dat er geen data is ipv dat de pagina leeg is (verwarrend)