### PR TITLE
Modified application serializer for HasMany

### DIFF
--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -5,14 +5,11 @@ export default DS.JSONAPISerializer.extend(DataTableSerializerMixin, {
 
   // eslint-disable-next-line no-unused-vars
   shouldSerializeHasMany(snapshot, key, relationshipType) {
-    const shouldSerialize = this._super(...arguments);
-    const serializeOption = relationshipType.options || {
-      serialize: true,
-    };
-    if (typeof serializeOption.serialize !== 'undefined') {
-      return shouldSerialize && serializeOption.serialize;
+    // If serialization option specified, use that. Otherwise use Ember Data defaults
+    if (relationshipType.options && (typeof relationshipType.options.serialize !== 'undefined')) {
+      return relationshipType.options.serialize;
     }
-    return shouldSerialize;
+    return this._super(...arguments);
   },
 
   serialize() {


### PR DESCRIPTION
This PR slightly changes the (already customized) serialization logic for `hasMany` relationships.  

By default, the `hasMany`-side of a (non many-to-many) relationship doesn't serialize. Ember data assumes that it's more logical to serialize a many-to-one relationship on the `belongsTo`-side, if there is one. However, for us this doesn't always work out in practice since we don't always have the inverse of a relationship available in api (mostly due to limitations of the mu-cl-resource version we're using). That's where ember-data's `inverse: null` comes in. This option tells the serializer "the other side of the relationship isn't available, so we have no other choice than to serialize the `hasMany`-side anyway".
In the current Kaleidos setup however, the `inverse: null` option gets heavily over-used. `inverse:null` is meant for cases like the one mentioned above, not for specifying a relationship on both sides, and then specifying `inverse: null` on either side in order to get both sides of the relationship to serialize. This sort-of accomplishes the goal of making both sides of the relationship serialize, with the catch however that you lose ember-data's relationship-resolving capabilities ("the other side doesn't update automatically"). On top of that, by configuring that a `hasMany`-relationship always serializes (by specifying `inverse: null`), one can put a lot of needless strain on the database, since saving a model after the tiniest property-update will re-save the `hasMany`-relationships as well (this quickly adds up, when one imagines 1-n cases where n=40, or 200 for example).

This PR proposes a serializer configuration where the `serialize` option will always be interpreted as specified, and using the default ember-data behaviour when unspecified.

When comparing to the previous setup, only places that manually specify `serialize: true` will be impacted. Since this option currently doesn't occur in the codebase, there should be no impact on merge, but it paves the way for future improvements, removing some unrightful `inverse: null`s and specifying `serialize: true` where there's no other option.