### PR TITLE
KAS-2165 correct use of sortBy

### DIFF
--- a/app/pods/components/agenda/agenda-header/component.js
+++ b/app/pods/components/agenda/agenda-header/component.js
@@ -56,7 +56,7 @@ export default Component.extend(FileSaverMixin, {
   currentAgendaitems: alias('sessionService.currentAgendaitems'),
   currentSession: alias('sessionService.currentSession'),
   currentAgenda: alias('sessionService.currentAgenda'),
-  agendas: alias('sessionService.agendas'),
+  agendas: alias('sessionService.agendas'), // This list is reverse sorted on serialNumber
   selectedAgendaitem: alias('sessionService.selectedAgendaitem'),
   definiteAgendas: alias('sessionService.definiteAgendas'),
 
@@ -76,7 +76,8 @@ export default Component.extend(FileSaverMixin, {
     const agendas = await this.get('agendas');
     const lastAgendaFromList = agendas
       .filter((agenda) => !agenda.get('isDesignAgenda'))
-      .sortBy('-serialnumber')
+      .sortBy('serialnumber')
+      .reverse()
       .get('firstObject');
     return lastAgendaFromList.agendaName;
   }),
@@ -210,11 +211,13 @@ export default Component.extend(FileSaverMixin, {
       const agendas = await this.get('agendas');
       const designAgenda = agendas
         .filter((agenda) => agenda.get('isDesignAgenda'))
-        .sortBy('-serialnumber')
+        .sortBy('serialnumber')
+        .reverse()
         .get('firstObject');
       const lastAgenda = agendas
         .filter((agenda) => !agenda.get('isDesignAgenda'))
-        .sortBy('-serialnumber')
+        .sortBy('serialnumber')
+        .reverse()
         .get('firstObject');
 
       if (lastAgenda) {
@@ -497,12 +500,14 @@ export default Component.extend(FileSaverMixin, {
       const agendas = await this.get('agendas');
       const designAgenda = agendas
         .filter((agenda) => agenda.get('isDesignAgenda'))
-        .sortBy('-serialnumber')
+        .sortBy('serialnumber')
+        .reverse()
         .get('firstObject');
 
       const lastAgenda = agendas
         .filter((agenda) => !agenda.get('isDesignAgenda'))
-        .sortBy('-serialnumber')
+        .sortBy('serialnumber')
+        .reverse()
         .get('firstObject');
 
       const session = await lastAgenda.get('createdFor');

--- a/app/services/session-service.js
+++ b/app/services/session-service.js
@@ -59,7 +59,8 @@ export default Service.extend({
 
   definiteAgendas: computed('agendas', function() {
     return this.get('agendas').filter((agenda) => !agenda.get('isDesignAgenda'))
-      .sortBy('-name');
+      .sortBy('serialnumber')
+      .reverse();
   }),
 
   async findPreviousAgendaOfSession(session, agenda) {


### PR DESCRIPTION
Code spreekt voor zich.
Gekozen om de sortering bij te houden, ook al die is momenteel overbodig wan de alias van session-service is al correct gesorteerd

sortBy('-name') aangepast naar serialNumber omdat name een alias is van serialNumber in het agenda model.
`name: computed.alias('serialnumber'),`