### PR TITLE
KAS-2147: Implement status badges

### DIFF
--- a/app/pods/publications/publication/controller.js
+++ b/app/pods/publications/publication/controller.js
@@ -298,4 +298,74 @@ export default class PublicationController extends Controller {
     }
     return null;
   }
+
+  get showStatusForTranslations() {
+    const totalTranslations = this.model.counts.totalTranslations;
+    const closedOrWithdrawn = this.model.counts.closedOrWithdrawnTranslationRequests;
+    const openTranslation = this.model.counts.openTranslationRequests;
+
+    // Er zijn geen translations aangemaakt.
+    if (totalTranslations === 0) {
+      return {
+        status: 'not-started',
+      };
+    }
+
+    // Er is 1 open translation, toon enkel de icon
+    if (openTranslation === 1 && (totalTranslations === 1)) {
+      return {
+        status: '',
+      };
+    }
+
+    // Er zijn nog open statussen
+    if (openTranslation !== 0) {
+      return {
+        value: `${closedOrWithdrawn}/${totalTranslations}`,
+      };
+    }
+
+    // Alle requests zijn afgehandeld.
+    if (totalTranslations === closedOrWithdrawn) {
+      return {
+        status: 'done',
+      };
+    }
+    return null;
+  }
+
+  get showStatusForPublicationPreviews() {
+    const totalPublishPreviewRequests = this.model.counts.totalPublishPreviewRequests;
+    const closedOrWithdrawnPublishPrevieuwRequests = this.model.counts.closedOrWithdrawnPublishPrevieuwRequests;
+    const openPublishPreviewRequests = this.model.counts.openPublishPreviewRequests;
+
+    // Er zijn geen translations aangemaakt.
+    if (totalPublishPreviewRequests === 0) {
+      return {
+        status: 'not-started',
+      };
+    }
+
+    // Er is 1 open translation en er is maar 1 publishpreview, toon enkel de icon
+    if (openPublishPreviewRequests === 1 && (totalPublishPreviewRequests === 1)) {
+      return {
+        status: '',
+      };
+    }
+
+    // Er zijn nog open statussen
+    if (openPublishPreviewRequests !== 0) {
+      return {
+        value: `${closedOrWithdrawnPublishPrevieuwRequests}/${totalPublishPreviewRequests}`,
+      };
+    }
+
+    // Alle requests zijn afgehandeld.
+    if (totalPublishPreviewRequests === closedOrWithdrawnPublishPrevieuwRequests) {
+      return {
+        status: 'done',
+      };
+    }
+    return null;
+  }
 }

--- a/app/pods/publications/publication/route.js
+++ b/app/pods/publications/publication/route.js
@@ -46,7 +46,9 @@ export default class PublicationRoute extends Route.extend(AuthenticatedRouteMix
       counts: {
         totalTranslations: totalTranslations.length,
         closedOrWithdrawnTranslationRequests: closedTranslationRequests.length + withdrawnTranslationRequests.length,
+        openTranslationRequests: totalTranslations.length - closedTranslationRequests.length - withdrawnTranslationRequests.length,
         totalPublishPreviewRequests: totalPublishPreviewRequests.length,
+        openPublishPreviewRequests: totalPublishPreviewRequests.length - closedPublishPreviewRequests.length - withdrawnPublishPreviewRequests.length,
         closedOrWithdrawnPublishPrevieuwRequests: closedPublishPreviewRequests.length + withdrawnPublishPreviewRequests.length,
       },
       refreshAction: this.refreshModel,

--- a/app/pods/publications/publication/template.hbs
+++ b/app/pods/publications/publication/template.hbs
@@ -20,17 +20,13 @@
             <WebComponents::AuTab @route="publications.publication.translations" data-test-publication-case-nav-translations>
               <div class="auk-u-flex auk-u-flex--center">
                 <span class="auk-u-mr-2">{{t "translations"}}</span>
-                {{#if (gt this.model.counts.totalTranslations 0)}}
-                  <WebComponents::AuStatusPill>{{this.model.counts.closedOrWithdrawnTranslationRequests}}&#47;{{this.model.counts.totalTranslations}}</WebComponents::AuStatusPill>
-                {{/if}}
+                <WebComponents::AuStatusPill @status={{this.showStatusForTranslations.status}}>{{this.showStatusForTranslations.value}}</WebComponents::AuStatusPill>
               </div>
             </WebComponents::AuTab>
             <WebComponents::AuTab @route="publications.publication.publishpreview" data-test-publication-case-nav-publishpreview>
               <div class="auk-u-flex auk-u-flex--center">
                 <span class="auk-u-mr-2">{{t "publishpreview-requests"}}</span>
-                {{#if (gt this.model.counts.totalPublishPreviewRequests 0)}}
-                  <WebComponents::AuStatusPill>{{this.model.counts.closedOrWithdrawnPublishPrevieuwRequests}}&#47;{{this.model.counts.totalPublishPreviewRequests}}</WebComponents::AuStatusPill>
-                {{/if}}
+                <WebComponents::AuStatusPill @status={{this.showStatusForPublicationPreviews.status}}>{{this.showStatusForPublicationPreviews.value}}</WebComponents::AuStatusPill>
               </div>
             </WebComponents::AuTab>
           </WebComponents::AuTabs>


### PR DESCRIPTION
# KAS-2147: Implement status badges
In deze story hebben we de statusbadges bovenaan de publicatieroute geïmplementeerd.

## 🖼 Screenshots
## Vertalingen
### Aanvraag nog niet gestart
![image](https://user-images.githubusercontent.com/11557630/106125806-e0b86b00-615c-11eb-9f56-4e86d760ac23.png)

### 1 Aanvraag lopende
![image](https://user-images.githubusercontent.com/11557630/106125918-05144780-615d-11eb-99d1-e423d029d3de.png)

### 2 Aanvragen lopende
![image](https://user-images.githubusercontent.com/11557630/106125964-152c2700-615d-11eb-973a-ce4029da9e24.png)

### 1 aanvraag afgewerkt
![image](https://user-images.githubusercontent.com/11557630/106126040-2d03ab00-615d-11eb-8d40-3014381bce04.png)

### Alle aanvragen afgewerkt
![image](https://user-images.githubusercontent.com/11557630/106126100-3ee54e00-615d-11eb-8451-8b6195e79831.png)

## DrukProef
### Aanvraag nog niet gestart
![image](https://user-images.githubusercontent.com/11557630/106125806-e0b86b00-615c-11eb-9f56-4e86d760ac23.png)

### 1 Aanvraag lopende
![image](https://user-images.githubusercontent.com/11557630/106126223-6805de80-615d-11eb-9bc3-e49b1c5646f8.png)

### 2 Aanvragen lopende
![image](https://user-images.githubusercontent.com/11557630/106126276-781dbe00-615d-11eb-981b-11709ead7b3d.png)

### 1 aanvraag afgewerkt
![image](https://user-images.githubusercontent.com/11557630/106126341-8b308e00-615d-11eb-95aa-f5eb6541ada6.png)

### Alle aanvragen afgewerkt
![image](https://user-images.githubusercontent.com/11557630/106126383-971c5000-615d-11eb-9f41-89541c664885.png)

