### PR TITLE
KAS-2054: Publicatieroute afschermen

### DIFF
--- a/app/pods/publications/index/route.js
+++ b/app/pods/publications/index/route.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default class IndexPublicationRoute extends Route {
+export default class IndexPublicationRoute extends Route.extend(AuthenticatedRouteMixin)  {
   beforeModel() {
     /* It is assumed here that explicitly navigating to the index-route
      * expresses a desire to "reset", to "start a new search-session".

--- a/app/pods/publications/route.js
+++ b/app/pods/publications/route.js
@@ -1,6 +1,7 @@
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import Route from '@ember/routing/route';
 
-export default class PublicationsRoute extends Route {
+export default class PublicationsRoute extends Route.extend(AuthenticatedRouteMixin) {
   model() {
     // Normally we would query store here, but for now, we get the mocks
     return null;


### PR DESCRIPTION
# KAS-2054: Publicatieroute afschermen

## :shield: Wat is er veranderd
- Hoofdpublicatieroute AuthenticatedRoute gemaakt alsook de route in de index folder