### PR TITLE
KAS-2150: Paused functionality

### DIFF
--- a/app/models/publication-status.js
+++ b/app/models/publication-status.js
@@ -15,4 +15,8 @@ export default class PublicationStatus extends Model {
   get isPublished() {
     return this.uri === CONFIG.publicationStatusPublished.uri;
   }
+
+  get isPaused() {
+    return this.uri === CONFIG.publicationStatusPauzed.uri;
+  }
 }

--- a/app/pods/publications/paused/controller.js
+++ b/app/pods/publications/paused/controller.js
@@ -1,0 +1,11 @@
+import Controller from '@ember/controller';
+
+export default class PublicationsPausedController extends Controller {
+  get publicationsPaused() {
+    if (this.model) {
+      return this.model.filter((publication) => publication.isPaused);
+    }
+
+    return [];
+  }
+}

--- a/app/pods/publications/paused/index/route.js
+++ b/app/pods/publications/paused/index/route.js
@@ -1,0 +1,17 @@
+import Route from '@ember/routing/route';
+
+export default class IndexPausedRoute extends Route {
+  beforeModel() {
+    /* It is assumed here that explicitly navigating to the index-route
+     * expresses a desire to "reset", to "start a new search-session".
+     * Therefore all parameters except filters -such as "type" of agenda-item- are cleared.
+     * We assume that those (checkbox-like) filters are specific to the user/session
+     * and therefore are desired to be persisted. */
+    /* TODO: If you go through this transition when already in a search (sub-) route, the queryParams
+     * in the url get reset as requested, but you don't go through the model/setupController-hook
+     * of the "search" route, even though the queryParams are marked `refreshModel: true`.
+     * As a result "searchTextBuffer" doesn't get cleared.
+     */
+    this.transitionTo('publications.paused.paused-minister');
+  }
+}

--- a/app/pods/publications/paused/paused-minister/controller.js
+++ b/app/pods/publications/paused/paused-minister/controller.js
@@ -1,0 +1,33 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class PausedMinisterController extends Controller {
+  queryParams = {
+    page: {
+      type: 'number',
+    },
+    size: {
+      type: 'number',
+    },
+    sort: {
+      type: 'string',
+    },
+  };
+
+  sizeOptions = Object.freeze([5, 10, 20, 50, 100, 200]);
+
+  @tracked page = 0;
+  @tracked size = 25;
+  @tracked sort = '-created';
+
+  @action
+  selectSize(size) {
+    this.size = size;
+  }
+
+  @action
+  navigateToPublication(publicationFlowRow) {
+    this.transitionToRoute('publications.publication', publicationFlowRow.get('id'));
+  }
+}

--- a/app/pods/publications/paused/paused-minister/route.js
+++ b/app/pods/publications/paused/paused-minister/route.js
@@ -1,0 +1,46 @@
+import Route from '@ember/routing/route';
+import { action } from '@ember/object';
+import CONFIG from 'fe-redpencil/utils/config';
+
+export default class PausedMinisterRoute extends Route {
+  queryParams = {
+    page: {
+      refreshModel: true,
+      as: 'pagina',
+    },
+    size: {
+      refreshModel: true,
+      as: 'aantal',
+    },
+    sort: {
+      refreshModel: true,
+      as: 'sorteer',
+    },
+  };
+
+  async model(params) {
+    return this.store.query('publication-flow', {
+      filter: {
+        ':has:case': 'yes',
+        case: {
+          ':has:subcases': 'yes',
+        },
+        status: {
+          id: CONFIG.publicationStatusPauzed.id,
+        },
+      },
+      sort: params.sort,
+      include: 'case,status',
+    });
+  }
+
+  @action
+  refreshModel() {
+    this.refresh();
+  }
+
+  @action
+  refresh() {
+    super.refresh();
+  }
+}

--- a/app/pods/publications/paused/paused-minister/template.hbs
+++ b/app/pods/publications/paused/paused-minister/template.hbs
@@ -1,0 +1,86 @@
+<DataTable
+        @content={{this.model}}
+        @page={{this.page}}
+        @noDataMessage={{t "no-results-found"}}
+        @size={{this.size}}
+        @sort={{this.sort}}
+        @isLoading={{this.isLoadingModel}}
+        @onClickRow={{this.navigateToPublication}}
+        @class="auk-table auk-table--disable-bottom-border"
+        as |table|
+>
+  <table.content as |c|>
+    <c.header>
+      <th>{{t "agendaitem-case"}}</th>
+      {{th-sortable
+        currentSorting=this.sort
+        field="publicationNumber"
+        label=(t "publications-number")
+      }}
+      {{th-sortable
+        currentSorting=this.sort
+        field="publishBefore"
+        label=(t "publication-before")
+      }}
+      {{th-sortable
+        currentSorting=this.sort
+        field="modified"
+        label=(t "latest-modified")
+      }}
+      <th>{{t "translations"}}</th>
+      <th>{{t "proof"}}</th>
+      <th></th>
+      <th></th>
+    </c.header>
+    <c.body class="tr-hover" as |row|>
+      <td>
+        {{row.case.shortTitle}}
+      </td>
+      <td>
+        {{row.publicationNumber}}
+      </td>
+      <td>
+        {{#if row.publicationBefore}}
+          {{moment-format row.publicationBefore "DD-MM-YYYY"}}
+        {{else}}
+          {{t "dash"}}
+        {{/if}}
+      </td>
+      <td>
+        {{moment-format row.modified "DD-MM-YYYY"}}<br/>
+        <span class="auk-u-text-small auk-u-muted">{{moment-format row.modified "HH:mm"}}</span>
+      </td>
+      <td>
+        {{t "dash"}}
+        {{!-- {{#if row.translationStatus.[0].initiated}}
+        <WebComponents::AuStatusPill @status={{row.translationStatus.[0].status}}>{{row.translationStatus.[0].finished}}/{{row.translationStatus.[0].total}}</WebComponents::AuStatusPill>
+        {{else}}
+        -
+        {{/if}} --}}
+      </td>
+      <td>
+        {{t "dash"}}
+        {{!-- {{#if row.printProofStatus.[0].initiated}}
+        <WebComponents::AuStatusPill @status={{row.printProofStatus.[0].status}}>{{row.printProofStatus.[0].finished}}/{{row.printProofStatus.[0].total}}</WebComponents::AuStatusPill>
+        {{else}}
+        -
+        {{/if}} --}}
+      </td>
+      <td>
+        {{t "dash"}}
+        {{!-- <WebComponents::AuButton @skin="borderless" @layout="icon-only" @icon="comment" /> --}}
+        {{!-- {{#if row.internalComment}}
+        <WebComponents::AuButton @skin="borderless" @layout="icon-only" @icon="comment" id="comment-{{increment index}}">Hover over mij om de comment te bekijken</WebComponents::AuButton>
+        <EmberTooltip @tooltipClass="auk-tooltip" @targetId="comment-{{increment index}}" @side="left">
+          {{row.internalComment}}
+        </EmberTooltip>
+        {{/if}} --}}
+      </td>
+      <td>
+        <WebComponents::AuButtonToolbar>
+          <WebComponents::AuButton {{on "click" (fn this.navigateToPublication row)}} @skin="borderless" @layout="icon-only" @icon="chevron-right" data-test-publications-button-go-to-publication/>
+        </WebComponents::AuButtonToolbar>
+      </td>
+    </c.body>
+  </table.content>
+</DataTable>

--- a/app/pods/publications/paused/paused-not-minister/controller.js
+++ b/app/pods/publications/paused/paused-not-minister/controller.js
@@ -1,0 +1,33 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class PausedNotMinisterController extends Controller {
+  queryParams = {
+    page: {
+      type: 'number',
+    },
+    size: {
+      type: 'number',
+    },
+    sort: {
+      type: 'string',
+    },
+  };
+
+  sizeOptions = Object.freeze([5, 10, 25, 50, 100, 200]);
+
+  @tracked page = 0;
+  @tracked size = 25;
+  @tracked sort = '-created';
+
+  @action
+  selectSize(size) {
+    this.size = size;
+  }
+
+  @action
+  navigateToPublication(publicationFlowRow) {
+    this.transitionToRoute('publications.publication', publicationFlowRow.get('id'));
+  }
+}

--- a/app/pods/publications/paused/paused-not-minister/route.js
+++ b/app/pods/publications/paused/paused-not-minister/route.js
@@ -1,0 +1,50 @@
+import Route from '@ember/routing/route';
+import { action } from '@ember/object';
+import CONFIG from 'fe-redpencil/utils/config';
+
+export default class PausedNotMinisterRoute extends Route {
+  queryParams = {
+    page: {
+      refreshModel: true,
+      as: 'pagina',
+    },
+    size: {
+      refreshModel: true,
+      as: 'aantal',
+    },
+    sort: {
+      refreshModel: true,
+      as: 'sorteer',
+    },
+  };
+
+  async model(params) {
+    return this.store.query('publication-flow', {
+      filter: {
+        ':has:case': 'yes',
+        case: {
+          ':has-no:subcases': 'yes',
+        },
+        status: {
+          id: CONFIG.publicationStatusWithdrawn.id,
+        },
+      },
+      sort: params.sort,
+      page: {
+        number: params.page,
+        size: params.size,
+      },
+      include: 'case',
+    });
+  }
+
+  @action
+  refreshModel() {
+    this.refresh();
+  }
+
+  @action
+  refresh() {
+    super.refresh();
+  }
+}

--- a/app/pods/publications/paused/paused-not-minister/route.js
+++ b/app/pods/publications/paused/paused-not-minister/route.js
@@ -26,7 +26,7 @@ export default class PausedNotMinisterRoute extends Route {
           ':has-no:subcases': 'yes',
         },
         status: {
-          id: CONFIG.publicationStatusWithdrawn.id,
+          id: CONFIG.publicationStatusPauzed.id,
         },
       },
       sort: params.sort,

--- a/app/pods/publications/paused/paused-not-minister/template.hbs
+++ b/app/pods/publications/paused/paused-not-minister/template.hbs
@@ -1,0 +1,92 @@
+<DataTable
+    @content={{this.model}}
+    @page={{this.page}}
+    @noDataMessage={{t "no-results-found"}}
+    @size={{this.size}}
+    @sort={{this.sort}}
+    @isLoading={{this.isLoadingModel}}
+    @onClickRow={{this.navigateToPublication}}
+    @class="auk-table auk-table--disable-bottom-border"
+    as |table|
+>
+  <table.content as |c|>
+    <c.header>
+      <th>{{t "agendaitem-case"}}</th>
+      {{th-sortable
+        currentSorting=this.sort
+        field="publicationNumber"
+        label=(t "publications-number")
+      }}
+      {{th-sortable
+        currentSorting=this.sort
+        field="publishBefore"
+        label=(t "publication-before")
+      }}
+      {{th-sortable
+        currentSorting=this.sort
+        field="modified"
+        label=(t "latest-modified")
+      }}
+      <th>{{t "translations"}}</th>
+      <th>{{t "proof"}}</th>
+      <th></th>
+      <th></th>
+    </c.header>
+    <c.body class="tr-hover" as |row|>
+      <td>
+        {{row.case.shortTitle}}
+      </td>
+      <td>
+        {{row.publicationNumber}}
+      </td>
+      <td>
+        {{#if row.publishBefore}}
+          {{moment-format row.publishBefore "DD-MM-YYYY"}}
+        {{else}}
+          {{t "dash"}}
+        {{/if}}
+      </td>
+      <td>
+        {{moment-format row.modified "DD-MM-YYYY"}}<br/>
+        <span class="auk-u-text-small auk-u-muted">{{moment-format row.modified "HH:mm"}}</span>
+      </td>
+      <td>
+        {{t "dash"}}
+        {{!-- {{#if row.translationStatus.[0].initiated}}
+        <WebComponents::AuStatusPill @status={{row.translationStatus.[0].status}}>{{row.translationStatus.[0].finished}}/{{row.translationStatus.[0].total}}</WebComponents::AuStatusPill>
+        {{else}}
+        -
+        {{/if}} --}}
+      </td>
+      <td>
+        {{t "dash"}}
+        {{!-- {{#if row.printProofStatus.[0].initiated}}
+        <WebComponents::AuStatusPill @status={{row.printProofStatus.[0].status}}>{{row.printProofStatus.[0].finished}}/{{row.printProofStatus.[0].total}}</WebComponents::AuStatusPill>
+        {{else}}
+        -
+        {{/if}} --}}
+      </td>
+      <td>
+        {{#if row.remark}}
+          <WebComponents::AuButton @skin="borderless" @layout="icon-only" @icon="comment">
+            <AttachTooltip
+              @arrow="true"
+              @animation="fade"
+              @placement="left"
+              @class="auk-tooltip"
+            >
+              <p>
+                {{row.remark}}
+              </p>
+            </AttachTooltip>
+          </WebComponents::AuButton>
+        {{/if}}
+      </td>
+      <td>
+        <WebComponents::AuButtonToolbar>
+          <WebComponents::AuButton {{on "click" (fn this.navigateToPublication row)}} @skin="borderless" @layout="icon-only" @icon="chevron-right" data-test-publications-button-go-to-publication/>
+        </WebComponents::AuButtonToolbar>
+      </td>
+    </c.body>
+  </table.content>
+</DataTable>

--- a/app/pods/publications/paused/route.js
+++ b/app/pods/publications/paused/route.js
@@ -2,7 +2,6 @@ import Route from '@ember/routing/route';
 
 export default class PausedRoute extends Route {
   model() {
-    // Normally we would query store here, but for now, we get the mocks
     return null;
   }
 }

--- a/app/pods/publications/paused/route.js
+++ b/app/pods/publications/paused/route.js
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+
+export default class PausedRoute extends Route {
+  model() {
+    // Normally we would query store here, but for now, we get the mocks
+    return null;
+  }
+}

--- a/app/pods/publications/paused/template.hbs
+++ b/app/pods/publications/paused/template.hbs
@@ -1,7 +1,7 @@
 <div class="auk-scroll-wrapper__body">
   <div class="auk-u-m-4">
     <div class="auk-u-my-2">
-      <WebComponents::AuNavbar class="vlc-publication-overview-navbar" @noPadding="true">
+      <WebComponents::AuNavbar class="vlc-publication-overview-navbar" @noPadding="true" @border="bottom">
         <WebComponents::AuToolbar>
           <WebComponents::AuToolbar::Group>
             <WebComponents::AuTabs>

--- a/app/pods/publications/paused/template.hbs
+++ b/app/pods/publications/paused/template.hbs
@@ -1,0 +1,21 @@
+<div class="auk-scroll-wrapper__body">
+  <div class="auk-u-m-4">
+    <div class="auk-u-my-2">
+      <WebComponents::AuNavbar class="vlc-publication-overview-navbar" @noPadding="true">
+        <WebComponents::AuToolbar>
+          <WebComponents::AuToolbar::Group>
+            <WebComponents::AuTabs>
+              <WebComponents::AuTab @route="publications.paused.paused-minister" data-test-publication-paused-via-minister-tab>{{t "via-cabinet"}}</WebComponents::AuTab>
+              <WebComponents::AuTab @route="publications.paused.paused-not-minister" data-test-publication-paused-not-via-minister-tab>{{t "not-via-cabinet"}}</WebComponents::AuTab>
+            </WebComponents::AuTabs>
+          </WebComponents::AuToolbar::Group>
+          <WebComponents::AuToolbar::Group @position="right">
+            <WebComponents::AuToolbar::Item>
+            </WebComponents::AuToolbar::Item>
+          </WebComponents::AuToolbar::Group>
+        </WebComponents::AuToolbar>
+      </WebComponents::AuNavbar>
+    </div>
+    {{outlet}}
+  </div>
+</div>

--- a/app/pods/publications/publication/controller.js
+++ b/app/pods/publications/publication/controller.js
@@ -42,6 +42,13 @@ export default class PublicationController extends Controller {
       color: 'success',
     },
   }, {
+    id: CONFIG.publicationStatusPauzed.id,
+    label: 'Gepauzeerd',
+    icon: {
+      svg: 'circle-pause',
+      color: 'muted',
+    },
+  }, {
     id: CONFIG.publicationStatusWithdrawn.id,
     label: 'ingetrokken',
     icon: {

--- a/app/pods/publications/template.hbs
+++ b/app/pods/publications/template.hbs
@@ -20,6 +20,9 @@
                 <WebComponents::AuTab @route="publications.done" data-test-publications-overview-done-tab>
                   {{t "publications-published"}}
                 </WebComponents::AuTab>
+                <WebComponents::AuTab @route="publications.paused" data-test-publications-overview-paused-tab>
+                  {{t "publications-paused"}}
+                </WebComponents::AuTab>
                 <WebComponents::AuTab @route="publications.withdrawn" data-test-publications-overview-withdrawn-tab>
                   {{t "publications-withdrawn"}}
                 </WebComponents::AuTab>

--- a/app/router.js
+++ b/app/router.js
@@ -130,7 +130,8 @@ Router.map(function() {
     this.route('paused', { path: '/gepauzeerd', }, function() {
       this.route('paused-minister', { path: '/via-ministerraad', });
       this.route('paused-not-minister', { path: '/niet-via-ministerraad', });
-    });    this.route('withdrawn', { path: '/ingetrokken', }, function() {
+    });
+    this.route('withdrawn', { path: '/ingetrokken', }, function() {
       this.route('withdrawn-minister', { path: '/via-ministerraad', });
       this.route('withdrawn-not-minister', { path: '/niet-via-ministerraad', });
     });

--- a/app/router.js
+++ b/app/router.js
@@ -127,7 +127,10 @@ Router.map(function() {
       this.route('in-progress-not-minister', { path: '/niet-via-ministerraad', });
     });
     this.route('done', { path: '/behandeld', });
-    this.route('withdrawn', { path: '/ingetrokken', }, function() {
+    this.route('paused', { path: '/gepauzeerd', }, function() {
+      this.route('paused-minister', { path: '/via-ministerraad', });
+      this.route('paused-not-minister', { path: '/niet-via-ministerraad', });
+    });    this.route('withdrawn', { path: '/ingetrokken', }, function() {
       this.route('withdrawn-minister', { path: '/via-ministerraad', });
       this.route('withdrawn-not-minister', { path: '/niet-via-ministerraad', });
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2285,9 +2285,9 @@
       "integrity": "sha512-Lm1SxYukQr94oMbr5nKsnshp70k67FFD5bP9+Ov9sRsBSgBheLfgnhVivNtAFXdL+fs2voo9jOQORht0EwBbWA=="
     },
     "@kanselarij-vlaanderen/au-kaleidos-icons": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@kanselarij-vlaanderen/au-kaleidos-icons/-/au-kaleidos-icons-1.2.4.tgz",
-      "integrity": "sha512-wL5hhseShqNYgs6d6cv4KoQcD27VQhz34fmz6rCh1x+e100dqUu8HtJwLkJu70tg4NpRNjX+nhYxAoIY+8o++Q=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@kanselarij-vlaanderen/au-kaleidos-icons/-/au-kaleidos-icons-1.2.5.tgz",
+      "integrity": "sha512-xZCl1ZN5lq0IB0l4jP7K2TA+oJRXvxRKvjfzMTx0fxezE4YR7K6QcVSDaEDB/Io2QK/C2VXmCXNVJO197oTKzA=="
     },
     "@lblod/ember-acmidm-login": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "node": "10.* || >= 12"
   },
   "dependencies": {
-    "@kanselarij-vlaanderen/au-kaleidos-icons": "^1.2.4",
+    "@kanselarij-vlaanderen/au-kaleidos-icons": "^1.2.5",
     "@kanselarij-vlaanderen/au-kaleidos-css": "^1.17.0",
     "ember-in-viewport": "^3.7.5",
     "ember-test-selectors": "^3.0.0",

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -611,6 +611,7 @@
   "publications-in-progress": "In behandeling",
   "publications-new": "Nieuwe publicatie",
   "publications-published": "Gepubliceerd",
+  "publications-paused": "Gepauzeerd",
   "publications-to": "Naar publicatie",
   "publication-not-started-yet": "Nog niet gestart",
   "start-publication": "Publicatie starten",


### PR DESCRIPTION
# KAS-2150: Paused functionality
In deze PR geven we de gebruiker de mogelijkheid om een publicatiestatus op `gepauzeerd` te zetten.

## ✏️ Changes:
- Gepauzeerd route toegevoegd
- Gepauzeerd dropdown item toegevoegd
- Dependency update van `au-kaleidos-icons`

## Screenshots:
![image](https://user-images.githubusercontent.com/11557630/104176530-ae420a80-5407-11eb-995e-ef9c7ad63d1c.png)

![image](https://user-images.githubusercontent.com/11557630/104176548-b9953600-5407-11eb-99c7-3f8709ce0eed.png)
