### PR TITLE
Feature/kas 2018 delete documenten publicatie

### DIFF
--- a/app/models/case.js
+++ b/app/models/case.js
@@ -1,5 +1,7 @@
 import DS from 'ember-data';
 import { computed } from '@ember/object';
+import VRDocumentName, { compareFunction } from 'fe-redpencil/utils/vr-document-name';
+import { A } from '@ember/array';
 
 const {
   Model, attr, hasMany, belongsTo, PromiseObject,
@@ -19,6 +21,10 @@ export default Model.extend({
 
   subcases: hasMany('subcase'),
   pieces: hasMany('piece'),
+
+  sortedPieces: computed('pieces.@each.name', function() {
+    return A(this.get('pieces').toArray()).sort((pieceA, pieceB) => compareFunction(new VRDocumentName(pieceA.get('name')), new VRDocumentName(pieceB.get('name'))));
+  }),
 
   latestSubcase: computed('subcases.@each', function() {
     return PromiseObject.create({

--- a/app/pods/publications/publication/documents/controller.js
+++ b/app/pods/publications/publication/documents/controller.js
@@ -154,17 +154,23 @@ export default class PublicationDocumentsController extends Controller {
   *verifyDeleteExistingPiece() {
     const agendaitem = yield this.pieceToDelete.get('agendaitem');
     if (agendaitem) {
-      // possible unreachable code, failsafe
-      // do we want to show a toast ?
+      // Possible unreachable code, failsafe. Do we want to show a toast ?
     } else {
       // TODO delete with undo ?
       this.showLoader = true;
       this.isVerifyingDelete = false;
-      yield this.fileService.deletePiece(this.pieceToDelete);
+      const documentContainer = yield this.pieceToDelete.get('documentContainer');
+      const piecesFromContainer = yield documentContainer.get('pieces');
+      if (piecesFromContainer.length < 2) {
+        // Cleanup documentContainer if we are deleting the last piece in the container
+        // Must revise if we link docx and pdf as multiple files in 1 piece
+        yield this.fileService.deleteDocumentContainer(documentContainer);
+      } else {
+        yield this.fileService.deletePiece(this.pieceToDelete);
+      }
       yield this.model.case.hasMany('pieces').reload();
       this.showLoader = false;
       this.pieceToDelete = null;
-      // TODO delete orphan container if last piece is deleted
     }
   }
 

--- a/app/pods/publications/publication/documents/controller.js
+++ b/app/pods/publications/publication/documents/controller.js
@@ -103,8 +103,6 @@ export default class PublicationDocumentsController extends Controller {
     this.showLoader = true;
     this.isOpenPieceUploadModal = false;
     yield all(savePromises);
-    yield this.model.case.hasMany('pieces').reload();
-    this.currentPieces = this.pieces;
     this.showLoader = false;
     this.newPieces = A();
   }
@@ -164,7 +162,6 @@ export default class PublicationDocumentsController extends Controller {
       this.isVerifyingDelete = false;
       yield this.fileService.deletePiece(this.pieceToDelete);
       yield this.model.case.hasMany('pieces').reload();
-      this.currentPieces = this.pieces;
       this.showLoader = false;
       this.pieceToDelete = null;
       // TODO delete orphan container if last piece is deleted

--- a/app/pods/publications/publication/documents/template.hbs
+++ b/app/pods/publications/publication/documents/template.hbs
@@ -46,7 +46,7 @@
 
 
 <div hidden class="auk-u-mb-3">
-  {{#if (gt (await this.model.case.pieces.length) 0)}}
+  {{#if (gt (await this.model.case.sortedPieces.length) 0)}}
     <table class="auk-table">
       <thead>
         <tr>
@@ -72,7 +72,7 @@
         </tr>
       </thead>
       <tbody>
-        {{#each this.model.case.pieces as |piece|}}
+        {{#each this.model.case.sortedPieces as |piece|}}
           <tr data-test-publication-case-documents-piece-row>
             <td>
               <WebComponents::AuButton
@@ -206,7 +206,7 @@
 {{!-- TABLE FOR DOCUMENTS SIMPLIFIED --}}
 
 <div class="auk-u-mb-3">
-  {{#if (gt (await this.model.case.pieces.length) 0 )}}
+  {{#if (gt (await this.model.case.sortedPieces.length) 0 )}}
     {{#if this.renderPieces}}
       <table class="auk-table">
         <thead>
@@ -220,7 +220,7 @@
           </tr>
         </thead>
         <tbody>
-          {{#each this.model.case.pieces as |piece|}}
+          {{#each this.model.case.sortedPieces as |piece|}}
             <tr class="auk-table__row" data-test-publication-case-documents-piece-row>
               <td>
                 <WebComponents::AuCheckbox @toggle={{fn this.changePieceSelection piece}}/>
@@ -266,9 +266,11 @@
                       </WebComponents::AuDropdown::Item> --}}
                       {{!-- TODO the rules for deleting documents are not clear. OVRB should not be able to delete documents that have been released by kanselarij
                             Offering this as an option should be very restrictive --}}
-                      {{!-- <WebComponents::AuDropdown::Item @skin="danger" {{on "click" attacher.hide}}>
-                        {{t "document-delete"}}
-                      </WebComponents::AuDropdown::Item> --}}
+                      {{#if (not (await piece.agendaitem))}}
+                        <WebComponents::AuDropdown::Item @skin="danger" {{on "click" (fn this.deleteExistingPiece piece)}}>
+                          {{t "document-delete"}}
+                        </WebComponents::AuDropdown::Item>
+                      {{/if}}
                     </WebComponents::AuDropdown>
                   </AttachPopover>
                 </WebComponents::AuButtonToolbar>

--- a/app/pods/publications/publication/documents/template.hbs
+++ b/app/pods/publications/publication/documents/template.hbs
@@ -244,7 +244,7 @@
               </td>
               <td>
                 <WebComponents::AuButtonToolbar>
-                  <WebComponents::AuButton @skin="borderless" @icon="more" @layout="icon-only">
+                  <WebComponents::AuButton data-test-pub-case-doc-row-actions @skin="borderless" @icon="more" @layout="icon-only">
                   </WebComponents::AuButton>
                   <AttachPopover
                     @renderInPlace={{true}}
@@ -257,7 +257,7 @@
                   >
                     <WebComponents::AuDropdown>
                       {{!-- TODO opening viewer will only work for pdf files --}}
-                      <WebComponents::AuDropdown::Item {{on "click" (fn this.showPieceViewer piece.id)}}>
+                      <WebComponents::AuDropdown::Item data-test-pub-case-doc-row-action-view {{on "click" (fn this.showPieceViewer piece.id)}}>
                         {{t "view-document-details"}}
                       </WebComponents::AuDropdown::Item>
                       {{!-- TODO do we want this action ? how to upload a new version to a piece with multiple files ?? --}}
@@ -267,7 +267,7 @@
                       {{!-- TODO the rules for deleting documents are not clear. OVRB should not be able to delete documents that have been released by kanselarij
                             Offering this as an option should be very restrictive --}}
                       {{#if (not (await piece.agendaitem))}}
-                        <WebComponents::AuDropdown::Item @skin="danger" {{on "click" (fn this.deleteExistingPiece piece)}}>
+                        <WebComponents::AuDropdown::Item data-test-pub-case-doc-row-action-delete @skin="danger" {{on "click" (fn this.deleteExistingPiece piece)}}>
                           {{t "document-delete"}}
                         </WebComponents::AuDropdown::Item>
                       {{/if}}

--- a/app/pods/publications/publication/documents/template.hbs
+++ b/app/pods/publications/publication/documents/template.hbs
@@ -178,9 +178,11 @@
                       </WebComponents::AuDropdown::Item> --}}
                       {{!-- TODO the rules for deleting documents are not clear. OVRB should not be able to delete documents that have been released by kanselarij
                             Offering this as an option should be very restrictive --}}
-                      {{!-- <WebComponents::AuDropdown::Item @skin="danger" {{on "click" attacher.hide}}>
-                        {{t "document-delete"}}
-                      </WebComponents::AuDropdown::Item> --}}
+                      {{#if (not (await piece.agendaitem))}}
+                        <WebComponents::AuDropdown::Item @skin="danger" {{on "click" (fn this.deleteExistingPiece piece)}}>
+                          {{t "document-delete"}}
+                        </WebComponents::AuDropdown::Item>
+                      {{/if}}
                     </WebComponents::AuDropdown>
                   </AttachPopover>
                 </WebComponents::AuButtonToolbar>
@@ -227,7 +229,7 @@
             <Documents::DocumentUpload
               @piece={{piece}}
               @allowDocumentContainerEdit={{true}}
-              @onDelete={{perform this.deletePiece piece}} />
+              @onDelete={{perform this.deleteUploadedPiece piece}} />
           {{/each}}
         </div>
     </WebComponents::AuModal::Body>
@@ -326,7 +328,7 @@
 
 
 
-{{#if showLoader}}
+{{#if this.showLoader}}
   <WebComponents::AuModal>
     <WebComponents::AuModal::Header
       @title={{t "loading-text"}}
@@ -342,4 +344,17 @@
       />
     </WebComponents::AuModal::Body>
   </WebComponents::AuModal>
+{{/if}}
+
+
+{{!-- VERIFY DELETE PIECE MODAL --}}
+
+
+{{!-- TODO replace this with Au variant --}}
+{{#if this.isVerifyingDelete}}
+  <WebComponents::VlModalVerify
+    @title={{t "document-delete"}}
+    @message={{t "delete-document-message"}}
+    @cancel={{action this.cancelDeleteExistingPiece}}
+    @verify={{perform this.verifyDeleteExistingPiece}} />
 {{/if}}

--- a/cypress/selectors/publication.selectors.js
+++ b/cypress/selectors/publication.selectors.js
@@ -27,6 +27,9 @@ const selectors = {
     // buttons
     addDocumentsButton: '[data-test-publication-case-add-documents]',
     documentsPieceRow: '[data-test-publication-case-documents-piece-row]',
+    documentsRowActions: '[data-test-pub-case-doc-row-actions]',
+    documentsRowActionView: '[data-test-pub-case-doc-row-action-view]',
+    documentsRowActionDelete: '[data-test-pub-case-doc-row-action-delete]',
   },
   nav: {
     goBack: '[data-test-publication-case-nav-go-back]',


### PR DESCRIPTION
# KAS-2018: documenten kunnen verwijderen uit publicaties

## What has changed:

models/case.js:
 - sortedPieces computed toegevoegd (zelfde als op agendaitem model)

publication/documents/controller.js:
 - deletePiece hernoemd, dit wordt gebruikt in het upload venster
 - methods toegevoegd voor verwijderen van documenten met bevestiging, en annuleren in die bevestiging
 - check op piece.agendaitem zorgt ervoor dat je geen documenten kan verwijderen dat op een agenda staan

publication/documents/template.js:
 - sortedPieces ipv pieces
 - actie knop toegevoegd
 - verify modal (nog oude gebruikt, nieuwe maken op zich geen onderdeel van het ticket)

+ test gemaakt dat 2 doc toevoegd en 1 terug verwijderd
