### PR TITLE
KAS-2123: Aanvraag statussen tonen in header

### DIFF
--- a/app/models/activity-status.js
+++ b/app/models/activity-status.js
@@ -1,0 +1,12 @@
+import Model, {
+  attr, hasMany
+} from '@ember-data/model';
+
+export default class ActivityStatus extends Model {
+  @attr('string') uri;
+  @attr('string') label;
+  @attr('string') scopeNote; // empty in data
+  @attr('string') altLabel; // empty in data
+
+  @hasMany('activity') activity;
+}

--- a/app/models/activity.js
+++ b/app/models/activity.js
@@ -11,7 +11,6 @@ export default class Activity extends Model {
   @attr('datetime') finalTranslationDate;
   @attr('string') name;
   @attr('string') mailContent;
-  @attr('string') status;
 
   // Relations.
   @belongsTo('subcase') subcase;
@@ -26,6 +25,7 @@ export default class Activity extends Model {
 
   @belongsTo('language') language;
   @belongsTo('activity-type') type;
+  @belongsTo('activity-status') status;
 
   @hasMany('piece') usedPieces;
   @hasMany('piece') generatedPieces;
@@ -33,13 +33,22 @@ export default class Activity extends Model {
 
   // Getters.
   get isWithdrawn() {
-    return CONFIG.ACTIVITY_STATUSSES.withdrawn === this.get('status');
+    const _this = this;
+    return (async() => {
+      const status = await _this.get('status');
+      return CONFIG.ACTIVITY_STATUSSES.withdrawn.id === status.id;
+    })(_this);
   }
+
   get isFinished() {
-    return CONFIG.ACTIVITY_STATUSSES.closed === this.get('status');
+    const _this = this;
+    return (async() => {
+      const status = await _this.get('status');
+      return CONFIG.ACTIVITY_STATUSSES.closed.id === status.id;
+    })(_this);
   }
 
-
+  // async getter
   get wasPublished() {
     const _this = this;
     return (async() => {
@@ -53,7 +62,7 @@ export default class Activity extends Model {
       // Find Activities that are CLOSED that publish This one.
       const closingActivities = await this.store.query('activity', {
         'filter[publishes][:id:]': _this.id,
-        'filter[status]': CONFIG.ACTIVITY_STATUSSES.closed,
+        'filter[status][:id:]': CONFIG.ACTIVITY_STATUSSES.closed.id,
       });
       return closingActivities.length;
     })(_this);
@@ -71,7 +80,7 @@ export default class Activity extends Model {
       // Find Activities that are OPEN that publish This one.
       const openActivities = await this.store.query('activity', {
         'filter[publishes][:id:]': _this.id,
-        'filter[status]': CONFIG.ACTIVITY_STATUSSES.open,
+        'filter[status][:id:]': CONFIG.ACTIVITY_STATUSSES.open.id,
       });
       return openActivities.length > 0;
     })(_this);

--- a/app/pods/components/publications/publication/activity-request-panel/template.hbs
+++ b/app/pods/components/publications/publication/activity-request-panel/template.hbs
@@ -21,7 +21,7 @@
           <WebComponents::AuLabel>
             {{t "translation-mail-header"}}
           </WebComponents::AuLabel>
-          <p>{{@activity.mailContent}}</p>
+          <p class="vlc-u-pre">{{@activity.mailContent}}</p>
         </div>
         <WebComponents::AuLabel>
           {{t "files"}}

--- a/app/pods/publications/publication/case/route.js
+++ b/app/pods/publications/publication/case/route.js
@@ -3,14 +3,16 @@ import Route from '@ember/routing/route';
 
 export default class CaseRoute extends Route.extend(AuthenticatedRouteMixin) {
   async model() {
-    const publicationFlow = this.modelFor('publications.publication');
+    const parentHash = this.modelFor('publications.publication');
+    const publicationFlow = parentHash.publicationFlow;
     const _case = await publicationFlow.get('case');
     return _case;
   }
 
   async setupController(controller, model) {
     super.setupController(...arguments);
-    const publicationFlow = this.modelFor('publications.publication');
+    const parentHash = this.modelFor('publications.publication');
+    const publicationFlow = parentHash.publicationFlow;
     const contactPersons = await publicationFlow.get('contactPersons');
     const subcasesOnMeeting = await this.store.query('subcase', {
       filter: {

--- a/app/pods/publications/publication/controller.js
+++ b/app/pods/publications/publication/controller.js
@@ -55,54 +55,54 @@ export default class PublicationController extends Controller {
   ];
 
   get getPublicationStatus() {
-    return this.statusOptions.find((statusOption) => statusOption.id === this.model.get('status.id'));
+    return this.statusOptions.find((statusOption) => statusOption.id === this.model.publicationFlow.get('status.id'));
   }
 
   get getPublicationType() {
-    return this.typeOptions.find((typeOption) => typeOption.id === this.model.get('type.id'));
+    return this.typeOptions.find((typeOption) => typeOption.id === this.model.publicationFlow.get('type.id'));
   }
 
   get getTranslationDate() {
-    if (!this.model.get('translateBefore')) {
+    if (!this.model.publicationFlow.get('translateBefore')) {
       return null;
     }
-    return this.model.get('translateBefore');
+    return this.model.publicationFlow.get('translateBefore');
   }
 
   get getPublicationBeforeDate() {
-    if (!this.model.get('publishBefore')) {
+    if (!this.model.publicationFlow.get('publishBefore')) {
       return null;
     }
-    return this.model.get('publishBefore');
+    return this.model.publicationFlow.get('publishBefore');
   }
 
   get getPublicationDate() {
-    if (!this.model.get('publishedAt')) {
+    if (!this.model.publicationFlow.get('publishedAt')) {
       return null;
     }
-    return this.model.get('publishedAt');
+    return this.model.publicationFlow.get('publishedAt');
   }
 
   get getRemark() {
-    return this.model.get('remark');
+    return this.model.publicationFlow.get('remark');
   }
 
   get expiredPublicationBeforeDate() {
-    return moment(this.model.get('publishBefore'))
+    return moment(this.model.publicationFlow.get('publishBefore'))
       .isBefore(moment());
   }
   get expiredPublicationDate() {
-    return moment(this.model.get('publishedAt'))
+    return moment(this.model.publicationFlow.get('publishedAt'))
       .isBefore(moment());
   }
   get expiredTranslationDate() {
-    return moment(this.model.get('translateBefore'))
+    return moment(this.model.publicationFlow.get('translateBefore'))
       .isBefore(moment());
   }
 
   @action
   allowedTranslationDate(date) {
-    const end = moment(this.model.get('publishBefore'));
+    const end = moment(this.model.publicationFlow.get('publishBefore'));
     if (moment(date).isSameOrBefore(end) && moment(date).isSameOrAfter(moment())) {
       return true;
     }
@@ -113,8 +113,8 @@ export default class PublicationController extends Controller {
   allowedPublicationDate(date) {
     const end = moment().add(360, 'days');
     let startRange;
-    if (this.model.get('translateBefore')) {
-      startRange = moment(this.model.get('translateBefore'));
+    if (this.model.publicationFlow.get('translateBefore')) {
+      startRange = moment(this.model.publicationFlow.get('translateBefore'));
     } else {
       startRange = moment();
     }
@@ -127,25 +127,25 @@ export default class PublicationController extends Controller {
   @restartableTask
   *setPublicationNumber(event) {
     yield timeout(1000);
-    this.publicationService.publicationNumberAlreadyTaken(event.target.value, this.model.id).then((isPublicationNumberTaken) => {
+    this.publicationService.publicationNumberAlreadyTaken(event.target.value, this.model.publicationFlow.id).then((isPublicationNumberTaken) => {
       if (isPublicationNumberTaken) {
         this.numberIsAlreadyUsed = true;
         this.toaster.error(this.intl.t('publication-number-already-taken'), this.intl.t('warning-title'), {
           timeOut: 5000,
         });
       } else {
-        this.model.set('publicationNumber',  event.target.value);
+        this.model.publicationFlow.set('publicationNumber',  event.target.value);
         this.numberIsAlreadyUsed = false;
-        this.model.save();
+        this.model.publicationFlow.save();
       }
     });
   }
 
   @restartableTask
   *setNumacNumber(event) {
-    this.model.set('numacNumber', event.target.value);
+    this.model.publicationFlow.set('numacNumber', event.target.value);
     yield timeout(1000);
-    this.model.save();
+    this.model.publicationFlow.save();
   }
 
   @action
@@ -153,7 +153,7 @@ export default class PublicationController extends Controller {
     set(this, 'showPublicationDatePicker', false);
     set(this, 'showTranslationDatePicker', false);
     const date = moment(new Date(event));
-    const translateBefore = this.model.get('translateBefore');
+    const translateBefore = this.model.publicationFlow.get('translateBefore');
     if (typeof translateBefore !== undefined && !moment(translateBefore).isSameOrBefore(date, 'minutes')) {
       this.publicationNotAfterTranslationForPublication = true;
       this.toaster.error(this.intl.t('publication-date-after-translation-date'), this.intl.t('warning-title'), {
@@ -162,8 +162,8 @@ export default class PublicationController extends Controller {
       set(this, 'showPublicationDatePicker', true);
       set(this, 'showTranslationDatePicker', true);
     } else {
-      this.model.set('publishBefore', new Date(event));
-      this.model.save().then(() => {
+      this.model.publicationFlow.set('publishBefore', new Date(event));
+      this.model.publicationFlow.save().then(() => {
         set(this, 'showPublicationDatePicker', true);
         set(this, 'showTranslationDatePicker', true);
       }).
@@ -177,8 +177,8 @@ export default class PublicationController extends Controller {
 
   @action
   setPublicationDate(event) {
-    this.model.set('publishedAt', new Date(event));
-    this.model.save();
+    this.model.publicationFlow.set('publishedAt', new Date(event));
+    this.model.publicationFlow.save();
   }
 
   @action
@@ -186,7 +186,7 @@ export default class PublicationController extends Controller {
     set(this, 'showPublicationDatePicker', false);
     set(this, 'showTranslationDatePicker', false);
     const date = moment(new Date(event));
-    const publishBefore = this.model.get('publishBefore');
+    const publishBefore = this.model.publicationFlow.get('publishBefore');
     if (typeof publishBefore !== undefined && !moment(date).isSameOrBefore(publishBefore)) {
       this.publicationNotAfterTranslationForTranslation = true;
       this.toaster.error(this.intl.t('publication-date-after-translation-date'), this.intl.t('warning-title'), {
@@ -195,8 +195,8 @@ export default class PublicationController extends Controller {
       set(this, 'showPublicationDatePicker', true);
       set(this, 'showTranslationDatePicker', true);
     } else {
-      this.model.set('translateBefore', new Date(event));
-      this.model.save().then(() => {
+      this.model.publicationFlow.set('translateBefore', new Date(event));
+      this.model.publicationFlow.save().then(() => {
         set(this, 'showPublicationDatePicker', true);
         set(this, 'showTranslationDatePicker', true);
       }).
@@ -212,22 +212,22 @@ export default class PublicationController extends Controller {
   @action
   async setPublicationStatus(event) {
     const publicationStatus = await this.store.findRecord('publication-status', event.id);
-    this.model.set('status', publicationStatus);
-    this.model.save();
+    this.model.publicationFlow.set('status', publicationStatus);
+    this.model.publicationFlow.save();
   }
 
   @action
   async setPublicationType(event) {
     const publicationType = await this.store.findRecord('publication-type', event.id);
-    this.model.set('type', publicationType);
-    this.model.save();
+    this.model.publicationFlow.set('type', publicationType);
+    this.model.publicationFlow.save();
   }
 
   @restartableTask
   *setRemark(event) {
-    this.model.set('remark', event.target.value);
+    this.model.publicationFlow.set('remark', event.target.value);
     yield timeout(1000);
-    this.model.save();
+    this.model.publicationFlow.save();
   }
 
   @action

--- a/app/pods/publications/publication/documents/controller.js
+++ b/app/pods/publications/publication/documents/controller.js
@@ -183,12 +183,11 @@ export default class PublicationDocumentsController extends Controller {
   /** PUBLISH PREVIEW ACTIVITIES **/
 
   @action
-  openPublishPreviewRequestModal() {
-    this.isOpenPublishPreviewRequestModal = true;
+  async openPublishPreviewRequestModal() {
     this.previewActivity.pieces = this.selectedPieces;
-    const attachmentsString = this.concatNames(this.selectedPieces);
-    this.previewActivity.mailContent = CONFIG.mail.publishPreviewRequest.content.replace('%%attachments%%', attachmentsString);
-    this.previewActivity.mailSubject = CONFIG.mail.publishPreviewRequest.subject.replace('%%nummer%%', this.model.publicationFlow.publicationNumber);
+    this.previewActivity.mailContent = await this.activityService.replaceTokens(CONFIG.mail.publishPreviewRequest.content, this.model.publicationFlow, this.model.case);
+    this.previewActivity.mailSubject = await this.activityService.replaceTokens(CONFIG.mail.publishPreviewRequest.subject, this.model.publicationFlow, this.model.case);
+    this.isOpenPublishPreviewRequestModal = true;
   }
 
   @action
@@ -238,12 +237,11 @@ export default class PublicationDocumentsController extends Controller {
   /** TRANSLATION ACTIVITIES **/
 
   @action
-  openTranslationRequestModal() {
+  async openTranslationRequestModal() {
     this.translateActivity.finalTranslationDate = ((this.model.publicationFlow.translateBefore) ? this.model.publicationFlow.translateBefore : new Date());
     this.translateActivity.pieces = this.selectedPieces;
-    const attachmentsString = this.concatNames(this.selectedPieces);
-    set(this.translateActivity, 'mailContent', CONFIG.mail.translationRequest.content.replace('%%attachments%%', attachmentsString));
-    set(this.translateActivity, 'mailSubject', CONFIG.mail.translationRequest.subject.replace('%%nummer%%', this.model.publicationFlow.publicationNumber));
+    this.translateActivity.mailContent = await this.activityService.replaceTokens(CONFIG.mail.translationRequest.content, this.model.publicationFlow, this.model.case);
+    this.translateActivity.mailSubject = await this.activityService.replaceTokens(CONFIG.mail.translationRequest.subject, this.model.publicationFlow, this.model.case);
     this.showTranslationModal = true;
   }
 

--- a/app/pods/publications/publication/documents/controller.js
+++ b/app/pods/publications/publication/documents/controller.js
@@ -185,8 +185,8 @@ export default class PublicationDocumentsController extends Controller {
   @action
   async openPublishPreviewRequestModal() {
     this.previewActivity.pieces = this.selectedPieces;
-    this.previewActivity.mailContent = await this.activityService.replaceTokens(CONFIG.mail.publishPreviewRequest.content, this.model.publicationFlow, this.model.case);
-    this.previewActivity.mailSubject = await this.activityService.replaceTokens(CONFIG.mail.publishPreviewRequest.subject, this.model.publicationFlow, this.model.case);
+    this.previewActivity.mailContent = this.activityService.replaceTokens(CONFIG.mail.publishPreviewRequest.content, this.model.publicationFlow, this.model.case);
+    this.previewActivity.mailSubject = this.activityService.replaceTokens(CONFIG.mail.publishPreviewRequest.subject, this.model.publicationFlow, this.model.case);
     this.isOpenPublishPreviewRequestModal = true;
   }
 
@@ -240,8 +240,8 @@ export default class PublicationDocumentsController extends Controller {
   async openTranslationRequestModal() {
     this.translateActivity.finalTranslationDate = ((this.model.publicationFlow.translateBefore) ? this.model.publicationFlow.translateBefore : new Date());
     this.translateActivity.pieces = this.selectedPieces;
-    this.translateActivity.mailContent = await this.activityService.replaceTokens(CONFIG.mail.translationRequest.content, this.model.publicationFlow, this.model.case);
-    this.translateActivity.mailSubject = await this.activityService.replaceTokens(CONFIG.mail.translationRequest.subject, this.model.publicationFlow, this.model.case);
+    this.translateActivity.mailContent = this.activityService.replaceTokens(CONFIG.mail.translationRequest.content, this.model.publicationFlow, this.model.case);
+    this.translateActivity.mailSubject = this.activityService.replaceTokens(CONFIG.mail.translationRequest.subject, this.model.publicationFlow, this.model.case);
     this.showTranslationModal = true;
   }
 

--- a/app/pods/publications/publication/documents/controller.js
+++ b/app/pods/publications/publication/documents/controller.js
@@ -231,6 +231,7 @@ export default class PublicationDocumentsController extends Controller {
     this.renderPieces = true;
 
     alert('the mails dont work yet. infra is working on it.');
+    this.model.refreshAction();
     this.transitionToRoute('publications.publication.publishpreview');
   }
 
@@ -284,6 +285,7 @@ export default class PublicationDocumentsController extends Controller {
     this.showLoader = false;
     this.renderPieces = true;
     alert('the mails dont work yet. infra is working on it.');
+    this.model.refreshAction();
     this.transitionToRoute('publications.publication.translations');
   }
 

--- a/app/pods/publications/publication/documents/route.js
+++ b/app/pods/publications/publication/documents/route.js
@@ -5,7 +5,8 @@ import { A } from '@ember/array';
 
 export default class PublicationDocumentsRoute extends Route.extend(AuthenticatedRouteMixin) {
   async model() {
-    const publicationFlow = this.modelFor('publications.publication');
+    const parentHash = this.modelFor('publications.publication');
+    const publicationFlow = parentHash.publicationFlow;
     const _case = await publicationFlow.get('case');
     const caze = await this.store.findRecord('case', _case.get('id'), {
       include: 'pieces,pieces.document-container,pieces.document-container.type',

--- a/app/pods/publications/publication/documents/route.js
+++ b/app/pods/publications/publication/documents/route.js
@@ -16,6 +16,7 @@ export default class PublicationDocumentsRoute extends Route.extend(Authenticate
     return hash({
       publicationFlow,
       case: caze,
+      refreshAction: parentHash.refreshAction,
     });
   }
 

--- a/app/pods/publications/publication/publishpreview/controller.js
+++ b/app/pods/publications/publication/publishpreview/controller.js
@@ -95,7 +95,7 @@ export default class PublicationPublishPreviewController extends Controller {
         publishingActivity.status = CONFIG.ACTIVITY_STATUSSES.withdrawn;
         publishingActivity.endDate = moment().utc();
         await publishingActivity.save();
-        await this.send('refreshModel');
+        this.model.refreshAction();
       });
     this.showLoader = false;
   }
@@ -109,7 +109,7 @@ export default class PublicationPublishPreviewController extends Controller {
         publishingActivity.status = CONFIG.ACTIVITY_STATUSSES.closed;
         publishingActivity.endDate = moment().utc();
         await publishingActivity.save();
-        await this.send('refreshModel');
+        this.model.refreshAction();
       });
     this.showLoader = false;
   }

--- a/app/pods/publications/publication/publishpreview/controller.js
+++ b/app/pods/publications/publication/publishpreview/controller.js
@@ -37,8 +37,8 @@ export default class PublicationPublishPreviewController extends Controller {
   async requestPublicationModal(activity) {
     this.publicationActivity.pieces = await activity.usedPieces;
     set(this.publicationActivity, 'previewActivity', activity);
-    this.publicationActivity.mailContent = await this.activityService.replaceTokens(CONFIG.mail.publishRequest.content, this.model.publicationFlow, this.model.case);
-    this.publicationActivity.mailSubject = await this.activityService.replaceTokens(CONFIG.mail.publishRequest.subject, this.model.publicationFlow, this.model.case);
+    this.publicationActivity.mailContent = this.activityService.replaceTokens(CONFIG.mail.publishRequest.content, this.model.publicationFlow, this.model.case);
+    this.publicationActivity.mailSubject = this.activityService.replaceTokens(CONFIG.mail.publishRequest.subject, this.model.publicationFlow, this.model.case);
     this.showpublicationModal = true;
   }
 

--- a/app/pods/publications/publication/publishpreview/route.js
+++ b/app/pods/publications/publication/publishpreview/route.js
@@ -2,11 +2,11 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 import Route from '@ember/routing/route';
 import CONFIG from 'fe-redpencil/utils/config';
 import { hash } from 'rsvp';
-import { action } from '@ember/object';
 
 export default class PublicationPublishPreviewRoute extends Route.extend(AuthenticatedRouteMixin) {
   async model() {
-    const publicationFlow = this.modelFor('publications.publication');
+    const parentHash = this.modelFor('publications.publication');
+    const publicationFlow = parentHash.publicationFlow;
     let _case = await publicationFlow.get('case');
     _case = await this.store.findRecord('case', _case.get('id'), {
       include: 'pieces,pieces.document-container,pieces.document-container.type',
@@ -23,11 +23,7 @@ export default class PublicationPublishPreviewRoute extends Route.extend(Authent
       publicationFlow,
       case: _case,
       publishPreviewActivities: publishPreviewActivities,
+      refreshAction: parentHash.refreshAction,
     });
-  }
-
-  @action
-  refreshModel() {
-    this.refresh();
   }
 }

--- a/app/pods/publications/publication/publishpreview/template.hbs
+++ b/app/pods/publications/publication/publishpreview/template.hbs
@@ -11,28 +11,66 @@
             </WebComponents::AuToolbar::Item>
           </WebComponents::AuToolbar::Group>
           <WebComponents::AuToolbar::Group @position="right">
-            <WebComponents::AuToolbar::Item>
-              {{#if (await activity.wasPublished)}}
-                {{t "publications-published"}} {{moment-format activity.endDate "DD MMMM YYYY [om] H:mm"}}
-              {{else if (await activity.hasOpenPublishingActivity)}}
-                <WebComponents::AuButton
-                        @skin="primary"
-                  {{on "click" (fn this.markPublicationActivityPublished activity)}}>
-                  {{t "publications-published"}}
-                </WebComponents::AuButton>
+
+
+
+
+            {{#if (await activity.isWithdrawn) }}
+
+              <WebComponents::AuToolbar::Item>
+                <WebComponents::AuPillList>
+                  <WebComponents::AuPill @skin="danger">{{t "cancelled-request"}} {{moment-format activity.endDate "DD MMMM YYYY [om] H:mm"}}</WebComponents::AuPill>
+                </WebComponents::AuPillList>
+              </WebComponents::AuToolbar::Item>
+
+            {{else if (await activity.isFinished) }}
+
+              <WebComponents::AuToolbar::Item>
+                {{t "publishpreview"}} {{t "finished"}} {{moment-format activity.endDate "DD MMMM YYYY [om] H:mm"}}
+              </WebComponents::AuToolbar::Item>
+
+
+              <WebComponents::AuToolbar::Item>
+                {{#if (await activity.wasPublished)}}
+                  {{t "publications-published"}} {{moment-format activity.endDate "DD MMMM YYYY [om] H:mm"}}
+                {{else if (await activity.hasOpenPublishingActivity)}}
+                  <WebComponents::AuButton
+                          @skin="primary"
+                    {{on "click" (fn this.markPublicationActivityPublished activity)}}>
+                    {{t "publications-published"}}
+                  </WebComponents::AuButton>
+                  <WebComponents::AuButton
+                          @skin="tertiary"
+                    {{on "click" (fn this.cancelExistingPublicationActivity activity)}}>
+                    {{t "cancel-request"}}
+                  </WebComponents::AuButton>
+                {{else}}
+                  <WebComponents::AuButton
+                          @skin="primary"
+                    {{on "click" (fn this.requestPublicationModal activity )}}>
+                    {{t "request-publication"}}
+                  </WebComponents::AuButton>
+                {{/if}}
+              </WebComponents::AuToolbar::Item>
+
+            {{else}}
+
+              <WebComponents::AuToolbar::Item>
                 <WebComponents::AuButton
                         @skin="tertiary"
-                  {{on "click" (fn this.cancelExistingPublicationActivity activity)}}>
+                  {{on "click" (fn this.cancelExistingPreviewActivity activity)}}>
                   {{t "cancel-request"}}
                 </WebComponents::AuButton>
-              {{else}}
-                <WebComponents::AuButton
-                        @skin="primary"
-                  {{on "click" (fn this.requestPublicationModal activity )}}>
-                  {{t "request-publication"}}
-                </WebComponents::AuButton>
-              {{/if}}
-            </WebComponents::AuToolbar::Item>
+              </WebComponents::AuToolbar::Item>
+
+              <WebComponents::AuToolbar::Item>
+                <WebComponents::AuCheckbox
+                        @toggle={{fn this.markPreviewActivityDone activity}}
+                        @label="Afgewerkt"/>
+              </WebComponents::AuToolbar::Item>
+
+            {{/if}}
+
           </WebComponents::AuToolbar::Group>
         </WebComponents::AuToolbar>
       </WebComponents::AuNavbar>

--- a/app/pods/publications/publication/route.js
+++ b/app/pods/publications/publication/route.js
@@ -1,12 +1,46 @@
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import Route from '@ember/routing/route';
+import { hash } from 'rsvp';
+import CONFIG from 'fe-redpencil/utils/config';
+import { action } from '@ember/object';
 
 export default class PublicationRoute extends Route.extend(AuthenticatedRouteMixin) {
   async model(params) {
-    return await this.store.findRecord('publication-flow', params.publication_id, {
+    const publicationFlow = await this.store.findRecord('publication-flow', params.publication_id, {
       reload: true,
     }, {
       include: 'case,contact-person,status,type',
+    });
+
+    const totalTranslations = await this.store.query('activity', {
+      'filter[subcase][publication-flow][:id:]': publicationFlow.id,
+      'filter[type][:id:]': CONFIG.ACTIVITY_TYPES.vertalen.id,
+    });
+    const openTranslationRequests = await this.store.query('activity', {
+      'filter[subcase][publication-flow][:id:]': publicationFlow.id,
+      'filter[type][:id:]': CONFIG.ACTIVITY_TYPES.vertalen.id,
+      'filter[status]': 'closed',
+    });
+
+    const totalPublishPreviewRequests = await this.store.query('activity', {
+      'filter[subcase][publication-flow][:id:]': publicationFlow.id,
+      'filter[type][:id:]': CONFIG.ACTIVITY_TYPES.drukproeven.id,
+    });
+    const openPublishPrevieuwRequests = await this.store.query('activity', {
+      'filter[subcase][publication-flow][:id:]': publicationFlow.id,
+      'filter[type][:id:]': CONFIG.ACTIVITY_TYPES.drukproeven.id,
+      'filter[status]': 'closed',
+    });
+
+    return hash({
+      publicationFlow,
+      counts: {
+        totalTranslations: totalTranslations.length,
+        openTranslationRequests: openTranslationRequests.length,
+        totalPublishPreviewRequests: totalPublishPreviewRequests.length,
+        openPublishPrevieuwRequests: openPublishPrevieuwRequests.length,
+      },
+      refreshAction: this.refreshModel,
     });
   }
 
@@ -14,5 +48,10 @@ export default class PublicationRoute extends Route.extend(AuthenticatedRouteMix
   resetController(controller, _, transition) {
     controller.publicationNotAfterTranslationForPublication = false;
     controller.publicationNotAfterTranslationForTranslation = false;
+  }
+
+  @action
+  refreshModel() {
+    this.refresh();
   }
 }

--- a/app/pods/publications/publication/route.js
+++ b/app/pods/publications/publication/route.js
@@ -16,37 +16,38 @@ export default class PublicationRoute extends Route.extend(AuthenticatedRouteMix
       'filter[subcase][publication-flow][:id:]': publicationFlow.id,
       'filter[type][:id:]': CONFIG.ACTIVITY_TYPES.vertalen.id,
     });
-
-    // TODO: Dit covered nog niet alle requests die niet open staan..
-    //  hier dient ook gefiltered te worden op withdrawn status
-    //  maar hiervoor dient status een relatie te zijn ipv rechtstreeks op het model
-    const closedOrWithdrawnTranslationRequests = await this.store.query('activity', {
+    const closedTranslationRequests = await this.store.query('activity', {
       'filter[subcase][publication-flow][:id:]': publicationFlow.id,
       'filter[type][:id:]': CONFIG.ACTIVITY_TYPES.vertalen.id,
-      'filter[status]': 'closed',
+      'filter[status][:id:]': CONFIG.ACTIVITY_STATUSSES.closed.id,
     });
-
+    const WithdrawnTranslationRequests = await this.store.query('activity', {
+      'filter[subcase][publication-flow][:id:]': publicationFlow.id,
+      'filter[type][:id:]': CONFIG.ACTIVITY_TYPES.vertalen.id,
+      'filter[status][:id:]': CONFIG.ACTIVITY_STATUSSES.withdrawn.id,
+    });
     const totalPublishPreviewRequests = await this.store.query('activity', {
       'filter[subcase][publication-flow][:id:]': publicationFlow.id,
       'filter[type][:id:]': CONFIG.ACTIVITY_TYPES.drukproeven.id,
     });
-
-    // TODO: Dit covered nog niet alle requests die niet open staan..
-    //  hier dient ook gefiltered te worden op withdrawn status
-    //  maar hiervoor dient status een relatie te zijn ipv rechtstreeks op het model
-    const closedOrWithdrawnPublishPrevieuwRequests = await this.store.query('activity', {
+    const withdrawnPublishPrevieuwRequests = await this.store.query('activity', {
       'filter[subcase][publication-flow][:id:]': publicationFlow.id,
       'filter[type][:id:]': CONFIG.ACTIVITY_TYPES.drukproeven.id,
-      'filter[status]': 'closed',
+      'filter[status][:id:]': CONFIG.ACTIVITY_STATUSSES.withdrawn.id,
+    });
+    const closedPublishPrevieuwRequests = await this.store.query('activity', {
+      'filter[subcase][publication-flow][:id:]': publicationFlow.id,
+      'filter[type][:id:]': CONFIG.ACTIVITY_TYPES.drukproeven.id,
+      'filter[status][:id:]': CONFIG.ACTIVITY_STATUSSES.closed.id,
     });
 
     return hash({
       publicationFlow,
       counts: {
         totalTranslations: totalTranslations.length,
-        closedOrWithdrawnTranslationRequests: closedOrWithdrawnTranslationRequests.length,
+        closedOrWithdrawnTranslationRequests: closedTranslationRequests.length + WithdrawnTranslationRequests.length,
         totalPublishPreviewRequests: totalPublishPreviewRequests.length,
-        closedOrWithdrawnPublishPrevieuwRequests: closedOrWithdrawnPublishPrevieuwRequests.length,
+        closedOrWithdrawnPublishPrevieuwRequests: closedPublishPrevieuwRequests.length + withdrawnPublishPrevieuwRequests.length,
       },
       refreshAction: this.refreshModel,
     });

--- a/app/pods/publications/publication/route.js
+++ b/app/pods/publications/publication/route.js
@@ -16,7 +16,11 @@ export default class PublicationRoute extends Route.extend(AuthenticatedRouteMix
       'filter[subcase][publication-flow][:id:]': publicationFlow.id,
       'filter[type][:id:]': CONFIG.ACTIVITY_TYPES.vertalen.id,
     });
-    const openTranslationRequests = await this.store.query('activity', {
+
+    // TODO: Dit covered nog niet alle requests die niet open staan..
+    //  hier dient ook gefiltered te worden op withdrawn status
+    //  maar hiervoor dient status een relatie te zijn ipv rechtstreeks op het model
+    const closedOrWithdrawnTranslationRequests = await this.store.query('activity', {
       'filter[subcase][publication-flow][:id:]': publicationFlow.id,
       'filter[type][:id:]': CONFIG.ACTIVITY_TYPES.vertalen.id,
       'filter[status]': 'closed',
@@ -26,7 +30,11 @@ export default class PublicationRoute extends Route.extend(AuthenticatedRouteMix
       'filter[subcase][publication-flow][:id:]': publicationFlow.id,
       'filter[type][:id:]': CONFIG.ACTIVITY_TYPES.drukproeven.id,
     });
-    const openPublishPrevieuwRequests = await this.store.query('activity', {
+
+    // TODO: Dit covered nog niet alle requests die niet open staan..
+    //  hier dient ook gefiltered te worden op withdrawn status
+    //  maar hiervoor dient status een relatie te zijn ipv rechtstreeks op het model
+    const closedOrWithdrawnPublishPrevieuwRequests = await this.store.query('activity', {
       'filter[subcase][publication-flow][:id:]': publicationFlow.id,
       'filter[type][:id:]': CONFIG.ACTIVITY_TYPES.drukproeven.id,
       'filter[status]': 'closed',
@@ -36,9 +44,9 @@ export default class PublicationRoute extends Route.extend(AuthenticatedRouteMix
       publicationFlow,
       counts: {
         totalTranslations: totalTranslations.length,
-        openTranslationRequests: openTranslationRequests.length,
+        closedOrWithdrawnTranslationRequests: closedOrWithdrawnTranslationRequests.length,
         totalPublishPreviewRequests: totalPublishPreviewRequests.length,
-        openPublishPrevieuwRequests: openPublishPrevieuwRequests.length,
+        closedOrWithdrawnPublishPrevieuwRequests: closedOrWithdrawnPublishPrevieuwRequests.length,
       },
       refreshAction: this.refreshModel,
     });

--- a/app/pods/publications/publication/route.js
+++ b/app/pods/publications/publication/route.js
@@ -30,12 +30,12 @@ export default class PublicationRoute extends Route.extend(AuthenticatedRouteMix
       'filter[subcase][publication-flow][:id:]': publicationFlow.id,
       'filter[type][:id:]': CONFIG.ACTIVITY_TYPES.drukproeven.id,
     });
-    const withdrawnPublishPrevieuwRequests = await this.store.query('activity', {
+    const withdrawnPublishPreviewRequests = await this.store.query('activity', {
       'filter[subcase][publication-flow][:id:]': publicationFlow.id,
       'filter[type][:id:]': CONFIG.ACTIVITY_TYPES.drukproeven.id,
       'filter[status][:id:]': CONFIG.ACTIVITY_STATUSSES.withdrawn.id,
     });
-    const closedPublishPrevieuwRequests = await this.store.query('activity', {
+    const closedPublishPreviewRequests = await this.store.query('activity', {
       'filter[subcase][publication-flow][:id:]': publicationFlow.id,
       'filter[type][:id:]': CONFIG.ACTIVITY_TYPES.drukproeven.id,
       'filter[status][:id:]': CONFIG.ACTIVITY_STATUSSES.closed.id,
@@ -47,7 +47,7 @@ export default class PublicationRoute extends Route.extend(AuthenticatedRouteMix
         totalTranslations: totalTranslations.length,
         closedOrWithdrawnTranslationRequests: closedTranslationRequests.length + withdrawnTranslationRequests.length,
         totalPublishPreviewRequests: totalPublishPreviewRequests.length,
-        closedOrWithdrawnPublishPrevieuwRequests: closedPublishPrevieuwRequests.length + withdrawnPublishPrevieuwRequests.length,
+        closedOrWithdrawnPublishPreviewRequests: closedPublishPreviewRequests.length + withdrawnPublishPreviewRequests.length,
       },
       refreshAction: this.refreshModel,
     });

--- a/app/pods/publications/publication/route.js
+++ b/app/pods/publications/publication/route.js
@@ -21,7 +21,7 @@ export default class PublicationRoute extends Route.extend(AuthenticatedRouteMix
       'filter[type][:id:]': CONFIG.ACTIVITY_TYPES.vertalen.id,
       'filter[status][:id:]': CONFIG.ACTIVITY_STATUSSES.closed.id,
     });
-    const WithdrawnTranslationRequests = await this.store.query('activity', {
+    const withdrawnTranslationRequests = await this.store.query('activity', {
       'filter[subcase][publication-flow][:id:]': publicationFlow.id,
       'filter[type][:id:]': CONFIG.ACTIVITY_TYPES.vertalen.id,
       'filter[status][:id:]': CONFIG.ACTIVITY_STATUSSES.withdrawn.id,
@@ -45,7 +45,7 @@ export default class PublicationRoute extends Route.extend(AuthenticatedRouteMix
       publicationFlow,
       counts: {
         totalTranslations: totalTranslations.length,
-        closedOrWithdrawnTranslationRequests: closedTranslationRequests.length + WithdrawnTranslationRequests.length,
+        closedOrWithdrawnTranslationRequests: closedTranslationRequests.length + withdrawnTranslationRequests.length,
         totalPublishPreviewRequests: totalPublishPreviewRequests.length,
         closedOrWithdrawnPublishPrevieuwRequests: closedPublishPrevieuwRequests.length + withdrawnPublishPrevieuwRequests.length,
       },

--- a/app/pods/publications/publication/template.hbs
+++ b/app/pods/publications/publication/template.hbs
@@ -5,9 +5,11 @@
         <div class="o-flex o-flex--vertical auk-u-mt-2">
           <span class="auk-overline auk-u-muted"
                   data-test-publication-detail-menu-publication-number>
-            {{uppercase (concat (t "publication-flow") " " this.model.publicationNumber)}}
+            {{uppercase
+              (concat (t "publication-flow") " " this.model.publicationFlow.publicationNumber)
+            }}
           </span>
-          <h4 class="auk-toolbar-complex__title" data-test-publication-detail-menu-short-title>{{model.case.shortTitle}}</h4>
+          <h4 class="auk-toolbar-complex__title" data-test-publication-detail-menu-short-title>{{model.publicationFlow.case.shortTitle}}</h4>
           <WebComponents::AuTabs @reversed="true">
             <WebComponents::AuTab @isHierarchicalBack="true" @route="publications.in-progress.in-progress-not-minister" data-test-publication-case-nav-go-back></WebComponents::AuTab>
             <WebComponents::AuTab @route="publications.publication.case" data-test-publication-case-nav-case>{{t "agendaitem-case"}}</WebComponents::AuTab>
@@ -15,13 +17,13 @@
             <WebComponents::AuTab @route="publications.publication.translations" data-test-publication-case-nav-translations>
               <div class="o-flex o-flex--center">
                 <span class="auk-u-mr-2">{{t "translations"}}</span>
-                <WebComponents::AuStatusPill></WebComponents::AuStatusPill>
+                <WebComponents::AuStatusPill>{{this.model.counts.openTranslationRequests}}&#47;{{this.model.counts.totalTranslations}}</WebComponents::AuStatusPill>
               </div>
             </WebComponents::AuTab>
             <WebComponents::AuTab @route="publications.publication.publishpreview" data-test-publication-case-nav-publishpreview>
               <div class="o-flex o-flex--center">
                 <span class="auk-u-mr-2">{{t "publishpreview-requests"}}</span>
-                <WebComponents::AuStatusPill></WebComponents::AuStatusPill>
+                <WebComponents::AuStatusPill>{{this.model.counts.openPublishPrevieuwRequests}}&#47;{{this.model.counts.totalPublishPreviewRequests}}</WebComponents::AuStatusPill>
               </div>
             </WebComponents::AuTab>
           </WebComponents::AuTabs>
@@ -62,7 +64,7 @@
             <div class="auk-u-m-3">
               <div class="auk-form-group {{getClassForPublicationNumber}}">
                 <WebComponents::AuLabel>{{t 'publications-number'}}</WebComponents::AuLabel>
-                <WebComponents::AuInput type="number" value={{this.model.publicationNumber}} @block="true"
+                <WebComponents::AuInput type="number" value={{this.model.publicationFlow.publicationNumber}} @block="true"
                   {{on "input" (perform this.setPublicationNumber)}} />
                 {{#if this.numberIsAlreadyUsed}}
                   <div class="auk-form-help-text auk-form-help-text--danger">
@@ -89,10 +91,10 @@
               </div>
               <div class="auk-form-group">
                 <WebComponents::AuLabel>{{t "publication-form-numac-nummer"}}</WebComponents::AuLabel>
-                <WebComponents::AuInput type="number" value={{this.model.numacNumber}} @block="true" readonly
+                <WebComponents::AuInput type="number" value={{this.model.publicationFlow.numacNumber}} @block="true" readonly
                   {{on "input" (perform this.setNumacNumber)}} />
               </div>
-              {{#if this.model.status.isToBePublished}}
+              {{#if this.model.publicationFlow.status.isToBePublished}}
                 <div class="auk-form-group">
                   <WebComponents::AuLabel>{{t 'final-publication-date'}}</WebComponents::AuLabel>
                   {{#if this.showPublicationDatePicker}}
@@ -140,7 +142,7 @@
                   {{/if}}
                 </div>
               {{/if}}
-              {{#if this.model.status.isPublished}}
+              {{#if this.model.publicationFlow.status.isPublished}}
                 <div class="auk-form-group">
                   <WebComponents::AuLabel for="blockInput">{{t "publication-form-publication-date"}}</WebComponents::AuLabel>
                   <WebComponents::AuDatepicker @defaultDate={{this.getPublicationDate}} @onChange={{this.setPublicationDate}}/>

--- a/app/pods/publications/publication/template.hbs
+++ b/app/pods/publications/publication/template.hbs
@@ -17,13 +17,13 @@
             <WebComponents::AuTab @route="publications.publication.translations" data-test-publication-case-nav-translations>
               <div class="o-flex o-flex--center">
                 <span class="auk-u-mr-2">{{t "translations"}}</span>
-                <WebComponents::AuStatusPill>{{this.model.counts.openTranslationRequests}}&#47;{{this.model.counts.totalTranslations}}</WebComponents::AuStatusPill>
+                <WebComponents::AuStatusPill>{{this.model.counts.closedOrWithdrawnTranslationRequests}}&#47;{{this.model.counts.totalTranslations}}</WebComponents::AuStatusPill>
               </div>
             </WebComponents::AuTab>
             <WebComponents::AuTab @route="publications.publication.publishpreview" data-test-publication-case-nav-publishpreview>
               <div class="o-flex o-flex--center">
                 <span class="auk-u-mr-2">{{t "publishpreview-requests"}}</span>
-                <WebComponents::AuStatusPill>{{this.model.counts.openPublishPrevieuwRequests}}&#47;{{this.model.counts.totalPublishPreviewRequests}}</WebComponents::AuStatusPill>
+                <WebComponents::AuStatusPill>{{this.model.counts.closedOrWithdrawnPublishPrevieuwRequests}}&#47;{{this.model.counts.totalPublishPreviewRequests}}</WebComponents::AuStatusPill>
               </div>
             </WebComponents::AuTab>
           </WebComponents::AuTabs>

--- a/app/pods/publications/publication/translations/controller.js
+++ b/app/pods/publications/publication/translations/controller.js
@@ -17,7 +17,7 @@ export default class PublicationTranslationController extends Controller {
     translationActivity.status = CONFIG.ACTIVITY_STATUSSES.withdrawn;
     translationActivity.endDate = moment().utc();
     await translationActivity.save();
-    await this.send('refreshModel');
+    this.model.refreshAction();
     this.showLoader = false;
   }
 
@@ -27,7 +27,7 @@ export default class PublicationTranslationController extends Controller {
     translationActivity.status = CONFIG.ACTIVITY_STATUSSES.closed;
     translationActivity.endDate = moment().utc();
     await translationActivity.save();
-    await this.send('refreshModel');
+    this.model.refreshAction();
     this.showLoader = false;
   }
 }

--- a/app/pods/publications/publication/translations/controller.js
+++ b/app/pods/publications/publication/translations/controller.js
@@ -14,7 +14,8 @@ export default class PublicationTranslationController extends Controller {
   @action
   async cancelExistingTranslationActivity(translationActivity) {
     this.showLoader = true;
-    translationActivity.status = CONFIG.ACTIVITY_STATUSSES.withdrawn;
+    const withDrawnStatus = await this.store.findRecord('activity-status', CONFIG.ACTIVITY_STATUSSES.withdrawn.id);
+    translationActivity.status = withDrawnStatus;
     translationActivity.endDate = moment().utc();
     await translationActivity.save();
     this.model.refreshAction();
@@ -24,7 +25,8 @@ export default class PublicationTranslationController extends Controller {
   @action
   async markTranslationActivityDone(translationActivity) {
     this.showLoader = true;
-    translationActivity.status = CONFIG.ACTIVITY_STATUSSES.closed;
+    const closedStatus = await this.store.findRecord('activity-status', CONFIG.ACTIVITY_STATUSSES.closed.id);
+    translationActivity.status = closedStatus;
     translationActivity.endDate = moment().utc();
     await translationActivity.save();
     this.model.refreshAction();

--- a/app/pods/publications/publication/translations/route.js
+++ b/app/pods/publications/publication/translations/route.js
@@ -2,11 +2,11 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 import Route from '@ember/routing/route';
 import CONFIG from 'fe-redpencil/utils/config';
 import { hash } from 'rsvp';
-import { action } from '@ember/object';
 
 export default class PublicationTranslationRoute extends Route.extend(AuthenticatedRouteMixin) {
   async model() {
-    const publicationFlow = this.modelFor('publications.publication');
+    const parentHash = this.modelFor('publications.publication');
+    const publicationFlow = parentHash.publicationFlow;
     let _case = await publicationFlow.get('case');
     _case = await this.store.findRecord('case', _case.get('id'), {
       include: 'pieces,pieces.document-container,pieces.document-container.type',
@@ -23,11 +23,7 @@ export default class PublicationTranslationRoute extends Route.extend(Authentica
       publicationFlow,
       case: _case,
       translationActivities: translationActivities,
+      refreshAction: parentHash.refreshAction,
     });
-  }
-
-  @action
-  refreshModel() {
-    this.refresh();
   }
 }

--- a/app/pods/publications/publication/translations/template.hbs
+++ b/app/pods/publications/publication/translations/template.hbs
@@ -10,15 +10,15 @@
           </WebComponents::AuToolbar::Group>
           <WebComponents::AuToolbar::Group @position="right">
 
-            {{#if activity.isWithdrawn }}
+            {{#if (await activity.isWithdrawn) }}
 
               <WebComponents::AuToolbar::Item>
                 <WebComponents::AuPillList>
-                  <WebComponents::AuPill @skin="danger">{{t "canceled-request"}} {{moment-format activity.endDate "DD MMMM YYYY [om] H:mm"}}</WebComponents::AuPill>
+                  <WebComponents::AuPill @skin="danger">{{t "cancelled-request"}} {{moment-format activity.endDate "DD MMMM YYYY [om] H:mm"}}</WebComponents::AuPill>
                 </WebComponents::AuPillList>
               </WebComponents::AuToolbar::Item>
 
-            {{else if activity.isFinished }}
+            {{else if (await activity.isFinished) }}
 
               <WebComponents::AuToolbar::Item>
                 {{t "finished"}} {{moment-format activity.endDate "DD MMMM YYYY [om] H:mm"}}

--- a/app/services/activity-service.js
+++ b/app/services/activity-service.js
@@ -23,7 +23,7 @@ export default class activityService extends Service {
   }
 
   /**
-   * Replace activityn Tokens.
+   * Replace activity Tokens.
    *
    * @param string
    * @param publicationFlow
@@ -31,11 +31,11 @@ export default class activityService extends Service {
    * @returns {Promise<*>}
    */
   async replaceTokens(defaultString, publicationFlow, _case) {
-    let string = defaultString;
-    string = string.replace('%%nummer%%', publicationFlow.publicationNumber);
-    string = string.replace('%%titel%%', this.caseTitleFromCase(_case));
-    string = string.replace('%%kaleidosenvironment%%', window.location.origin);
-    return string;
+    let outputString = defaultString;
+    outputString = outputString.replace('%%nummer%%', publicationFlow.publicationNumber);
+    outputString = outputString.replace('%%titel%%', this.caseTitleFromCase(_case));
+    outputString = outputString.replace('%%kaleidosenvironment%%', window.location.origin);
+    return outputString;
   }
 
   /**

--- a/app/services/activity-service.js
+++ b/app/services/activity-service.js
@@ -30,7 +30,7 @@ export default class activityService extends Service {
    * @param _case
    * @returns {Promise<*>}
    */
-  async replaceTokens(defaultString, publicationFlow, _case) {
+  replaceTokens(defaultString, publicationFlow, _case) {
     let outputString = defaultString;
     outputString = outputString.replace('%%nummer%%', publicationFlow.publicationNumber);
     outputString = outputString.replace('%%titel%%', this.caseTitleFromCase(_case));
@@ -52,11 +52,11 @@ export default class activityService extends Service {
       .toDate();
 
     const requestTranslationActivityType = await this.store.findRecord('activity-type', CONFIG.ACTIVITY_TYPES.vertalen.id);
-    const requestTranslationActivityStatus = await this.store.findRecord('activity-status', CONFIG.ACTIVITY_STATUSSES.open.id);
+    const activityOpenStatus = await this.store.findRecord('activity-status', CONFIG.ACTIVITY_STATUSSES.open.id);
 
     // Create activity.
     const translateActivity = this.store.createRecord('activity', {
-      status: requestTranslationActivityStatus,
+      status: activityOpenStatus,
       startDate: creationDatetime,
       finalTranslationDate,
       mailContent,

--- a/app/services/activity-service.js
+++ b/app/services/activity-service.js
@@ -89,11 +89,11 @@ export default class activityService extends Service {
 
     // publishPreviewActivityType.
     const requestPublishPreviewActivityType = await this.store.findRecord('activity-type', CONFIG.ACTIVITY_TYPES.drukproeven.id);
-    const requestActivityStatus = await this.store.findRecord('activity-status', CONFIG.ACTIVITY_STATUSSES.open.id);
+    const activityOpenStatus = await this.store.findRecord('activity-status', CONFIG.ACTIVITY_STATUSSES.open.id);
 
     // Create activity.
     const PublishPreviewActivity = this.store.createRecord('activity', {
-      status: requestActivityStatus,
+      status: activityOpenStatus,
       startDate: creationDatetime,
       mailContent,
       subcase,
@@ -125,11 +125,11 @@ export default class activityService extends Service {
 
     // publishActivityType.
     const requestPublishActivityType = await this.store.findRecord('activity-type', CONFIG.ACTIVITY_TYPES.publiceren.id);
-    const requestActivityStatus = await this.store.findRecord('activity-status', CONFIG.ACTIVITY_STATUSSES.open.id);
+    const activityOpenStatus = await this.store.findRecord('activity-status', CONFIG.ACTIVITY_STATUSSES.open.id);
 
     // Create activity.
     const PublishPreviewActivity = this.store.createRecord('activity', {
-      status: requestActivityStatus,
+      status: activityOpenStatus,
       startDate: creationDatetime,
       mailContent,
       subcase,

--- a/app/services/activity-service.js
+++ b/app/services/activity-service.js
@@ -9,6 +9,36 @@ export default class activityService extends Service {
   @service intl;
 
   /**
+   * Get case title.
+   *
+   * @param _case
+   * @returns {*}
+   */
+  caseTitleFromCase(_case) {
+    const shortTitle = _case.shortTitle;
+    if (shortTitle) {
+      return shortTitle;
+    }
+    return _case.title;
+  }
+
+  /**
+   * Replace activityn Tokens.
+   *
+   * @param string
+   * @param publicationFlow
+   * @param _case
+   * @returns {Promise<*>}
+   */
+  async replaceTokens(defaultString, publicationFlow, _case) {
+    let string = defaultString;
+    string = string.replace('%%nummer%%', publicationFlow.publicationNumber);
+    string = string.replace('%%titel%%', this.caseTitleFromCase(_case));
+    string = string.replace('%%kaleidosenvironment%%', window.location.origin);
+    return string;
+  }
+
+  /**
    * Create a new Translation Activity.
    *
    * @param finalTranslationDate
@@ -22,10 +52,11 @@ export default class activityService extends Service {
       .toDate();
 
     const requestTranslationActivityType = await this.store.findRecord('activity-type', CONFIG.ACTIVITY_TYPES.vertalen.id);
+    const requestTranslationActivityStatus = await this.store.findRecord('activity-status', CONFIG.ACTIVITY_STATUSSES.open.id);
 
     // Create activity.
     const translateActivity = this.store.createRecord('activity', {
-      status: CONFIG.ACTIVITY_STATUSSES.open,
+      status: requestTranslationActivityStatus,
       startDate: creationDatetime,
       finalTranslationDate,
       mailContent,
@@ -58,10 +89,11 @@ export default class activityService extends Service {
 
     // publishPreviewActivityType.
     const requestPublishPreviewActivityType = await this.store.findRecord('activity-type', CONFIG.ACTIVITY_TYPES.drukproeven.id);
+    const requestActivityStatus = await this.store.findRecord('activity-status', CONFIG.ACTIVITY_STATUSSES.open.id);
 
     // Create activity.
     const PublishPreviewActivity = this.store.createRecord('activity', {
-      status: CONFIG.ACTIVITY_STATUSSES.open,
+      status: requestActivityStatus,
       startDate: creationDatetime,
       mailContent,
       subcase,
@@ -93,10 +125,11 @@ export default class activityService extends Service {
 
     // publishActivityType.
     const requestPublishActivityType = await this.store.findRecord('activity-type', CONFIG.ACTIVITY_TYPES.publiceren.id);
+    const requestActivityStatus = await this.store.findRecord('activity-status', CONFIG.ACTIVITY_STATUSSES.open.id);
 
     // Create activity.
     const PublishPreviewActivity = this.store.createRecord('activity', {
-      status: CONFIG.ACTIVITY_STATUSSES.open,
+      status: requestActivityStatus,
       startDate: creationDatetime,
       mailContent,
       subcase,

--- a/app/utils/config.js
+++ b/app/utils/config.js
@@ -38,15 +38,15 @@ export default EmberObject.create({
   mail: {
     defaultFromAddress: 'noreply@vlaanderen.be',
     translationRequest: {
-      content: 'Collega’s\n\nIn bijlage voor vertaling ons dossier (publicatienummer):\n\n%%titel%%\n\nLimiet vertaling: %%limiet%%\n\nAantal bladzijden:\n\nAantal woorden:\n\n\n\nVriendelijke groeten,\n\nTeam OVRB',
+      content: 'Collega’s\n\nIn bijlage voor vertaling ons dossier (publicatienummer):\n\n%%titel%%\n\nLimiet vertaling:\n\nAantal bladzijden:\n\nAantal woorden:\n\n\n\nVriendelijke groeten,\n\nTeam OVRB\n\n[%%kaleidosenvironment%%]',
       subject: '[%%kaleidosenvironment%%] Vertaalaanvraag (%%nummer%%)',
     },
     publishPreviewRequest: {
-      content: 'Beste,\n\nIn bijlage voor drukproef ons dossier (%%nummer%%):\n\n(%%titel%%)\n\nVriendelijke groeten,\n\nTeam OVRB',
+      content: 'Beste,\n\nIn bijlage voor drukproef ons dossier (%%nummer%%):\n\n(%%titel%%)\n\nVriendelijke groeten,\n\nTeam OVRB\n\n[%%kaleidosenvironment%%]',
       subject: '[%%kaleidosenvironment%%] Dossier (%%nummer%%) – drukproef aub',
     },
     publishRequest: {
-      content: 'Beste,\n\nIn bijlage \n\n%%attachments%%\n\nVoor publicatie %%nummer%%.\n\nVriendelijke groeten,\n\nTeam OVRB',
+      content: 'Beste,\n\nVoor publicatie %%nummer%%.\n\nVriendelijke groeten,\n\nTeam OVRB\n\n[%%kaleidosenvironment%%]',
       subject: '[%%kaleidosenvironment%%] Aanvraag publicatie (%%numac%%)',
     },
   },
@@ -193,9 +193,18 @@ export default EmberObject.create({
     },
   },
   ACTIVITY_STATUSSES: {
-    open: 'open',
-    withdrawn: 'withdrawn',
-    closed: 'closed',
+    open: {
+      url: 'http://kanselarij.vo.data.gift/id/concept/activity-types/917349a2-4361-11eb-b378-0242ac130002',
+      id: '917349a2-4361-11eb-b378-0242ac130002',
+    },
+    withdrawn: {
+      url: 'http://kanselarij.vo.data.gift/id/concept/activity-types/b26eb1a0-4361-11eb-b378-0242ac130002',
+      id: 'b26eb1a0-4361-11eb-b378-0242ac130002',
+    },
+    closed: {
+      url: 'http://kanselarij.vo.data.gift/id/concept/activity-types/a6f7b9f2-4361-11eb-b378-0242ac130002',
+      id: 'a6f7b9f2-4361-11eb-b378-0242ac130002',
+    },
   },
   SUBCASE_TYPES: {
     vertalen: {

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -689,7 +689,7 @@
   "name-document": "Naam Document",
   "file-extension": "Bestandstype",
   "cancel-request": "Aanvraag intrekken",
-  "canceled-request": "ingetrokken",
+  "cancelled-request": "ingetrokken",
   "requested-on": "Aanvraag op",
   "request": "Aanvraag",
   "translation-mail-header": "Begeleidende tekst",


### PR DESCRIPTION
# Related
Pr met model changes: https://github.com/kanselarij-vlaanderen/kaleidos-project/pull/143/files

# KAS-2123: Aanvraag statussen tonen
In deze PR hebben we de de status pills geïmplementeerd die weergeven waar de vertalingsaanvraag staat voor een publicatieflow.

## What has changed:
- Aanvragen voor vertalingsaanvragen en drukproefaanvragen worden opgehaald
- Views refreshen bij het aanmaken van data.
 
## Screenshots
![image](https://user-images.githubusercontent.com/11557630/102617687-e1131e80-4139-11eb-88c1-107621843e3f.png)
