### PR TITLE
KAS-2181: Fix double click search

### DIFF
--- a/app/pods/search/agenda-items/route.js
+++ b/app/pods/search/agenda-items/route.js
@@ -54,7 +54,6 @@ export default class AgendaitemSearchRoute extends Route {
   model(filterParams) {
     const searchParams = this.paramsFor('search');
     const params = {...searchParams, ...filterParams}; // eslint-disable-line
-    console.log('params agendaitems', params);
     if (!params.dateFrom) {
       params.dateFrom = null;
     }

--- a/app/pods/search/agenda-items/route.js
+++ b/app/pods/search/agenda-items/route.js
@@ -54,6 +54,16 @@ export default class AgendaitemSearchRoute extends Route {
   model(filterParams) {
     const searchParams = this.paramsFor('search');
     const params = {...searchParams, ...filterParams}; // eslint-disable-line
+    console.log('params agendaitems', params);
+    if (!params.dateFrom) {
+      params.dateFrom = null;
+    }
+    if (!params.dateTo) {
+      params.dateTo = null;
+    }
+    if (!params.mandatees) {
+      params.mandatees = null;
+    }
     this.lastParams.stageLive(params);
 
     if (this.lastParams.anyFieldChanged(Object.keys(params).filter((key) => key !== 'page'))) {

--- a/app/pods/search/cases/route.js
+++ b/app/pods/search/cases/route.js
@@ -54,7 +54,6 @@ export default class CasesSearchRoute extends Route {
   model(filterParams) {
     const searchParams = this.paramsFor('search');
     const params = {...searchParams, ...filterParams}; // eslint-disable-line
-    console.log('params', params);
 
     this.lastParams.stageLive(params);
 

--- a/app/pods/search/cases/route.js
+++ b/app/pods/search/cases/route.js
@@ -54,6 +54,8 @@ export default class CasesSearchRoute extends Route {
   model(filterParams) {
     const searchParams = this.paramsFor('search');
     const params = {...searchParams, ...filterParams}; // eslint-disable-line
+    console.log('params', params);
+
     this.lastParams.stageLive(params);
 
     if (this.lastParams.anyFieldChanged(Object.keys(params).filter((key) => key !== 'page'))) {


### PR DESCRIPTION
# KAS-2181: Fix double click search op agendaitem search route
Minor bugfix voor het resetten van de search opties, omdat er nu een `undefined` geset wordt bij het klikken op `volgende` denkt het systeem dat hij terug moet springen naar 0. Daarna staan alle properties mooi hetzelfde waardoor de `volgende` klik wel verwerkt wordt wanneer je er opnieuw op drukt.

Na een halve dag zoeken, hard reset geschreven op deze properties om de `undefined` naar `null` te zetten, dit lost het probleem op.
![image](https://user-images.githubusercontent.com/11557630/106012542-d09c7f00-60bb-11eb-9870-d174da910fa2.png)
