### PR TITLE
KAS-2123: Toevoegen lock-closed icon

### DIFF
--- a/app/pods/publications/publication/documents/template.hbs
+++ b/app/pods/publications/publication/documents/template.hbs
@@ -226,7 +226,7 @@
                 <WebComponents::AuCheckbox @toggle={{fn this.changePieceSelection piece}}/>
               </td>
               <td>
-                {{#if piece.confidential}}
+                {{#if (await piece.agendaitem)}}
                   <WebComponents::AuIcon @name="lock-closed" @iconSkinColor="muted" @layout="icon-only"/>
                 {{/if}}
                 {{await piece.name}}


### PR DESCRIPTION
# KAS-2123: Toevoegen `lock-closed` icon
In deze PR voegen we een lock-icon toe wanneer het document van de ministerraad komt en niet verwijderd kan worden

## ✏️ Changes
- If check aangepast (ik vermoed dat gewoon de verkeerde variabele aangesproken geweest is.

## 🖼  Screenshots
![image](https://user-images.githubusercontent.com/11557630/104745283-3567e900-574e-11eb-8ae1-a457f2b208cb.png)
