### PR TITLE
KAS-2158: numac nummers

### DIFF
--- a/app/models/numac-number.js
+++ b/app/models/numac-number.js
@@ -1,0 +1,8 @@
+import Model, {
+  attr, belongsTo
+} from '@ember-data/model';
+
+export default class NumacNumber extends Model {
+  @attr('string') name;
+  @belongsTo('publication-flow') publicationFlow;
+}

--- a/app/models/publication-flow.js
+++ b/app/models/publication-flow.js
@@ -11,7 +11,6 @@ export default class PublicationFlow extends Model {
   @attr('datetime') translateBefore;
   @attr('datetime') publishBefore;
   @attr('datetime') publishedAt;
-  @attr('string') numacNumber; // is this only 1 per flow ?
   @attr('string') remark;
   @attr('number') priority;
   @attr('datetime') created;
@@ -22,12 +21,16 @@ export default class PublicationFlow extends Model {
 
   // Belongs To.
   @belongsTo('case') case;
+
   @belongsTo('publication-status', {
     inverse: null,
   }) status;
   @belongsTo('publication-type') type;
 
   // Has many .
+  @hasMany('numac-number', {
+    inverse: null,
+  }) numacNumbers;
   @hasMany('subcase') subcases;
   @hasMany('contact-person') contactPersons;
   @hasMany('mandatee') mandatees;

--- a/app/pods/publications/index/template.hbs
+++ b/app/pods/publications/index/template.hbs
@@ -21,6 +21,11 @@
             @label={{t "publications-table-publication-number"}}
           />
         {{/if}}
+
+        {{#if this.filterTableColumnOptionKeys.numacNumberFilterOption}}
+          <th>{{t "numac-number"}}</th>
+        {{/if}}
+
         {{#if this.filterTableColumnOptionKeys.derivedPublicationTypeFilterOption}}
           <th>
             <span class="auk-u-mr">
@@ -141,6 +146,13 @@
               row.publicationNumberFilterOption
               (t "dash")
             }}
+          </td>
+        {{/if}}
+        {{#if this.filterTableColumnOptionKeys.numacNumberFilterOption}}
+          <td>
+            {{#each row.numacNumbers as |numac|}}
+              <WebComponents::AuPill>{{numac.name }}</WebComponents::AuPill>
+            {{/each}}
           </td>
         {{/if}}
         {{#if this.filterTableColumnOptionKeys.derivedPublicationTypeFilterOption}}
@@ -320,6 +332,7 @@
               <WebComponents::AuCheckboxList>
                 <WebComponents::AuCheckbox @name="caseNameFilterOption" @label={{t "publications-table-case-name"}} @checked={{this.filterTableColumnOptionKeys.caseNameFilterOption}} @toggle={{this.toggleFilterOption}} />
                 <WebComponents::AuCheckbox @name="publicationNumberFilterOption" @label={{t "publications-table-publication-number"}} @checked={{this.filterTableColumnOptionKeys.publicationNumberFilterOption}} @toggle={{this.toggleFilterOption}}/>
+                <WebComponents::AuCheckbox @name="numacNumberFilterOption" @label={{t "publications-table-numacnummer-bs"}} @checked={{this.filterTableColumnOptionKeys.numacNumberFilterOption}} @toggle={{this.toggleFilterOption}}/>
                 <WebComponents::AuCheckbox @name="derivedPublicationTypeFilterOption" @label={{t "publications-table-derived-publicationtype"}} @checked={{this.filterTableColumnOptionKeys.derivedPublicationTypeFilterOption}} @toggle={{this.toggleFilterOption}}/>
                 <WebComponents::AuCheckbox @name="onMeetingFilterOption" @label={{t "publications-table-on-meeting"}} @checked={{this.filterTableColumnOptionKeys.onMeetingFilterOption}} @toggle={{this.toggleFilterOption}}/>
                 <WebComponents::AuCheckbox @name="requestedPublicationDateFilterOption" @label={{t "publications-table-requested-publication-date"}} @checked={{this.filterTableColumnOptionKeys.requestedPublicationDateFilterOption}} @toggle={{this.toggleFilterOption}}/>

--- a/app/pods/publications/publication/controller.js
+++ b/app/pods/publications/publication/controller.js
@@ -184,6 +184,14 @@ export default class PublicationController extends Controller {
     this.set('showLoader', true);
     const numacNumber = await this.publicationService.createNumacNumber(this.newNumacNumber);
     await this.publicationService.linkNumacNumber(numacNumber, this.model.publicationFlow);
+    this.set('newNumacNumber', '');
+    this.set('showLoader', false);
+  }
+
+  @action
+  async deleteNumacNumber(numacNumber) {
+    this.set('showLoader', true);
+    await this.publicationService.unlinkNumacNumber(numacNumber, this.model.publicationFlow);
     this.set('showLoader', false);
   }
 

--- a/app/pods/publications/publication/controller.js
+++ b/app/pods/publications/publication/controller.js
@@ -26,6 +26,8 @@ export default class PublicationController extends Controller {
   @tracked showPublicationDatePicker = true;
   @tracked showConfirmWithdraw = false;
 
+  @tracked newNumacNumber = '';
+  @tracked showLoader = false;
 
   statusOptions = [{
     id: CONFIG.publicationStatusToPublish.id,
@@ -165,11 +167,24 @@ export default class PublicationController extends Controller {
     });
   }
 
-  @restartableTask
-  *setNumacNumber(event) {
-    this.model.publicationFlow.set('numacNumber', event.target.value);
-    yield timeout(1000);
-    this.model.publicationFlow.save();
+  get numacNumbers() {
+    if (this.model.publicationFlow.numacNumbers) {
+      return this.model.publicationFlow.numacNumbers;
+    }
+    return false;
+  }
+
+  @action
+  setNumacNummer(event) {
+    this.newNumacNumber = event.target.value;
+  }
+
+  @action
+  async addNumacNumber() {
+    this.set('showLoader', true);
+    const numacNumber = await this.publicationService.createNumacNumber(this.newNumacNumber);
+    await this.publicationService.linkNumacNumber(numacNumber, this.model.publicationFlow);
+    this.set('showLoader', false);
   }
 
   @action

--- a/app/pods/publications/publication/controller.js
+++ b/app/pods/publications/publication/controller.js
@@ -182,8 +182,7 @@ export default class PublicationController extends Controller {
   @action
   async addNumacNumber() {
     this.set('showLoader', true);
-    const numacNumber = await this.publicationService.createNumacNumber(this.newNumacNumber);
-    await this.publicationService.linkNumacNumber(numacNumber, this.model.publicationFlow);
+    await this.publicationService.createNumacNumber(this.newNumacNumber, this.model.publicationFlow);
     this.set('newNumacNumber', '');
     this.set('showLoader', false);
   }

--- a/app/pods/publications/publication/route.js
+++ b/app/pods/publications/publication/route.js
@@ -9,7 +9,7 @@ export default class PublicationRoute extends Route.extend(AuthenticatedRouteMix
     const publicationFlow = await this.store.findRecord('publication-flow', params.publication_id, {
       reload: true,
     }, {
-      include: 'case,contact-person,status,type',
+      include: 'case,contact-person,status,type,numac-number',
     });
 
     const totalTranslations = await this.store.query('activity', {

--- a/app/pods/publications/publication/template.hbs
+++ b/app/pods/publications/publication/template.hbs
@@ -101,14 +101,23 @@
               </div>
               <div class="auk-form-group">
                 <WebComponents::AuLabel>{{t "publication-form-numac-nummer"}}</WebComponents::AuLabel>
-                {{#each this.numacNumbers as |numac|}}
-                  <WebComponents::AuInput
-                    type="number"
-                    value={{ numac.name }}
-                    @block="true"
-                    readonly
-                  />
-                {{/each}}
+                <div style="background: #FFFFFF;border: 1px solid #CCD1D9; box-sizing: border-box;">
+                  {{#each this.numacNumbers as |numac|}}
+                    <div style="    background-color: lightgray;
+                                    border: 1px solid gray;
+                                    border-radius: 8px;
+                                    display: inline-block;
+                                    padding: 0.4em;">
+                      <span>{{ numac.name }}</span>
+                      <WebComponents::AuButton
+                        @skin="borderless"
+                        @icon="close"
+                        @layout="icon-only"
+                        {{on "click" (fn this.deleteNumacNumber numac)}}
+                        data-test-cases-backlink/>
+                    </div>
+                  {{/each}}
+                </div>
                 <WebComponents::AuInput
                   type="text"
                   id="newNumacNumber"

--- a/app/pods/publications/publication/template.hbs
+++ b/app/pods/publications/publication/template.hbs
@@ -112,7 +112,7 @@
                                         display: inline-block;
                                         min-width: 60px;
                                         font-weight:bold;
-                                        line-height: 1.2em;
+                                        line-height: 1.9rem;
                                         color:#69717C;
                                         text-align: right;
                                         padding: 0.4em;float:left;">

--- a/app/pods/publications/publication/template.hbs
+++ b/app/pods/publications/publication/template.hbs
@@ -101,37 +101,40 @@
               </div>
               <div class="auk-form-group">
                 <WebComponents::AuLabel>{{t "publication-form-numac-nummer"}}</WebComponents::AuLabel>
-                <div style="background: #FFFFFF;border: 1px solid #CCD1D9; box-sizing: border-box;  line-height: 0.8em;  padding: 7px;">  
-                  {{#each this.numacNumbers as |numac|}}
-                    <div style="display:inline-block;margin:0.1em;">
-                      <div style="    background-color: #F3F5F6;
-                                      border: 1px solid #CBD2DA;
-                                      border-right:0px solid #CBD2DA;
-                                      border-radius: 8px 0px 0px 8px;
-                                      display: inline-block;
-                                      padding: 0px;
-                                      min-width: 60px;
-                                      font-weight:bold;
-                                      line-height: 1.2em;
-                                      color:#69717C;
-                                      text-align: right;
-                                      padding: 0.4em;float:left;">
-                        <span>{{ numac.name }}</span>
-                      </div>
-                      <div style="    background-color: #F3F5F6;
+                <div style="background: #FFFFFF;border: 1px solid #CCD1D9; box-sizing: border-box;  line-height: 0.8em;  padding: 7px;">
+                  {{#if (gt this.numacNumbers.length 0) }}
+                    {{#each this.numacNumbers as |numac|}}
+                      <div style="display:inline-block;margin:0.1em;">
+                        <div style="    background-color: #F3F5F6;
                                         border: 1px solid #CBD2DA;
-                                            border-radius: 0px 8px 8px 0px;
+                                        border-right:0px solid #CBD2DA;
+                                        border-radius: 8px 0px 0px 8px;
                                         display: inline-block;
+                                        min-width: 60px;
+                                        font-weight:bold;
+                                        line-height: 1.2em;
+                                        color:#69717C;
+                                        text-align: right;
                                         padding: 0.4em;float:left;">
-                        <WebComponents::AuButton class="auk-button--nopadding"
-                          @skin="borderless"
-                          @icon="close"
-                          @layout="icon-only"
-                          {{on "click" (fn this.deleteNumacNumber numac)}}
-                          data-test-cases-backlink/>
+                          <span>{{ numac.name }}</span>
+                        </div>
+                        <div style="    background-color: #F3F5F6;
+                                          border: 1px solid #CBD2DA;
+                                              border-radius: 0px 8px 8px 0px;
+                                          display: inline-block;
+                                          padding: 0.4em;float:left;">
+                          <WebComponents::AuButton class="auk-button--nopadding"
+                            @skin="borderless"
+                            @icon="close"
+                            @layout="icon-only"
+                            {{on "click" (fn this.deleteNumacNumber numac)}}
+                            data-test-cases-backlink/>
+                        </div>
                       </div>
-                    </div>
-                  {{/each}}
+                    {{/each}}
+                  {{else}}
+                    <span class="auk-icon--light">{{t "no-numac-number-yet"}}</span>
+                  {{/if}}
                 </div>
                 <WebComponents::AuInput
                   type="text"

--- a/app/pods/publications/publication/template.hbs
+++ b/app/pods/publications/publication/template.hbs
@@ -129,7 +129,7 @@
                   @skin="borderless"
                   {{on "click"
                    this.addNumacNumber}}>
-                  {{t "save"}}
+                  {{t "add"}}
                 </WebComponents::AuButton>
               </div>
               {{#if this.model.publicationFlow.status.isToBePublished}}

--- a/app/pods/publications/publication/template.hbs
+++ b/app/pods/publications/publication/template.hbs
@@ -103,18 +103,32 @@
                 <WebComponents::AuLabel>{{t "publication-form-numac-nummer"}}</WebComponents::AuLabel>
                 <div style="background: #FFFFFF;border: 1px solid #CCD1D9; box-sizing: border-box;">
                   {{#each this.numacNumbers as |numac|}}
-                    <div style="    background-color: lightgray;
-                                    border: 1px solid gray;
-                                    border-radius: 8px;
-                                    display: inline-block;
-                                    padding: 0.4em;">
-                      <span>{{ numac.name }}</span>
-                      <WebComponents::AuButton
-                        @skin="borderless"
-                        @icon="close"
-                        @layout="icon-only"
-                        {{on "click" (fn this.deleteNumacNumber numac)}}
-                        data-test-cases-backlink/>
+                    <div style="display:inline-block;margin:0.1em;">
+                      <div style="    background-color: #F3F5F6;
+                                      border: 1px solid #CBD2DA;
+                                      border-right:0px solid #CBD2DA;
+                                      border-radius: 8px 0px 0px 8px;
+                                      display: inline-block;
+                                      padding: 0px;
+                                      min-width: 60px;
+                                      font-weight:bold;
+                                      color:#69717C;
+                                      text-align: right;
+                                      padding: 0.4em;float:left;">
+                        <span>{{ numac.name }}</span>
+                      </div>
+                      <div style="    background-color: #F3F5F6;
+                                        border: 1px solid #CBD2DA;
+                                            border-radius: 0px 8px 8px 0px;
+                                        display: inline-block;
+                                        padding: 0.4em;float:left;">
+                        <WebComponents::AuButton class="auk-button--nopadding"
+                          @skin="borderless"
+                          @icon="close"
+                          @layout="icon-only"
+                          {{on "click" (fn this.deleteNumacNumber numac)}}
+                          data-test-cases-backlink/>
+                      </div>
                     </div>
                   {{/each}}
                 </div>

--- a/app/pods/publications/publication/template.hbs
+++ b/app/pods/publications/publication/template.hbs
@@ -101,7 +101,7 @@
               </div>
               <div class="auk-form-group">
                 <WebComponents::AuLabel>{{t "publication-form-numac-nummer"}}</WebComponents::AuLabel>
-                <div style="background: #FFFFFF;border: 1px solid #CCD1D9; box-sizing: border-box;">
+                <div style="background: #FFFFFF;border: 1px solid #CCD1D9; box-sizing: border-box;  line-height: 0.8em;  padding: 7px;">  
                   {{#each this.numacNumbers as |numac|}}
                     <div style="display:inline-block;margin:0.1em;">
                       <div style="    background-color: #F3F5F6;
@@ -112,6 +112,7 @@
                                       padding: 0px;
                                       min-width: 60px;
                                       font-weight:bold;
+                                      line-height: 1.2em;
                                       color:#69717C;
                                       text-align: right;
                                       padding: 0.4em;float:left;">

--- a/app/pods/publications/publication/template.hbs
+++ b/app/pods/publications/publication/template.hbs
@@ -101,12 +101,27 @@
               </div>
               <div class="auk-form-group">
                 <WebComponents::AuLabel>{{t "publication-form-numac-nummer"}}</WebComponents::AuLabel>
-                {{#if this.model.publicationFlow.numacNumber}}
-                  <WebComponents::AuInput type="number" value={{this.model.publicationFlow.numacNumber}} @block="true" readonly
-                    {{on "input" (perform this.setNumacNumber)}} />
-                {{else}}
-                  <span class="auk-icon--light">{{t "no-numac-number-yet"}}</span>
-                {{/if}}
+                {{#each this.numacNumbers as |numac|}}
+                  <WebComponents::AuInput
+                    type="number"
+                    value={{ numac.name }}
+                    @block="true"
+                    readonly
+                  />
+                {{/each}}
+                <WebComponents::AuInput
+                  type="text"
+                  id="newNumacNumber"
+                  value={{mut this.newNumacNumber}}
+                  onchange={{action "setNumacNummer"}}
+                />
+
+                <WebComponents::AuButton
+                  @skin="borderless"
+                  {{on "click"
+                   this.addNumacNumber}}>
+                  {{t "save"}}
+                </WebComponents::AuButton>
               </div>
               {{#if this.model.publicationFlow.status.isToBePublished}}
                 <div class="auk-form-group">
@@ -220,4 +235,10 @@
       </WebComponents::AuToolbar>
     </WebComponents::AuModal::Footer>
   </WebComponents::AuModal>
+{{/if}}
+
+
+
+{{#if this.showLoader}}
+  <WebComponents::AuLoadingOverlay/>
 {{/if}}

--- a/app/services/publication-service.js
+++ b/app/services/publication-service.js
@@ -111,4 +111,18 @@ export default class PublicationService extends Service {
   invalidatePublicationCache() {
     this.cachedData = A([]);
   }
+
+  async createNumacNumber(name) {
+    const numacNumber = this.store.createRecord('numac-number', {
+      name: name,
+    });
+    return await numacNumber.save();
+  }
+
+  async linkNumacNumber(numacNumber, publicationFlow) {
+    const numberslist = await publicationFlow.get('numacNumbers');
+    numberslist.pushObject(numacNumber);
+    publicationFlow.set('numacNumbers', numberslist);
+    return await publicationFlow.save();
+  }
 }

--- a/app/services/publication-service.js
+++ b/app/services/publication-service.js
@@ -127,7 +127,6 @@ export default class PublicationService extends Service {
   }
 
   async unlinkNumacNumber(numacNumber, publicationFlow) {
-    console.log(numacNumber);
     const numberslist = await publicationFlow.get('numacNumbers').toArray();
     for (let index = 0; index < numberslist.length; index++) {
       const numacNumberInLoop = numberslist[index];

--- a/app/services/publication-service.js
+++ b/app/services/publication-service.js
@@ -112,29 +112,18 @@ export default class PublicationService extends Service {
     this.cachedData = A([]);
   }
 
-  async createNumacNumber(name) {
-    const numacNumber = this.store.createRecord('numac-number', {
+  async createNumacNumber(name, publicationFlow) {
+    const numacNumber = await this.store.createRecord('numac-number', {
       name: name,
+      publicationFlow: publicationFlow,
     });
-    return await numacNumber.save();
-  }
-
-  async linkNumacNumber(numacNumber, publicationFlow) {
-    const numberslist = await publicationFlow.get('numacNumbers');
-    numberslist.pushObject(numacNumber);
-    publicationFlow.set('numacNumbers', numberslist);
-    return await publicationFlow.save();
+    await numacNumber.save();
+    await publicationFlow.hasMany('numacNumbers').reload();
+    return numacNumber;
   }
 
   async unlinkNumacNumber(numacNumber, publicationFlow) {
-    const numberslist = await publicationFlow.get('numacNumbers').toArray();
-    for (let index = 0; index < numberslist.length; index++) {
-      const numacNumberInLoop = numberslist[index];
-      if (numacNumberInLoop.get('id') === numacNumber.get('id')) {
-        numberslist.splice(index, 1);
-      }
-    }
-    publicationFlow.set('numacNumbers', numberslist);
-    return await publicationFlow.save();
+    await numacNumber.deleteRecord();
+    await publicationFlow.hasMany('numacNumbers').reload();
   }
 }

--- a/app/services/publication-service.js
+++ b/app/services/publication-service.js
@@ -125,4 +125,17 @@ export default class PublicationService extends Service {
     publicationFlow.set('numacNumbers', numberslist);
     return await publicationFlow.save();
   }
+
+  async unlinkNumacNumber(numacNumber, publicationFlow) {
+    console.log(numacNumber);
+    const numberslist = await publicationFlow.get('numacNumbers').toArray();
+    for (let index = 0; index < numberslist.length; index++) {
+      const numacNumberInLoop = numberslist[index];
+      if (numacNumberInLoop.get('id') === numacNumber.get('id')) {
+        numberslist.splice(index, 1);
+      }
+    }
+    publicationFlow.set('numacNumbers', numberslist);
+    return await publicationFlow.save();
+  }
 }

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -704,6 +704,7 @@
   "publication-form-publication-date": "PublicatieDatum BS",
   "publication-form-numac-nummer": "Werknummer BS",
   "no-numac-number-yet": "Nog geen werknummer",
+  "numac-number": "Werknummer BS",
   "requests":"Aanvragen",
   "request-translations":"Vertaling(en) aanvragen",
   "request-translations-for-publication":"Vertalingen aanvragen voor Publicatie {publicationNumber}",


### PR DESCRIPTION
### Backend PR
https://github.com/kanselarij-vlaanderen/kaleidos-project/pull/161

### Frontend:
<img width="322" alt="Screenshot 2021-02-09 at 14 18 14" src="https://user-images.githubusercontent.com/592312/107370153-e447dc80-6ae2-11eb-9bc8-cb65cd1921b5.png">

<img width="216" alt="Screenshot 2021-02-09 at 14 49 49" src="https://user-images.githubusercontent.com/592312/107372821-1eff4400-6ae6-11eb-8964-ebe9d40268bd.png">


### Remarks:
@brechtPhilips Waar steek ik de CSS hiervoor?
@emilyvandewalle hoe doe ik die CSS beter?

Ik weet dat het input veld in het design er niet in zit, maar in het design wordt er van powerselect uitgegaan en dit geeft altijd extra zoekfunctionaliteit (geen resultaten gevonden) bijvoorbeeld en dit lijkt erg "out of place"
<img width="305" alt="Screenshot 2021-02-09 at 14 37 24" src="https://user-images.githubusercontent.com/592312/107371250-5b31a500-6ae4-11eb-96be-a342290fc61d.png">


Op deze manier is het functioneel en kan het gebruikt worden.