### PR TITLE
Enable octane

### DIFF
--- a/app/pods/components/agenda/printable-agenda/component.js
+++ b/app/pods/components/agenda/printable-agenda/component.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+});

--- a/app/pods/components/agenda/printable-agenda/list-section/component.js
+++ b/app/pods/components/agenda/printable-agenda/list-section/component.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+});

--- a/app/pods/components/agenda/printable-agenda/list-section/item-group/component.js
+++ b/app/pods/components/agenda/printable-agenda/list-section/item-group/component.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+});

--- a/app/pods/components/agenda/printable-agenda/list-section/item-group/item-group-header/component.js
+++ b/app/pods/components/agenda/printable-agenda/list-section/item-group/item-group-header/component.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+});

--- a/app/pods/components/agenda/printable-agenda/list-section/item-group/item/component.js
+++ b/app/pods/components/agenda/printable-agenda/list-section/item-group/item/component.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+});

--- a/config/optional-features.json
+++ b/config/optional-features.json
@@ -1,3 +1,5 @@
 {
-  "jquery-integration": true
+  "application-template-wrapper": false,
+  "jquery-integration": true,
+  "template-only-glimmer-components": true
 }

--- a/package.json
+++ b/package.json
@@ -123,6 +123,9 @@
   "engines": {
     "node": "10.* || >= 12"
   },
+  "ember": {
+    "edition": "octane"
+  },
   "dependencies": {
     "@kanselarij-vlaanderen/au-kaleidos-icons": "^1.2.2",
     "@kanselarij-vlaanderen/au-kaleidos-css": "^1.16.1",


### PR DESCRIPTION
Adds configuration that specifies octane. This makes that you can use [ember-cli](https://cli.emberjs.com/release/basic-use/cli-commands/#generatemorefiles) in the same way you would use it in your average ember project instead of having to copy-paste, strip, ... stuff for generation.
The generated `component.js` -files within this PR are for keeping non-octane components working the way they did without refactoring them to octane.