### PR TITLE
Bugfix/kas 2164 sorted pieces

### DIFF
--- a/app/models/document-container.js
+++ b/app/models/document-container.js
@@ -58,9 +58,9 @@ export default Model.extend({
     }
   ),
 
-  reverseSortedPieces: computed('sortedPieces', function() {
+  reverseSortedPieces: computed('pieces.@each', function() {
     return PromiseArray.create({
-      promise: this.get('sortedPieces').then((sortedPieces) => sortedPieces.reverse()),
+      promise: this.get('pieces').then((pieces) => pieces.sortBy('created').reverse()),
     });
   }),
 

--- a/app/pods/components/documents/report-link/component.js
+++ b/app/pods/components/documents/report-link/component.js
@@ -3,7 +3,6 @@ import { action } from '@ember/object';
 import moment from 'moment';
 import { inject as service } from '@ember/service';
 import config from 'fe-redpencil/utils/config';
-import { A } from '@ember/array';
 import VRDocumentName from 'fe-redpencil/utils/vr-document-name';
 import { tracked } from '@glimmer/tracking';
 
@@ -15,7 +14,6 @@ export default class ReportLink extends Component {
   @service store;
 
   @tracked isShowingPieces = false;
-  @tracked reverseSortedPieces = A([]);
   @tracked isUploadingNewPiece = false;
   @tracked isEditing = false;
   @tracked defaultAccessLevel = null;
@@ -24,7 +22,6 @@ export default class ReportLink extends Component {
   @tracked nameBuffer = '';
   @tracked isVerifyingDelete = false;
   @tracked lastPiece = null;
-  @tracked mySortedPieces;
   @tracked documentTypes = null;
 
   classNameBindings = ['aboutToDelete'];


### PR DESCRIPTION
initiële gedachte was dat er iets mis was met de computed sortedPieces en lastPiece van documentContainer.

Na grondig zoeken gevonden dat het probleem lag bij een andere computed, reverseSortedPieces.
Die ging de sortedPieces reversen bij het openen van de versie geschiedenis.
Die array hersorteren in de reverseSortedPieces ging geen nieuwe lijst gebruiken/teruggeven, maar ging de originele lijst van sortedPieces hersorteren omdat de ref hetzelfde is.

Opgelost door de reversedSortedPieces te laten starten van de relatie pieces en de sort opnieuw te doen en te reversen

note: sortBy('-created') werkt niet, de enige juiste manier is sortBy('created') en dan reversen.

In report-link is het enkel opkuis, daar stonden nog ongebruikte tracked variabelen