### PR TITLE
KAS-2153 don't use lastPiece, sortedPieces promise return wrong sorted list

### DIFF
--- a/app/pods/components/documents/report-link/component.js
+++ b/app/pods/components/documents/report-link/component.js
@@ -106,16 +106,17 @@ export default class ReportLink extends Component {
       this.defaultAccessLevel = await this.store.findRecord('access-level', config.internRegeringAccessLevelId);
     }
 
-    const previousPiece = this.args.documentContainer ? (await this.args.documentContainer.get('lastPiece')) : null;
+    const containerPieces = await this.args.documentContainer.get('pieces');
+    const sortedContainerPieces = containerPieces.sortBy('created');
+    const previousPiece = sortedContainerPieces.get('lastObject');
     const newPiece = this.createNewPiece(uploadedFile, previousPiece, {
       accessLevel: this.defaultAccessLevel,
     });
     newPiece.set('created', creationDate);
     newPiece.set('modified', creationDate);
-    const pieces = await this.args.documentContainer.get('pieces');
-    pieces.pushObject(newPiece);
+    containerPieces.pushObject(newPiece);
     newPiece.set('documentContainer', this.args.documentContainer); // Explicitly set relation both ways
-    const newName = new VRDocumentName(previousPiece.get('name')).withOtherPieceSuffix(pieces.length);
+    const newName = new VRDocumentName(previousPiece.get('name')).withOtherPieceSuffix(containerPieces.length);
     newPiece.set('name', newName);
     this.args.documentContainer.notifyPropertyChange('pieces');// Why exactly? Ember should handle this?
     this.pieceInCreation = await newPiece;
@@ -172,8 +173,8 @@ export default class ReportLink extends Component {
   @action
   async cancelUploadPiece() {
     if (this.uploadedFile) {
-      const piece = await this.args.documentContainer.lastPiece;
-      piece.rollbackAttributes();
+      const previousPiece = await this.pieceInCreation.get('previousPiece');
+      previousPiece.rollbackAttributes();
       const pieceInCreation = await this.uploadedFile.get('piece');
       if (pieceInCreation) {
         await this.fileService.deletePiece(pieceInCreation);
@@ -181,6 +182,7 @@ export default class ReportLink extends Component {
         await this.fileService.deleteFile(this.uploadedFile);
       }
       this.uploadedFile = null;
+      this.pieceInCreation = null;
     }
     this.isUploadingNewPiece = false;
   }
@@ -188,7 +190,7 @@ export default class ReportLink extends Component {
   @action
   async savePiece() {
     this.isLoading = true;
-    const piece = await this.args.documentContainer.lastPiece;
+    const piece = this.pieceInCreation;
     await piece.save();
     try {
       await this.attachPieceToTreatment(piece, this.args.treatment);
@@ -200,6 +202,7 @@ export default class ReportLink extends Component {
         this.uploadedFile = null;
         this.isLoading = false;
         this.isUploadingNewPiece = false;
+        this.pieceInCreation = null;
       }
     }
   }
@@ -238,10 +241,14 @@ export default class ReportLink extends Component {
   @action
   async setPreviousPiece(documentContainer) {
     if (documentContainer) {
-      const lastPiece = await documentContainer.get('lastPiece');
-      if (lastPiece) {
-        this.args.treatment.set('report', lastPiece);
-        await this.args.treatment.save();
+      const containerPieces = await documentContainer.get('pieces');
+      if (containerPieces) {
+        const sortedContainerPieces = containerPieces.sortBy('created');
+        const previousPiece = sortedContainerPieces.get('lastObject');
+        if (previousPiece) {
+          this.args.treatment.set('report', previousPiece);
+          await this.args.treatment.save();
+        }
       }
     }
   }


### PR DESCRIPTION
# HOTFIX to PROD!

KAS-2153: Bis beslissing kon niet opgeladen worden
Na debuggen gezien dat de computed documentContainer.lastPiece een fout piece terug gaf.
Dit kwam doordat de computed documentContainer.sortedPieces een fout gesorteerde lijst teruggeeft.
Dit zijn allebei computeds die met promises werken, vermoedelijk gaat het daarom fout.

Bij het uploaden van een bisbeslissing krijgen we daardoor de originele beslissing terug, en die werd gesaved ipv de BIS...

## What has changed:
Report-link/component.js:
- previousPiece ophalen via documentContainer.lastPiece vervangen door ter plaatse te gaan sorteren ipv te werken met computed promises.

bij cancelUploadPieces:
- De .lastPiece was soms fout, we willen hier de previousPiece rollbacken, de nieuwe piece wordt hier sowieso verwijdert.
- Ook pieceInCreation hier leegmaken, state werd bijgehouden en was niet juist.

bij savePiece:
- de .lastPiece was soms fout, na uploaden BIS kwam hier de originele piece uit, dus de bis wordt dan niet gesaved, als gevolg heeft treatment nog steeds hetzelfde report (origineel ipv BIS)

bij setPreviousPiece:
- Bij verwijderen van de laatste versie moeten we de vorige versie herstellen dus ook hier lastPiece vervangen om zeker te zijn dat we de juiste piece hebben.

# HOTFIX to PROD!

