### PR TITLE
KAS-2044: toon lange titels

### DIFF
--- a/app/styles/custom-components/_vlc-page-header.scss
+++ b/app/styles/custom-components/_vlc-page-header.scss
@@ -23,10 +23,9 @@
   }
 
   .vlc-page-header__title--max-width-title {
-    text-overflow: ellipsis;
-    max-width: 500px;
+    min-width: 500px;
+    max-width: 800px;
     overflow: hidden;
-    white-space: nowrap;
   }
 
   .vlc-page-header__subtitle {

--- a/app/styles/custom-components/_vlc-toolbar.scss
+++ b/app/styles/custom-components/_vlc-toolbar.scss
@@ -23,7 +23,6 @@ $c-toolbar-middle-z: 20;
   flex-shrink: 0;
   align-items: center;
   justify-content: space-between;
-  /*min-height: $c-toolbar-size-regular;*/
 }
 
 .vlc-toolbar--medium {

--- a/app/styles/custom-components/_vlc-toolbar.scss
+++ b/app/styles/custom-components/_vlc-toolbar.scss
@@ -23,7 +23,7 @@ $c-toolbar-middle-z: 20;
   flex-shrink: 0;
   align-items: center;
   justify-content: space-between;
-  height: $c-toolbar-size-regular;
+  /*min-height: $c-toolbar-size-regular;*/
 }
 
 .vlc-toolbar--medium {


### PR DESCRIPTION
Old style:
<img width="1123" alt="Screenshot 2020-12-08 at 08 48 01" src="https://user-images.githubusercontent.com/592312/101454971-1a75ae00-3932-11eb-9346-8c2f90bec310.png">


New style:
<img width="1118" alt="Screenshot 2020-12-08 at 08 44 16" src="https://user-images.githubusercontent.com/592312/101454868-e9957900-3931-11eb-99e9-80c4d42abd85.png">

<img width="1102" alt="Screenshot 2020-12-08 at 08 44 00" src="https://user-images.githubusercontent.com/592312/101454873-eb5f3c80-3931-11eb-8608-d0a7d51b438d.png">
