### PR TITLE
Bugfix/kas 2000 stale pieces from cache

### DIFF
--- a/app/pods/components/documents/subcase-documents/component.js
+++ b/app/pods/components/documents/subcase-documents/component.js
@@ -17,6 +17,8 @@ import { addPieceToAgendaitem } from 'fe-redpencil/utils/documents';
 
 export default class SubcaseDocuments extends Component {
   @service currentSession;
+  @service toaster;
+  @service intl;
   @service store;
 
   @tracked isEnabledPieceEdit = false;
@@ -173,6 +175,10 @@ export default class SubcaseDocuments extends Component {
           // list from cache is stale, wait with back-off strategy
           yield timeout(500 + (index * 500));
         }
+        this.toaster.error(this.intl.t('documents-may-not-be-saved-message'), this.intl.t('warning-title'),
+          {
+            timeOut: 60000,
+          });
       }
     } else if (this.itemType === 'subcase') {
       // Link piece to all agendaitems that are related to the subcase via an agendaActivity
@@ -199,7 +205,10 @@ export default class SubcaseDocuments extends Component {
             // list from cache is stale, wait with back-off strategy
             yield timeout(500 + (index * 500));
           }
-        // Throw error ? remove doc ?
+          this.toaster.error(this.intl.t('documents-may-not-be-saved-message'), this.intl.t('warning-title'),
+            {
+              timeOut: 60000,
+            });
         }
       }
 

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -674,5 +674,6 @@
   "view-document-details": "Bekijk document details",
   "publication-number-already-taken":"Dit publicatienummer is reeds in gebruik.",
   "date-expired": "Datum verstreken",
-  "publication-sidebar-tooltip": "Dit is een interne opmerking voor het OVRB-team."
+  "publication-sidebar-tooltip": "Dit is een interne opmerking voor het OVRB-team.",
+  "documents-may-not-be-saved-message": "Er zijn inconsistenties vastgesteld bij het toevoegen van de documenten. Noteer je wijzigingen en hernieuw deze pagina om te kijken of de documenten correct zijn toegevoegd."
 }


### PR DESCRIPTION
# HOTFIX voor PROD!! #


bug: BIS/TER etc. verdwijnen regelmatig van de agendapunten
voor beschrijving van het probleem:
https://kanselarij.atlassian.net/browse/KAS-2000?focusedCommentId=14893

## What has changed ##
bij toevoegen documenten (meerdere nieuwe) /of nieuwe versies (1 per keer) wordt dezelfde code gebruikt om agendapunten en procedurestappen te updaten

Toevoegen via agendaitem:
- na de PUT calls van de nieuwe pieces een reload lus toegevoegd, waarbij we het resultat checken van de reload van de relatie.
in lokale testen hebben we 1 a 2 iteraties voor de cache de juiste data teruggeeft (lokale stack huft en puft)
- Als de reload niet zou lukken na 10 keer tonen we een waarschuwing dat de gebruiker moet refreshen.
Dan is de lokale data sowieso weg.

Toevoegen via prodecurestap:
- async map omgezet naar for lus
- het setten van properties en saven van agendaitem verplaatst naar zodat dit voor de PUT call gebeuren
- na de PUT calls ook de reload lust gezet, zodat we de lokale store kunnen updaten let correcte data vanuit de cache
- waarschuwing als de lus na 10 keer nog steeds geen juiste data oplevert.


# HOTFIX voor PROD!! #