### PR TITLE
KAS-2149: implement new loader visual

### DIFF
--- a/app/pods/components/web-components/au-loader/template.hbs
+++ b/app/pods/components/web-components/au-loader/template.hbs
@@ -1,9 +1,8 @@
 {{#if @message}}
-  <div class="auk-loader-wrapper">
+  <div class="auk-loader-wrapper auk-loader-wrapper--small">
     <div class="auk-loader" role="alert" aria-busy="true"></div>
-    <p>{{@message}}</p>
+    <p class="auk-u-text-align--center">{{@message}}</p>
   </div>
 {{else}}
   <div class="auk-loader" role="alert" aria-busy="true"></div>
 {{/if}}
-{{!-- TODO css was missing, check if this works --}}

--- a/app/pods/components/web-components/au-loading-overlay/template.hbs
+++ b/app/pods/components/web-components/au-loading-overlay/template.hbs
@@ -1,11 +1,9 @@
-<WebComponents::AuModal>
-  <WebComponents::AuModal::Header
-    @title={{this.getTitle}}
-    @hideCloseButton={{true}}
-  />
-  <WebComponents::AuModal::Body>
-    <WebComponents::AuLoader
-      @message={{this.getMessage}}
-    />
-  </WebComponents::AuModal::Body>
-</WebComponents::AuModal>
+<div class="auk-u-flex auk-u-flex--justify-around">
+  <WebComponents::AuModal @size="xsmall">
+    <WebComponents::AuModal::Body>
+      <WebComponents::AuLoader
+              @message={{this.getMessage}}
+      />
+    </WebComponents::AuModal::Body>
+  </WebComponents::AuModal>
+</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2280,9 +2280,9 @@
       }
     },
     "@kanselarij-vlaanderen/au-kaleidos-css": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@kanselarij-vlaanderen/au-kaleidos-css/-/au-kaleidos-css-1.17.0.tgz",
-      "integrity": "sha512-Lm1SxYukQr94oMbr5nKsnshp70k67FFD5bP9+Ov9sRsBSgBheLfgnhVivNtAFXdL+fs2voo9jOQORht0EwBbWA=="
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/@kanselarij-vlaanderen/au-kaleidos-css/-/au-kaleidos-css-1.17.2.tgz",
+      "integrity": "sha512-7jz52Akif9o7ZcuZHGx8xalIeeIal4MLOaUWKI3mr7dwUAWM+hZmJ4vkNtd/S17V/wwrcD1WOXLE06gzThBIHQ=="
     },
     "@kanselarij-vlaanderen/au-kaleidos-icons": {
       "version": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
   },
   "dependencies": {
     "@kanselarij-vlaanderen/au-kaleidos-icons": "^1.2.4",
-    "@kanselarij-vlaanderen/au-kaleidos-css": "^1.17.0",
+    "@kanselarij-vlaanderen/au-kaleidos-css": "^1.17.2",
     "ember-in-viewport": "^3.7.5",
     "ember-test-selectors": "^3.0.0",
     "ember-tooltips": "^3.4.5",


### PR DESCRIPTION
# 🕶 KAS-2149: implement new loader visual
In deze PR hebben we de bestaande `au-loader` aangepast zodat deze een betere visuele weergave heeft.

## 🖼 Screenshot
![image](https://user-images.githubusercontent.com/11557630/104320117-30066680-54e2-11eb-882f-6ac65eb67b3b.png)
