### PR TITLE
KAS-2205: Toon type vergadering op afdrukvoorbeeld

### DIFF
--- a/app/pods/components/agenda/printable-agenda/template.hbs
+++ b/app/pods/components/agenda/printable-agenda/template.hbs
@@ -2,7 +2,7 @@
   {{utils/logo-header}}
 
   <h4 class="vlc-printable-agenda-list__session-title" data-test-agenda-print-header-title>
-    {{t "session-of-government"}} - {{this.meeting.kindToShow.altLabel}} {{t "of"}} {{moment-format this.meeting.plannedStart "dddd DD MMMM YYYY"}}
+    {{this.meeting.kindToShow.altLabel}} - {{t "session-of"}} {{moment-format this.meeting.plannedStart "dddd DD MMMM YYYY \o\m HH:mm"}}
   </h4>
   <h4 class="vlc-printable-agenda-list__session-title">
     {{t "agenda"}}

--- a/app/pods/components/agenda/printable-agenda/template.hbs
+++ b/app/pods/components/agenda/printable-agenda/template.hbs
@@ -2,7 +2,7 @@
   {{utils/logo-header}}
 
   <h4 class="vlc-printable-agenda-list__session-title" data-test-agenda-print-header-title>
-    {{t "session-of"}} {{moment-format this.meeting.plannedStart "dddd DD MMMM YYYY \o\m HH:mm"}}
+    {{t "session-of-government"}} - {{this.meeting.kindToShow.altLabel}} {{t "of"}} {{moment-format this.meeting.plannedStart "dddd DD MMMM YYYY"}}
   </h4>
   <h4 class="vlc-printable-agenda-list__session-title">
     {{t "agenda"}}

--- a/app/pods/components/agenda/printable-agenda/template.hbs
+++ b/app/pods/components/agenda/printable-agenda/template.hbs
@@ -2,10 +2,7 @@
   {{utils/logo-header}}
 
   <h4 class="vlc-printable-agenda-list__session-title" data-test-agenda-print-header-title>
-    {{this.meeting.kindToShow.altLabel}} - {{t "session-of"}} {{moment-format this.meeting.plannedStart "dddd DD MMMM YYYY \o\m HH:mm"}}
-  </h4>
-  <h4 class="vlc-printable-agenda-list__session-title">
-    {{t "agenda"}}
+    {{t "agenda-of"}} {{moment-format this.meeting.plannedStart "dddd DD MMMM YYYY"}} - {{this.meeting.kindToShow.altLabel}}
   </h4>
 
   {{#if (gt this.notas.length 0)}}

--- a/app/pods/components/agenda/printable-agenda/template.hbs
+++ b/app/pods/components/agenda/printable-agenda/template.hbs
@@ -2,7 +2,7 @@
   {{utils/logo-header}}
 
   <h4 class="vlc-printable-agenda-list__session-title" data-test-agenda-print-header-title>
-    {{t "agenda-of"}} {{moment-format this.meeting.plannedStart "dddd DD MMMM YYYY"}} - {{this.meeting.kindToShow.altLabel}}
+    {{t "agenda-of"}} {{moment-format this.meeting.plannedStart "dddd DD MMMM YYYY \o\m HH:mm"}} - {{this.meeting.kindToShow.altLabel}}
   </h4>
 
   {{#if (gt this.notas.length 0)}}

--- a/app/styles/custom-components/_vlc-printable-agenda-list.scss
+++ b/app/styles/custom-components/_vlc-printable-agenda-list.scss
@@ -14,6 +14,8 @@ $indentation-spacing: 3rem;
   .vlc-printable-agenda-list__session-title {
     margin-top: 0;
     text-align: center;
+    text-decoration: underline;
+    text-transform: uppercase;
     font-size: 2.4rem;
   }
 

--- a/app/styles/custom-components/_vlc-printable-agenda-list.scss
+++ b/app/styles/custom-components/_vlc-printable-agenda-list.scss
@@ -14,8 +14,6 @@ $indentation-spacing: 3rem;
   .vlc-printable-agenda-list__session-title {
     margin-top: 0;
     text-align: center;
-    text-decoration: underline;
-    text-transform: uppercase;
     font-size: 2.4rem;
   }
 

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -255,6 +255,7 @@
   "not-yet-on-agenda": "Nog niet geagendeerd",
   "not-yet-requested": "Nog niet aangevraagd",
   "session-of": "Vergadering van",
+  "session-of-government": "Vergadering van de Vlaamse Regering",
   "notifications": "Meldingen",
   "number-session": "Nummer vergadering: ",
   "of": "van",

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -255,7 +255,6 @@
   "not-yet-on-agenda": "Nog niet geagendeerd",
   "not-yet-requested": "Nog niet aangevraagd",
   "session-of": "Vergadering van",
-  "session-of-government": "Vergadering van de Vlaamse Regering",
   "notifications": "Meldingen",
   "number-session": "Nummer vergadering: ",
   "of": "van",


### PR DESCRIPTION
# KAS-2205: Toon type vergadering op afdrukbare versie

## Changes
- Aanpassen van tekst op afdrukbare versie
- Toevoegen van type vergadering op afdrukbare versie

## 🖼 Screenshots
**Before**
![image](https://user-images.githubusercontent.com/11557630/106129830-ed3ec280-6160-11eb-8b37-284fd90f9a4f.png)
**After**
![image](https://user-images.githubusercontent.com/11557630/106255538-7108b580-621a-11eb-8818-4f2bb47bb809.png)
