### PR TITLE
ACCEPT: KAS-2060: Prevent dubbel publicatienummer vanaf sidebar

### DIFF
--- a/app/pods/agendas/overview/template.hbs
+++ b/app/pods/agendas/overview/template.hbs
@@ -62,7 +62,7 @@
             {{#if (await model)}}
               {{#data-table
                 content=(await model)
-                class="vl-data-table vl-data-table--zebra vl-data-table--align-middle"
+                class="vl-data-table vl-data-table--zebra vl-data-table--align-middle vl-data-table--no-scroll"
                 page=page
                 size=size
                 sort=sort

--- a/app/pods/components/publications/publications-overview-table/template.hbs
+++ b/app/pods/components/publications/publications-overview-table/template.hbs
@@ -1,4 +1,5 @@
 {{!-- template-lint-disable  --}}
+{{!-- TODO AUK classes gebruiken --}}
 <div class="vl-u-spacer-extended-l">
   <table class="vl-data-table vl-data-table--zebra vl-data-table--align-middle">
     <thead>
@@ -38,7 +39,7 @@
           <td>{{publication.type}}</td>
           <td>
             {{publication.dateStartPublication}}<br>
-            <span class="u-muted">{{publication.timeStartPublication}}</span>
+            <span class="auk-u-muted">{{publication.timeStartPublication}}</span>
           </td>
           <td>{{publication.datePublicationDeadline}}</td>
           <td>
@@ -67,6 +68,7 @@
             {{/if}}
           </td>
           <td>
+            {{!-- TODO AuButtonLink gebruiken --}}
             <LinkTo
               @route="publications.in-progress"
               class="vl-button vl-button--link vl-button--icon"

--- a/app/pods/components/web-components/au-radio/template.hbs
+++ b/app/pods/components/web-components/au-radio/template.hbs
@@ -3,7 +3,7 @@
   {{@label}}
   {{#if this.sublabel}}
     <br/>
-    <span class="u-muted u-text-small">{{@sublabel}}</span>
+    <span class="auk-u-muted auk-u-text-small">{{@sublabel}}</span>
   {{/if}}
   <span class="auk-radio__box"></span>
 </label>

--- a/app/pods/newsletter/nota-updates/template.hbs
+++ b/app/pods/newsletter/nota-updates/template.hbs
@@ -1,14 +1,15 @@
-<div class="vl-u-spacer-extended-l">
+<div class="vl-u-spacer-extended-l--padding vl-u-scroll-scrollable">
   <div class="vl-u-spacer--large">
     <div>
-      {{#if this.model.notas.length}}
+      {{!-- Indien er geen resultaten gevonden zijn, komt dit doordat er geen documenten als type 'nota' bij agendapunten staan --}}
+      {{!-- {{#if this.model.notas.length}} --}}
         <DataTable
           @content={{this.model.notas}}
           @page={{this.page}}
           @noDataMessage={{t "no-results-found"}}
           @size={{this.size}}
           @sort={{this.sort}}
-          @class="vl-data-table vl-data-table--zebra vl-data-table--align-middle"
+          @class="vl-data-table vl-data-table--zebra vl-data-table--align-middle vl-data-table--no-scroll"
           @isLoading={{this.isLoadingModel}}
           as |table|
         >
@@ -73,7 +74,7 @@
             </c.body>
           </table.content>
         </DataTable>
-      {{/if}}
+      {{!-- {{/if}} --}}
     </div>
   </div>
 </div>

--- a/app/pods/newsletter/nota-updates/template.hbs
+++ b/app/pods/newsletter/nota-updates/template.hbs
@@ -1,8 +1,7 @@
 <div class="vl-u-spacer-extended-l--padding vl-u-scroll-scrollable">
   <div class="vl-u-spacer--large">
     <div>
-      {{!-- Indien er geen resultaten gevonden zijn, komt dit doordat er geen documenten als type 'nota' bij agendapunten staan --}}
-      {{!-- {{#if this.model.notas.length}} --}}
+      {{!-- Indien er geen resultaten gevonden worden, komt dit doordat er geen documenten als type 'nota' bij agendapunten staan --}}
         <DataTable
           @content={{this.model.notas}}
           @page={{this.page}}
@@ -74,7 +73,6 @@
             </c.body>
           </table.content>
         </DataTable>
-      {{!-- {{/if}} --}}
     </div>
   </div>
 </div>

--- a/app/pods/publications/in-progress/in-progress-minister/template.hbs
+++ b/app/pods/publications/in-progress/in-progress-minister/template.hbs
@@ -26,7 +26,7 @@
     <c.body class="tr-hover" as |row|>
       <td>
         {{row.case.shortTitle}}<br/>
-        <span class="u-text-small u-muted">
+        <span class="auk-u-text-small auk-u-muted">
           {{row.publicationNumber}}
           {{t "dash"}}
         </span>
@@ -40,7 +40,7 @@
       </td>
       <td>
         {{moment-format row.modified "DD-MM-YYYY"}}<br/>
-        <span class="u-text-small u-muted">{{moment-format row.modified "HH:ss"}}</span>
+        <span class="auk-u-text-small auk-u-muted">{{moment-format row.modified "HH:ss"}}</span>
       </td>
       <td>
         {{t "dash"}}

--- a/app/pods/publications/in-progress/in-progress-not-minister/controller.js
+++ b/app/pods/publications/in-progress/in-progress-not-minister/controller.js
@@ -15,10 +15,10 @@ export default class PublicationsInProgressNotMinisterController extends Control
     },
   };
 
-  sizeOptions = Object.freeze([5, 10, 20, 50, 100, 200]);
+  sizeOptions = Object.freeze([5, 10, 25, 50, 100, 200]);
 
   @tracked page = 0;
-  @tracked size = 5;
+  @tracked size = 25;
   @tracked sort = '-created';
 
   @action

--- a/app/pods/publications/in-progress/in-progress-not-minister/route.js
+++ b/app/pods/publications/in-progress/in-progress-not-minister/route.js
@@ -30,6 +30,10 @@ export default class InProgressNotRoute extends Route {
         },
       },
       sort: params.sort,
+      page: {
+        number: params.page,
+        size: params.size,
+      },
       include: 'case',
     });
   }

--- a/app/pods/publications/in-progress/in-progress-not-minister/template.hbs
+++ b/app/pods/publications/in-progress/in-progress-not-minister/template.hbs
@@ -26,7 +26,7 @@
     <c.body class="tr-hover" as |row|>
       <td>
         {{row.case.shortTitle}}<br/>
-        <span class="u-text-small u-muted">
+        <span class="auk-u-text-small auk-u-muted">
           {{row.publicationNumber}}
           {{t "dash"}}
         </span>
@@ -40,7 +40,7 @@
       </td>
       <td>
         {{moment-format row.modified "DD-MM-YYYY"}}<br/>
-        <span class="u-text-small u-muted">{{moment-format row.modified "HH:ss"}}</span>
+        <span class="auk-u-text-small auk-u-muted">{{moment-format row.modified "HH:ss"}}</span>
       </td>
       <td>
         {{t "dash"}}

--- a/app/pods/publications/in-progress/template.hbs
+++ b/app/pods/publications/in-progress/template.hbs
@@ -1,6 +1,6 @@
 <div class="auk-scroll-wrapper__body">
-  <div class="u-m-4">
-    <div class="u-my-2">
+  <div class="auk-u-m-4">
+    <div class="auk-u-my-2">
       <WebComponents::AuNavbar class="vlc-publication-overview-navbar" @noPadding="true">
         <WebComponents::AuToolbar>
           <WebComponents::AuToolbar::Group>

--- a/app/pods/publications/index/route.js
+++ b/app/pods/publications/index/route.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default class IndexPublicationRoute extends Route {
+export default class IndexPublicationRoute extends Route.extend(AuthenticatedRouteMixin)  {
   beforeModel() {
     /* It is assumed here that explicitly navigating to the index-route
      * expresses a desire to "reset", to "start a new search-session".

--- a/app/pods/publications/publication/case/template.hbs
+++ b/app/pods/publications/publication/case/template.hbs
@@ -1,5 +1,5 @@
  {{!--  DOSSIER PANEL  --}}
-  <div class="u-mb-3">
+  <div class="auk-u-mb-3">
     {{#if this.isInscriptionInEditMode}}
       <WebComponents::AuPanel class="auk-panel--editing">
         <WebComponents::AuPanel::Header>
@@ -77,7 +77,7 @@
   {{!--  MINISTER PANEL  --}}
 
 
-  <div hidden class="u-mb-3">
+  <div hidden class="auk-u-mb-3">
     <WebComponents::AuPanel>
       <WebComponents::AuPanel::Header>
         <WebComponents::AuToolbar>
@@ -105,11 +105,11 @@
           <tbody>
             <tr>
               <td class="o-flex o-flex--vertical-center">
-                <WebComponents::AuBadge @icon="user" /> <span class="u-mx-2">{{t "cancel"}}</span>
+                <WebComponents::AuBadge @icon="user" /> <span class="auk-u-mx-2">{{t "cancel"}}</span>
               </td>
               <td>
                 <span>{{t "cancel"}}</span>
-                <span class="u-muted">{{t "cancel"}}</span>
+                <span class="auk-u-muted">{{t "cancel"}}</span>
               </td>
               <td class="vl-u-align-right">
                 <button
@@ -127,6 +127,7 @@
                     @placement="left"
                     as |attacher|
                   >
+                  {{!-- TODO use AuDropdown --}}
                     <ul class="vlc-dropdown-menu">
                       <li class="vlc-dropdown-menu__item">
                         <button class="vl-link vl-link--block" type="button"
@@ -156,7 +157,7 @@
 
   {{!--  CONTACTPERSON PANEL  --}}
 
-  <div class="u-mb-3">
+  <div class="auk-u-mb-3">
     <WebComponents::AuPanel>
       <WebComponents::AuPanel::Header>
         <WebComponents::AuToolbar>
@@ -192,10 +193,10 @@
                 <tr>
                   <td class="o-flex o-flex--vertical-center">
                     <WebComponents::AuBadge @icon="user"/>
-                    <span class="u-mx-2">{{ await contactPerson.nameToDisplay}}</span>
+                    <span class="auk-u-mx-2">{{ await contactPerson.nameToDisplay}}</span>
                   </td>
                   <td class="">
-                    <span class="u-mx-2">
+                    <span class="auk-u-mx-2">
                       {{#if contactPerson.email }}
                         <a href="mailto:{{contactPerson.email}}">{{contactPerson.email}}</a>
                       {{/if}}
@@ -203,7 +204,7 @@
                   </td>
 
                   <td class="">
-                    <span class="u-mx-2">{{contactPerson.organisationName}}</span>
+                    <span class="auk-u-mx-2">{{contactPerson.organisationName}}</span>
                   </td>
 
                   <td class="vl-u-align-right">
@@ -301,7 +302,7 @@
 
 {{!-- FULL PAGE LOADER --}}
 
-
+{{!-- TODO Auk modal --}}
 {{#if showLoader }}
   <WebComponents::VlModal
           @isOverlay={{true}}

--- a/app/pods/publications/publication/controller.js
+++ b/app/pods/publications/publication/controller.js
@@ -80,8 +80,6 @@ export default class PublicationController extends Controller {
 
   @restartableTask
   *setPublicationNumber(event) {
-    const currentActivePublicationNumber = this.model.publicationNumber;
-    console.log('currentActivePublicationNumber', currentActivePublicationNumber);
     this.publicationService.publicationNumberAlreadyTaken(event.target.value).then((isPublicationNumberTaken) => {
       if (isPublicationNumberTaken) {
         this.numberIsAlreadyUsed = true;

--- a/app/pods/publications/publication/documents/template.hbs
+++ b/app/pods/publications/publication/documents/template.hbs
@@ -1,7 +1,7 @@
 {{!-- TITLE AND TOOLBAR --}}
 
 
-<div class="u-my-2">
+<div class="auk-u-my-2">
   <WebComponents::AuToolbar>
     <WebComponents::AuToolbar::Group @position="left">
       <WebComponents::AuToolbar::Item>
@@ -45,14 +45,14 @@
 {{!-- TABLE FOR DOCUMENTS --}}
 
 
-<div class="u-mb-3">
+<div class="auk-u-mb-3">
   {{#if (gt (await @model.pieces.length) 0)}}
     <table class="auk-table">
       <thead>
         <tr>
           <th></th>
           <th class="auk-table__col--6">{{t "document"}}</th>
-          <th class="u-text-nowrap">{{t "uploaded-at"}}</th>
+          <th class="auk-u-text-nowrap">{{t "uploaded-at"}}</th>
           <th colspan="2">{{t "translations"}}</th>
           <th colspan="2">{{t "signatures"}}</th>
           <th colspan="2">{{t "proof"}}</th>
@@ -85,10 +85,10 @@
             <td>
               <div class="o-flex o-flex--vertical-center">
                 <WebComponents::AuBadge @icon="folder"></WebComponents::AuBadge>
-                <div class="u-ml-3">
-                  <span class="u-text-bold">{{await piece.name}}</span>
+                <div class="auk-u-ml-3">
+                  <span class="auk-u-text-bold">{{await piece.name}}</span>
                   <br>
-                  <span class="u-muted u text-small">{{await piece.documentContainer.type.label}}</span>
+                  <span class="auk-u-muted auk-u-text-small">{{await piece.documentContainer.type.label}}</span>
                 </div>
               </div>
 
@@ -96,7 +96,7 @@
             <td>
               {{moment-format piece.created}}
               <br>
-              <span class="u-muted u-text-small">{{moment-format piece.created "HH:mm"}}</span>
+              <span class="auk-u-muted auk-u-text-small">{{moment-format piece.created "HH:mm"}}</span>
             </td>
             <td colspan="2"></td>
             <td colspan="2"></td>
@@ -133,12 +133,12 @@
               <td>
                 <span>{{await piece.name}}</span>
                 <br>
-                <span class="u-muted u text-small">{{await piece.file.extension}}</span>
+                <span class="auk-u-muted auk-u-text-small">{{await piece.file.extension}}</span>
               </td>
               <td>
                 {{moment-format piece.created}}
                 <br>
-                <span class="u-muted u-text-small">{{moment-format piece.created "HH:mm"}}</span>
+                <span class="auk-u-muted auk-u-text-small">{{moment-format piece.created "HH:mm"}}</span>
               </td>
               {{!-- TODO Logic for checkboxes checked --}}
               {{!-- TODO Logic for the checkmark (isPresent), based on activities or just checking for the relevcant pieces? --}}

--- a/app/pods/publications/publication/template.hbs
+++ b/app/pods/publications/publication/template.hbs
@@ -2,7 +2,7 @@
   <WebComponents::AuToolbar>
     <WebComponents::AuToolbar::Group @position="left">
       <WebComponents::AuToolbar::Item>
-        <div class="o-flex o-flex--vertical u-mt-2">
+        <div class="o-flex o-flex--vertical auk-u-mt-2">
           <span class="auk-overline auk-u-muted"
                   data-test-publication-detail-menu-publication-number>
             {{uppercase (concat (t "publication-flow") " " this.model.publicationNumber)}}
@@ -21,10 +21,11 @@
   </WebComponents::AuToolbar>
 </WebComponents::AuNavbar>
 
+{{!-- Auk css gebruiken, component ? --}}
 <div class="auk-panel-layout auk-panel-layout--responsive">
   <div class="auk-panel-layout__main-content u-maximize-height auk-scroll-wrapper">
     <div class="auk-scroll-wrapper__body">
-      <div class="u-m-4">
+      <div class="auk-u-m-4">
         {{outlet}}
       </div>
     </div>
@@ -49,7 +50,7 @@
       {{#if (not collapsed)}}
         <div class="auk-scroll-wrapper">
           <div class="auk-scroll-wrapper__body">
-            <div class="u-m-3">
+            <div class="auk-u-m-3">
               <div class="auk-form-group">
                 <WebComponents::AuLabel>{{t 'publications-number'}}</WebComponents::AuLabel>
                 <WebComponents::AuInput type="number" value={{this.model.publicationNumber}} @block="true"

--- a/app/pods/publications/publication/template.hbs
+++ b/app/pods/publications/publication/template.hbs
@@ -51,7 +51,7 @@
         <div class="auk-scroll-wrapper">
           <div class="auk-scroll-wrapper__body">
             <div class="auk-u-m-3">
-              <div class="auk-form-group">
+              <div class="auk-form-group {{getClassForPublicationNumber}}">
                 <WebComponents::AuLabel>{{t 'publications-number'}}</WebComponents::AuLabel>
                 <WebComponents::AuInput type="number" value={{this.model.publicationNumber}} @block="true"
                   {{on "input" (perform this.setPublicationNumber)}} />

--- a/app/pods/publications/publication/template.hbs
+++ b/app/pods/publications/publication/template.hbs
@@ -55,6 +55,12 @@
                 <WebComponents::AuLabel>{{t 'publications-number'}}</WebComponents::AuLabel>
                 <WebComponents::AuInput type="number" value={{this.model.publicationNumber}} @block="true"
                   {{on "input" (perform this.setPublicationNumber)}} />
+                {{#if this.numberIsAlreadyUsed}}
+                  <div class="auk-form-help-text auk-form-help-text--warning">
+                    <WebComponents::AuIcon @name="alert-triangle"/>
+                    {{t "publication-number-already-taken"}}
+                  </div>
+                {{/if}}
               </div>
               <div class="auk-form-group">
                 <WebComponents::AuLabel for="blockInput">{{t 'status'}}</WebComponents::AuLabel>

--- a/app/pods/publications/route.js
+++ b/app/pods/publications/route.js
@@ -1,6 +1,7 @@
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import Route from '@ember/routing/route';
 
-export default class PublicationsRoute extends Route {
+export default class PublicationsRoute extends Route.extend(AuthenticatedRouteMixin) {
   model() {
     // Normally we would query store here, but for now, we get the mocks
     return null;

--- a/app/pods/publications/template.hbs
+++ b/app/pods/publications/template.hbs
@@ -1,10 +1,11 @@
 {{#if shouldShowPublicationHeader}}
+{{!-- TODO auk-panel-layout gebruiken, component ? --}}
   <div class="vlc-panel-layout__main-content">
     <WebComponents::AuNavbar class="vlc-publication-overview-navbar" @border="bottom" @skin="gray-100" @auto="true">
       <WebComponents::AuToolbar>
         <WebComponents::AuToolbar::Group @position="left">
           <WebComponents::AuToolbar::Item>
-            <div class="o-flex o-flex--vertical u-mt-2">
+            <div class="o-flex o-flex--vertical auk-u-mt-2">
               <h4 class="auk-toolbar-complex__title">{{t "publications" }}</h4>
               <WebComponents::AuTabs @reversed="true">
                 <WebComponents::AuTab @route="publications.to-treat" data-test-publications-overview-to-treat-tab>

--- a/app/pods/publications/to-treat/template.hbs
+++ b/app/pods/publications/to-treat/template.hbs
@@ -1,5 +1,5 @@
 <div class="auk-scroll-wrapper__body">
-  <div class="u-m-4">
+  <div class="auk-u-m-4">
     {{#if this.model.length}}
       <DataTable
               @content={{await this.model}}
@@ -22,7 +22,7 @@
           <c.body as |row|>
             {{#if row.isAgendaRow}}
               <td colspan="99" class="auk-table__cell--accent">
-                <h4 class="auk-h4 u-m-0">{{row.meeting.kindToShow.label}} {{moment-format row.meeting.plannedStart "DD.MM.YYYY"}}</h4>
+                <h4 class="auk-h4 auk-u-m-0">{{row.meeting.kindToShow.label}} {{moment-format row.meeting.plannedStart "DD.MM.YYYY"}}</h4>
               </td>
             {{else}}
               <td>

--- a/app/styles/custom-utilities/_extended-spacer.scss
+++ b/app/styles/custom-utilities/_extended-spacer.scss
@@ -23,6 +23,10 @@ $vl-u-spacer-extended-unit: 1rem !default;
   margin: $vl-u-spacer-extended-unit * 4 !important;
 }
 
+.vl-u-spacer-extended-l--padding {
+  padding: $vl-u-spacer-extended-unit * 4 !important;
+}
+
 /* Top
    ========================================================================== */
 

--- a/app/styles/govflanders/components/_data-table.scss
+++ b/app/styles/govflanders/components/_data-table.scss
@@ -199,6 +199,12 @@ $pad-tiny: 0.3rem;
     }
   }
 
+  &--no-scroll {
+    .data-table-content {
+      overflow: hidden;
+    }
+  }
+
   .vl-pill {
     vertical-align: middle;
 

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
   },
   "dependencies": {
     "@kanselarij-vlaanderen/au-kaleidos-icons": "^1.2.2",
-    "@kanselarij-vlaanderen/au-kaleidos-css": "^1.13.5",
+    "@kanselarij-vlaanderen/au-kaleidos-css": "^1.14.2",
     "ember-in-viewport": "^3.7.5",
     "ember-test-selectors": "^3.0.0",
     "ember-tooltips": "^3.4.5",


### PR DESCRIPTION
# KAS-2060: Prevent dubbel publicatienummer vanaf sidebar
In deze PR geven we een waarschuwing weer wanneer je een dubbel publicatienummer gebruikt.

## 📝 What has changed
- Een reeds gebruikte nummer voor een publicatie geeft een rode omranding om aan te tonen dat het al in gebruik is.
- Er wordt een toast geworpen wanneer een nummer reeds in gebruik is.
- Er wordt een melding weergeven wanneer een nummer reeds in gebruik is onder het veld

## 🖼 Screenshots
![image](https://user-images.githubusercontent.com/11557630/101327618-35331e80-386f-11eb-8c02-528de472c8c3.png)
