### PR TITLE
KAS-2161: Withdrawal reason and email popup

### DIFF
--- a/app/models/activity.js
+++ b/app/models/activity.js
@@ -11,6 +11,7 @@ export default class Activity extends Model {
   @attr('datetime') finalTranslationDate;
   @attr('string') name;
   @attr('string') mailContent;
+  @attr('string') withdrawReason;
   @attr('string') mailSubject;
 
   // Relations.

--- a/app/pods/components/publications/publication/activity-request-panel/template.hbs
+++ b/app/pods/components/publications/publication/activity-request-panel/template.hbs
@@ -17,12 +17,24 @@
     </WebComponents::AuPanel::Header>
     {{#if (not this.isCollapsed)}}
       <WebComponents::AuPanel::Body>
+
+        {{!-- IF WITHDRAWN SHOW REASON--}}
+        {{#if @activity.withdrawReason}}
+          <div class="auk-u-mb-4">
+            <WebComponents::AuLabel>
+              {{t "reason-withdraw"}}
+            </WebComponents::AuLabel>
+            <p class="auk-u-text-pre vlc-mail-content">{{@activity.withdrawReason}}</p>
+          </div>
+        {{/if}}
+
         <div class="auk-u-mb-4">
           <WebComponents::AuLabel>
             {{t "translation-mail-header"}}
           </WebComponents::AuLabel>
           <p class="auk-u-text-pre vlc-mail-content">{{@activity.mailContent}}</p>
         </div>
+
         <WebComponents::AuLabel>
           {{t "files"}}
         </WebComponents::AuLabel>

--- a/app/pods/publications/publication/publishpreview/controller.js
+++ b/app/pods/publications/publication/publishpreview/controller.js
@@ -383,7 +383,7 @@ export default class PublicationPublishPreviewController extends Controller {
   }
 
   @action
-  async hideWithdrawalWindow() {
+  hideWithdrawalWindow() {
     this.withdrawalReason = '';
     this.withdrawalSubject = '';
     this.withdrawalContent = '';

--- a/app/pods/publications/publication/publishpreview/controller.js
+++ b/app/pods/publications/publication/publishpreview/controller.js
@@ -16,7 +16,7 @@ export default class PublicationPublishPreviewController extends Controller {
   @service subcasesService;
   @service fileService;
 
-  // properties for making the design
+  // Properties for making the design.
   @tracked withdrawn = true;
   @tracked showLoader = false;
   @tracked showpublicationModal = false;
@@ -27,7 +27,7 @@ export default class PublicationPublishPreviewController extends Controller {
     pieces: A([]),
   };
 
-  // piece uploading
+  // piece uploading.
   @tracked isOpenUploadPublishPreviewModal = false;
   @tracked isOpenUploadPublishPreviewCorrectionModal = false;
   @tracked uploadedFile = null;
@@ -39,6 +39,13 @@ export default class PublicationPublishPreviewController extends Controller {
   @tracked pieceToDelete = null;
   @tracked isVerifyingDelete = false;
   @tracked activityToDeletePiecesFrom = null;
+
+  // Withdrawal.
+  @tracked withdrawalContent = '';
+  @tracked withdrawalSubject = '';
+  @tracked withdrawActivity = null;
+  @tracked withdrawalReason = '';
+  @tracked showWithdrawPopup = false;
 
   get publishPreviewActivities() {
     const publishPreviewActivities = this.model.publishPreviewActivities.map((activity) => activity);
@@ -277,13 +284,28 @@ export default class PublicationPublishPreviewController extends Controller {
   }
 
   @action
-  async cancelExistingPreviewActivity(previewActivity) {
+  async cancelExistingPreviewActivity() {
+    const previewActivity = this.withdrawActivity;
     this.showLoader = true;
+    this.showWithdrawPopup = false;
+
+    // Update activity.
     const withDrawnStatus = await this.store.findRecord('activity-status', CONFIG.ACTIVITY_STATUSSES.withdrawn.id);
     previewActivity.status = withDrawnStatus;
+    previewActivity.withdrawReason = this.withdrawalReason;
     previewActivity.endDate = moment().utc();
     await previewActivity.save();
+
+    const pieces = await previewActivity.get('usedPieces');
+    // Send email
+    this.emailService.sendEmail(CONFIG.EMAIL.DEFAULT_FROM, CONFIG.EMAIL.TO.activityWithdrawPublishPreviewEmail, this.withdrawalSubject, this.withdrawalContent, pieces);
+
+    // Reset local state.
     this.model.refreshAction();
+    this.withdrawalReason = '';
+    this.withdrawalSubject = '';
+    this.withdrawalContent = '';
+    this.withdrawActivity = null;
     this.showLoader = false;
   }
 
@@ -343,5 +365,29 @@ export default class PublicationPublishPreviewController extends Controller {
   @action
   async showPieceViewer(piece) {
     window.open(`/document/${(await piece).get('id')}`);
+  }
+
+  // Withdrawal.
+
+  @action
+  async showWithdrawalWindow(activity) {
+    this.showLoader = true;
+    this.withdrawActivity = activity;
+    const subcase = await activity.get('subcase');
+    const publicationFlow = await subcase.get('publicationFlow');
+    const _case = await publicationFlow.get('case');
+    set(this, 'withdrawalContent', this.activityService.replaceTokens(CONFIG.mail.withdrawalPublishPreview.content, publicationFlow, _case));
+    set(this, 'withdrawalSubject', this.activityService.replaceTokens(CONFIG.mail.withdrawalPublishPreview.subject, publicationFlow, _case));
+    this.showLoader = false;
+    this.showWithdrawPopup = true;
+  }
+
+  @action
+  async hideWithdrawalWindow() {
+    this.withdrawalReason = '';
+    this.withdrawalSubject = '';
+    this.withdrawalContent = '';
+    this.withdrawActivity = null;
+    this.showWithdrawPopup = false;
   }
 }

--- a/app/pods/publications/publication/publishpreview/template.hbs
+++ b/app/pods/publications/publication/publishpreview/template.hbs
@@ -61,7 +61,7 @@
               <WebComponents::AuToolbar::Item>
                 <WebComponents::AuButton
                         @skin="tertiary"
-                  {{on "click" (fn this.cancelExistingPreviewActivity activity)}}>
+                  {{on "click" (fn this.showWithdrawalWindow activity)}}>
                   {{t "cancel-request"}}
                 </WebComponents::AuButton>
               </WebComponents::AuToolbar::Item>
@@ -388,6 +388,77 @@
       >
         {{t "request-publication"}}
       </WebComponents::AuButton>
+    </WebComponents::AuModal::Footer>
+  </WebComponents::AuModal>
+{{/if}}
+
+
+
+{{!-- showWithdrawPopup --}}
+
+{{#if showWithdrawPopup}}
+  <WebComponents::AuModal
+    @size="medium"
+    data-test-withdraw-publishpreview
+  >
+    <WebComponents::AuModal::Header @title={{t "cancel-request"}}
+                                    @closeModal={{this.hideWithdrawalWindow}} />
+    <WebComponents::AuModal::Body>
+      <div class="auk-form-group-layout auk-form-group-layout--standard">
+        <div class='auk-form-group'>
+          <WebComponents::AuLabel for="reason">{{t "reason-withdraw"}}</WebComponents::AuLabel>
+          <WebComponents::AuTextarea
+            @rows="5"
+            @value={{this.withdrawalReason}}
+            data-test-publication-activity-withdrawal-reason-textarea
+          ></WebComponents::AuTextarea>
+        </div>
+        <div class='auk-form-group'>
+          <WebComponents::AuLabel for="subject">{{t "subject"}}</WebComponents::AuLabel>
+          <WebComponents::AuInput
+                  @block="true"
+                  type="text"
+                  id="subject"
+                  @value={{this.withdrawalSubject}}
+          />
+        </div>
+        <div class='auk-form-group'>
+          <WebComponents::AuLabel for="reason">{{t "content"}}</WebComponents::AuLabel>
+          <WebComponents::AuTextarea
+            @rows="8"
+            @value={{this.withdrawalContent}}
+            data-test-publication-activity-withdrawal-textarea
+          ></WebComponents::AuTextarea>
+        </div>
+      </div>
+    </WebComponents::AuModal::Body>
+    {{!-- TODO, use the template, yield the buttons in the right toolbar--}}
+    <WebComponents::AuModal::Footer @custom={{true}}>
+      <WebComponents::AuToolbar>
+        <WebComponents::AuToolbar::Group @position="left">
+          <WebComponents::AuToolbar::Item>
+            <WebComponents::AuButton
+                    @skin="borderless"
+              {{on "click" this.hideWithdrawalWindow}}
+            >
+              {{t "cancel"}}
+            </WebComponents::AuButton>
+          </WebComponents::AuToolbar::Item>
+        </WebComponents::AuToolbar::Group>
+        <WebComponents::AuToolbar::Group @position="right">
+          <WebComponents::AuToolbar::Item>
+            <WebComponents::AuButton
+                    @skin="primary"
+                    @icon="close"
+                    @size="small"
+              {{on "click" this.cancelExistingPreviewActivity}}
+                    data-test-withdraw-activity-submit-button
+            >
+              {{t "cancel-request"}}
+            </WebComponents::AuButton>
+          </WebComponents::AuToolbar::Item>
+        </WebComponents::AuToolbar::Group>
+      </WebComponents::AuToolbar>
     </WebComponents::AuModal::Footer>
   </WebComponents::AuModal>
 {{/if}}

--- a/app/pods/publications/publication/translations/controller.js
+++ b/app/pods/publications/publication/translations/controller.js
@@ -1,24 +1,72 @@
 import Controller from '@ember/controller';
-import { action } from '@ember/object';
+import {
+  action,
+  set
+} from '@ember/object';
+import { inject as service } from '@ember/service';
 import moment from 'moment';
 import CONFIG from 'fe-redpencil/utils/config';
 import { tracked } from '@glimmer/tracking';
 
 export default class PublicationTranslationController extends Controller {
+  // Tracked.
   @tracked showLoader = false;
+  @tracked showWithdrawPopup = false;
+  @tracked withdrawalContent = '';
+  @tracked withdrawalSubject = '';
+  @tracked withdrawActivity = null;
+  @tracked withdrawalReason = '';
+
+  // Services.
+  @service activityService;
+  @service emailService;
 
   get activities() {
     return this.model.translationActivities.map((activity) => activity);
   }
 
   @action
-  async cancelExistingTranslationActivity(translationActivity) {
+  async showWithdrawalWindow(translationActivity) {
+    this.withdrawActivity = translationActivity;
+    const subcase = await translationActivity.get('subcase');
+    const publicationFlow = await subcase.get('publicationFlow');
+    const _case = await publicationFlow.get('case');
+    set(this, 'withdrawalContent', this.activityService.replaceTokens(CONFIG.mail.withdrawalTranslation.content, publicationFlow, _case));
+    set(this, 'withdrawalSubject', this.activityService.replaceTokens(CONFIG.mail.withdrawalTranslation.subject, publicationFlow, _case));
+    this.showWithdrawPopup = true;
+  }
+
+  @action
+  async hideWithdrawalWindow() {
+    this.withdrawalReason = '';
+    this.withdrawalSubject = '';
+    this.withdrawalContent = '';
+    this.withdrawActivity = null;
+    this.showWithdrawPopup = false;
+  }
+
+  @action
+  async cancelExistingTranslationActivity() {
+    const translationActivity = this.withdrawActivity;
+    this.showWithdrawPopup = false;
     this.showLoader = true;
+
+    // Update activity.
     const withDrawnStatus = await this.store.findRecord('activity-status', CONFIG.ACTIVITY_STATUSSES.withdrawn.id);
     translationActivity.status = withDrawnStatus;
     translationActivity.endDate = moment().utc();
     await translationActivity.save();
+
+    const pieces = await translationActivity.get('usedPieces');
+    // Send email
+    this.emailService.sendEmail(CONFIG.EMAIL.DEFAULT_FROM, CONFIG.EMAIL.TO.activityWithdrawTranslationsEmail, this.withdrawalSubject, this.withdrawalContent, pieces);
+
+    // Reset local state.
     this.model.refreshAction();
+    this.withdrawalReason = '';
+    this.withdrawalSubject = '';
+    this.withdrawalContent = '';
+    this.withdrawActivity = null;
     this.showLoader = false;
   }
 

--- a/app/pods/publications/publication/translations/controller.js
+++ b/app/pods/publications/publication/translations/controller.js
@@ -54,6 +54,7 @@ export default class PublicationTranslationController extends Controller {
     // Update activity.
     const withDrawnStatus = await this.store.findRecord('activity-status', CONFIG.ACTIVITY_STATUSSES.withdrawn.id);
     translationActivity.status = withDrawnStatus;
+    translationActivity.withdrawReason = this.withdrawalReason;
     translationActivity.endDate = moment().utc();
     await translationActivity.save();
 

--- a/app/pods/publications/publication/translations/controller.js
+++ b/app/pods/publications/publication/translations/controller.js
@@ -37,7 +37,7 @@ export default class PublicationTranslationController extends Controller {
   }
 
   @action
-  async hideWithdrawalWindow() {
+  hideWithdrawalWindow() {
     this.withdrawalReason = '';
     this.withdrawalSubject = '';
     this.withdrawalContent = '';

--- a/app/pods/publications/publication/translations/template.hbs
+++ b/app/pods/publications/publication/translations/template.hbs
@@ -32,7 +32,7 @@
               <WebComponents::AuToolbar::Item>
                 <WebComponents::AuButton
                         @skin="tertiary"
-                  {{on "click" (fn this.cancelExistingTranslationActivity activity)}}>
+                  {{on "click" (fn this.showWithdrawalWindow activity)}}>
                   {{t "cancel-request"}}
                 </WebComponents::AuButton>
               </WebComponents::AuToolbar::Item>
@@ -72,6 +72,74 @@
   {{/if}}
 </div>
 
+
+{{!-- showWithdrawPopup --}}
+
+{{#if showWithdrawPopup}}
+  <WebComponents::AuModal
+          @size="medium"
+          data-test-withdraw-translation>
+    <WebComponents::AuModal::Header @title={{t "cancel-request"}}
+                                    @closeModal={{this.hideWithdrawalWindow}} />
+    <WebComponents::AuModal::Body>
+      <div class="auk-form-group-layout auk-form-group-layout--standard">
+        <div class='auk-form-group'>
+          <WebComponents::AuLabel for="reason">{{t "reason-withdraw"}}</WebComponents::AuLabel>
+          <WebComponents::AuTextarea
+                  @rows="5"
+                  @value={{this.withdrawalReason}}
+                  data-test-publication-activity-withdrawal-reason-textarea
+          ></WebComponents::AuTextarea>
+        </div>
+        <div class='auk-form-group'>
+          <WebComponents::AuLabel for="subject">{{t "subject"}}</WebComponents::AuLabel>
+          <WebComponents::AuInput
+            @block="true"
+            type="text"
+            id="subject"
+            @value={{this.withdrawalSubject}}
+          />
+        </div>
+        <div class='auk-form-group'>
+          <WebComponents::AuLabel for="reason">{{t "content"}}</WebComponents::AuLabel>
+          <WebComponents::AuTextarea
+            @rows="8"
+            @value={{this.withdrawalContent}}
+            data-test-publication-activity-withdrawal-textarea
+          ></WebComponents::AuTextarea>
+        </div>
+      </div>
+    </WebComponents::AuModal::Body>
+    {{!-- TODO, use the template, yield the buttons in the right toolbar--}}
+    <WebComponents::AuModal::Footer @custom={{true}}>
+      <WebComponents::AuToolbar>
+        <WebComponents::AuToolbar::Group @position="left">
+          <WebComponents::AuToolbar::Item>
+            <WebComponents::AuButton
+              @skin="borderless"
+              {{on "click" this.hideWithdrawalWindow}}
+            >
+              {{t "cancel"}}
+            </WebComponents::AuButton>
+          </WebComponents::AuToolbar::Item>
+        </WebComponents::AuToolbar::Group>
+        <WebComponents::AuToolbar::Group @position="right">
+          <WebComponents::AuToolbar::Item>
+            <WebComponents::AuButton
+              @skin="primary"
+              @icon="close"
+              @size="small"
+              {{on "click" this.cancelExistingTranslationActivity}}
+              data-test-withdraw-activity-submit-button
+            >
+              {{t "cancel-request"}}
+            </WebComponents::AuButton>
+          </WebComponents::AuToolbar::Item>
+        </WebComponents::AuToolbar::Group>
+      </WebComponents::AuToolbar>
+    </WebComponents::AuModal::Footer>
+  </WebComponents::AuModal>
+{{/if}}
 
 {{!-- LOADER --}}
 

--- a/app/utils/config.js
+++ b/app/utils/config.js
@@ -57,7 +57,11 @@ export default EmberObject.create({
     },
     publishRequest: {
       content: 'Beste,\n\nVoor publicatie %%nummer%%.\n\nVriendelijke groeten,\n\nTeam OVRB\n\n[%%kaleidosenvironment%%]',
-      subject: '[%%kaleidosenvironment%%] Aanvraag publicatie (%%numac%%)',
+      subject: '[%%kaleidosenvironment%%] Aanvraag publicatie (%%nummer%%)',
+    },
+    withdrawalTranslation: {
+      content: 'Beste,\n\nIntrekking vertaling voor %%nummer%%.\n\nVriendelijke groeten,\n\nTeam OVRB\n\n[%%kaleidosenvironment%%]',
+      subject: '[%%kaleidosenvironment%%] Intrekking vertalingsaanvraag (%%nummer%%)',
     },
   },
   formallyOkOptions: [
@@ -264,6 +268,7 @@ export default EmberObject.create({
     TO: {
       translationsEmail: 'johan.delaure@redpencil.be',
       publishpreviewEmail: 'johan.delaure@redpencil.be',
+      activityWithdrawTranslationsEmail: 'johan.delaure@redpencil.be',
       publishEmail: 'johan.delaure@redpencil.be',
     },
   },

--- a/app/utils/config.js
+++ b/app/utils/config.js
@@ -63,6 +63,10 @@ export default EmberObject.create({
       content: 'Beste,\n\nIntrekking vertaling voor %%nummer%%.\n\nVriendelijke groeten,\n\nTeam OVRB\n\n[%%kaleidosenvironment%%]',
       subject: '[%%kaleidosenvironment%%] Intrekking vertalingsaanvraag (%%nummer%%)',
     },
+    withdrawalPublishPreview: {
+      content: 'Beste,\n\nIntrekking drukproef voor %%nummer%%.\n\nVriendelijke groeten,\n\nTeam OVRB\n\n[%%kaleidosenvironment%%]',
+      subject: '[%%kaleidosenvironment%%] Intrekking drukproef (%%nummer%%)',
+    },
   },
   formallyOkOptions: [
     {
@@ -269,6 +273,7 @@ export default EmberObject.create({
       translationsEmail: 'johan.delaure@redpencil.be',
       publishpreviewEmail: 'johan.delaure@redpencil.be',
       activityWithdrawTranslationsEmail: 'johan.delaure@redpencil.be',
+      activityWithdrawPublishPreviewEmail: 'johan.delaure@redpencil.be',
       publishEmail: 'johan.delaure@redpencil.be',
     },
   },

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -742,6 +742,7 @@
   "BvR":"BvR",
   "cancel-publication-flow-confirm": "Bent u zeker dat u deze publicatie wil intrekken?",
   "withdraw": "Intrekken",
+  "reason-withdraw": "Reden van intrekken",
   "documents-may-not-be-saved-message": "Er zijn inconsistenties vastgesteld bij het toevoegen van de documenten. Noteer je wijzigingen en hernieuw deze pagina om te kijken of de documenten correct zijn toegevoegd.",
   "related-main-meeting-field-label": "Hoort bij ministerraad"
 }


### PR DESCRIPTION
### 🗣 
bij het intrekken is er nu de mogelijkheid tot ingeven van een reden. 
Dit zal worden bijgehouden in de activity. 
Er moet ook een mail gestuurd worden. hier heb ik ook de bestaande
- mail config voor aangepast (zie default mails)
- mail service gebruikt in de frontend (geeft visuele infra werkt niet popup)

### 🚂 backend PR
https://github.com/kanselarij-vlaanderen/kaleidos-project/pull/160

### 🌅 Screenshots
<img width="872" alt="Screenshot 2021-01-28 at 11 51 16" src="https://user-images.githubusercontent.com/592312/106127951-44dc2e80-615f-11eb-9817-48b75e389e49.png">

<img width="1311" alt="Screenshot 2021-01-28 at 11 59 54" src="https://user-images.githubusercontent.com/592312/106129255-5d991400-6160-11eb-920f-a30d5f6b54d0.png">

