### PR TITLE
KAS-2064: Format stond fout in de tabels (DEVELOPMENT)

### DIFF
--- a/app/pods/publications/in-progress/in-progress-minister/template.hbs
+++ b/app/pods/publications/in-progress/in-progress-minister/template.hbs
@@ -40,7 +40,7 @@
       </td>
       <td>
         {{moment-format row.modified "DD-MM-YYYY"}}<br/>
-        <span class="auk-u-text-small auk-u-muted">{{moment-format row.modified "HH:ss"}}</span>
+        <span class="auk-u-text-small auk-u-muted">{{moment-format row.modified "HH:mm"}}</span>
       </td>
       <td>
         {{t "dash"}}

--- a/app/pods/publications/in-progress/in-progress-not-minister/template.hbs
+++ b/app/pods/publications/in-progress/in-progress-not-minister/template.hbs
@@ -40,7 +40,7 @@
       </td>
       <td>
         {{moment-format row.modified "DD-MM-YYYY"}}<br/>
-        <span class="auk-u-text-small auk-u-muted">{{moment-format row.modified "HH:ss"}}</span>
+        <span class="auk-u-text-small auk-u-muted">{{moment-format row.modified "HH:mm"}}</span>
       </td>
       <td>
         {{t "dash"}}


### PR DESCRIPTION
## KAS-2064

-changed time format from HH:ss to HH:mm in the publication table
