### PR TITLE
Bugfix/kas 2376 demo feedback

### DIFF
--- a/app/models/subcase.js
+++ b/app/models/subcase.js
@@ -166,7 +166,10 @@ export default ModelWithModifier.extend({
 
   onAgendaInfo: computed('latestMeeting', async function() {
     const latestMeeting = await this.get('latestMeeting');
-    return latestMeeting.plannedStart;
+    if (latestMeeting) {
+      return latestMeeting.plannedStart;
+    }
+    return null;
   }),
 
   approved: computed('treatments', 'treatments.@each.decisionResultCode', function() {

--- a/app/pods/components/agenda/agenda-header/template.hbs
+++ b/app/pods/components/agenda/agenda-header/template.hbs
@@ -79,9 +79,9 @@
                       </li>
                       <li class="vlc-dropdown-menu__separator" aria-hidden="true"></li>
                     {{/if}}
-                    <li class="vlc-dropdown-menu__item">
-                      {{#if (not currentSession.isFinal)}}
-                        {{#if (await isSessionClosable)}}
+                    {{#if (not currentSession.isFinal)}}
+                      {{#if (await isSessionClosable)}}
+                        <li class="vlc-dropdown-menu__item">
                           <a href=""
                             data-test-agenda-header-lockAgenda
                             class="vl-link vl-link--block vl-u-text--error"
@@ -90,8 +90,11 @@
                           >
                             {{t "agenda-close"}}
                           </a>
-                        {{/if}}
-                      {{else}}
+                        </li>
+                        <li class="vlc-dropdown-menu__separator" aria-hidden="true"></li>
+                      {{/if}}
+                    {{else}}
+                      <li class="vlc-dropdown-menu__item">
                         <a href=""
                           data-test-agenda-header-unlockAgenda
                           class="vl-link vl-link--block"
@@ -100,13 +103,12 @@
                         >
                           {{t "agenda-reopen"}}
                         </a>
-                      {{/if}}
-                    </li>
-                    
+                      </li>
+                      <li class="vlc-dropdown-menu__separator" aria-hidden="true"></li>
+                    {{/if}}
                   {{/if}}
                   {{!-- These actions check for isEditor/isAdmin themselves, so we put these outside the previous if statement --}}
                   {{#if (await canDeleteSelectedAgenda)}}
-                    <li class="vlc-dropdown-menu__separator" aria-hidden="true"></li>
                     <li class="vlc-dropdown-menu__item vlc-dropdown-menu__item--action-danger">
                       <a href=""
                         data-test-agenda-header-deleteAgenda

--- a/app/pods/components/web-components/au-abbreviated-text/template.hbs
+++ b/app/pods/components/web-components/au-abbreviated-text/template.hbs
@@ -1,7 +1,7 @@
 {{#if this.textTooLong}}
   <div class="auk-u-flex">
     {{#if this.isCustom}}
-      <div class="{{@customTextClass}}">{{this.textAbbreviated}}</div>
+      <div class="{{@customTextClass}}" ...attributes>{{this.textAbbreviated}}</div>
     {{else}}
       {{this.textAbbreviated}}
     {{/if}}
@@ -18,7 +18,7 @@
   </div>
 {{else}}
   {{#if this.isCustom}}
-    <div class="{{@customTextClass}}">{{@text}}</div>
+    <div class="{{@customTextClass}}" ...attributes>{{@text}}</div>
   {{else}}
     {{@text}}
   {{/if}}

--- a/app/pods/components/web-components/au-abbreviated-text/template.hbs
+++ b/app/pods/components/web-components/au-abbreviated-text/template.hbs
@@ -1,10 +1,16 @@
 {{#if this.textTooLong}}
   <div class="auk-u-flex">
-    {{this.textAbbreviated}}
+    {{#if this.isCustom}}
+      <div class="{{@customTextClass}}">{{this.textAbbreviated}}</div>
+    {{else}}
+      {{this.textAbbreviated}}
+    {{/if}}
     <WebComponents::AuButtonLink
             @icon="circle-more"
             @skin="mute"
-            @layout="icon-only">
+            @layout="icon-only"
+            class="auk-u-flex--vertical-center"
+            >
       <EmberTooltip @tooltipClass="auk-tooltip">
         {{@text}}
       </EmberTooltip>
@@ -12,9 +18,7 @@
   </div>
 {{else}}
   {{#if this.isCustom}}
-    <h4 class="auk-toolbar-complex__title" data-test-publication-detail-menu-short-title>
-      {{@text}}
-    </h4>
+    <div class="{{@customTextClass}}">{{@text}}</div>
   {{else}}
     {{@text}}
   {{/if}}

--- a/app/pods/publications/index/template.hbs
+++ b/app/pods/publications/index/template.hbs
@@ -30,7 +30,7 @@
         {{/if}}
 
         {{#if this.filterTableColumnOptionKeys.numacNumberFilterOption}}
-          <th>{{t "numac-number"}}</th>
+          <th>{{t "publications-table-numacnummer-bs"}}</th>
         {{/if}}
 
         {{#if this.filterTableColumnOptionKeys.derivedPublicationTypeFilterOption}}
@@ -72,10 +72,6 @@
             @field="publishedAt"
             @label={{t "publications-table-publication-date"}}
           />
-        {{/if}}
-
-        {{#if this.filterTableColumnOptionKeys.numacNuberBsFilterOption}}
-          <th>{{t "publications-table-numacnummer-bs"}}</th>
         {{/if}}
 
         {{#if this.filterTableColumnOptionKeys.caseManagerFilterOption}}
@@ -141,11 +137,21 @@
         {{#if this.filterTableColumnOptionKeys.caseNameFilterOption}}
         {{!-- There is legacy data were case does not have a shortTitle, we have to fall back to title --}}
           <td class="auk-table__col--6">
-            {{if
+            {{#if row.case.shortTitle}}
+              <WebComponents::AuAbbreviatedText @text={{row.case.shortTitle}} @size="150"/>
+            {{else}}
+              {{#if row.case.title}}
+                <WebComponents::AuAbbreviatedText @text={{row.case.title}} @size="150"/>
+              {{else}}
+                {{t "dash"}}
+              {{/if}}
+            {{/if}}
+            {{!-- <WebComponents::AuAbbreviatedText @text={{this.titleText}} @size="150" @custom="true" /> --}}
+            {{!-- {{if
               row.case.shortTitle
               row.case.shortTitle
               (if row.case.title row.case.title (t "dash"))
-            }}
+            }} --}}
           </td>
         {{/if}}
         {{#if this.filterTableColumnOptionKeys.publicationNumberFilterOption}}
@@ -160,14 +166,16 @@
         {{#if this.filterTableColumnOptionKeys.numacNumberFilterOption}}
           <td>
             {{#each row.numacNumbers as |numac|}}
-              <WebComponents::AuPill>{{numac.name }}</WebComponents::AuPill>
+              <WebComponents::AuPill>{{numac.name}}</WebComponents::AuPill>
+            {{else}}
+              {{t "dash"}}
             {{/each}}
           </td>
         {{/if}}
         {{#if this.filterTableColumnOptionKeys.derivedPublicationTypeFilterOption}}
           <td>
             {{#if row.deducedType}}
-              {{ row.deducedType.label }}
+              {{row.deducedType.label}}
             {{else}}
               {{t "dash"}}
             {{/if}}
@@ -261,11 +269,11 @@
                 (eq (await row.translationRequestsFinished) (await row.translationRequestsTotal))
               }}
                 <WebComponents::AuStatusPill @status="done">
-                  {{ await row.translationRequestsFinished }} / {{ await row.translationRequestsTotal }}
+                  {{await row.translationRequestsFinished}} / {{await row.translationRequestsTotal}}
                 </WebComponents::AuStatusPill>
               {{else}}
                 <WebComponents::AuStatusPill @status="in-progress">
-                  {{ await row.translationRequestsFinished }} / {{ await row.translationRequestsTotal }}
+                  {{await row.translationRequestsFinished}} / {{await row.translationRequestsTotal}}
                 </WebComponents::AuStatusPill>
               {{/if}}
             {{else}}
@@ -288,11 +296,11 @@
                 (eq (await row.publishpreviewRequestsFinished) (await row.publishpreviewRequestsTotal))
               }}
                 <WebComponents::AuStatusPill @status="done">
-                  {{ await row.publishpreviewRequestsFinished }} / {{ await row.publishpreviewRequestsTotal }}
+                  {{await row.publishpreviewRequestsFinished}} / {{await row.publishpreviewRequestsTotal}}
                 </WebComponents::AuStatusPill>
               {{else}}
                 <WebComponents::AuStatusPill @status="in-progress">
-                  {{ await row.publishpreviewRequestsFinished }} / {{ await row.publishpreviewRequestsTotal }}
+                  {{await row.publishpreviewRequestsFinished}} / {{await row.publishpreviewRequestsTotal}}
                 </WebComponents::AuStatusPill>
               {{/if}}
             {{else}}
@@ -310,6 +318,8 @@
                   {{t "priority-procedure"}}
                 </p>
               </EmberTooltip>
+            {{else}}
+              {{t "dash"}}
             {{/if}}
           </td>
         {{/if}}
@@ -323,6 +333,8 @@
                   {{row.remark}}
                 </p>
               </EmberTooltip>
+            {{else}}
+              {{t "dash"}}
             {{/if}}
           </td>
         {{/if}}

--- a/app/pods/publications/index/template.hbs
+++ b/app/pods/publications/index/template.hbs
@@ -146,12 +146,6 @@
                 {{t "dash"}}
               {{/if}}
             {{/if}}
-            {{!-- <WebComponents::AuAbbreviatedText @text={{this.titleText}} @size="150" @custom="true" /> --}}
-            {{!-- {{if
-              row.case.shortTitle
-              row.case.shortTitle
-              (if row.case.title row.case.title (t "dash"))
-            }} --}}
           </td>
         {{/if}}
         {{#if this.filterTableColumnOptionKeys.publicationNumberFilterOption}}
@@ -198,14 +192,17 @@
         {{#if this.filterTableColumnOptionKeys.finalPublicationDateFilterOption}}
           <td class="auk-u-text-nowrap">
             {{#if row.publishBefore}}
+            {{!-- TODO We want to check if the publication is still ongoing, no warnings for published/withdrawn --}}
               {{#if
                 (is-between (moment-subtract row.publishBefore 2 precision='days') row.publishBefore)
               }}
                 <div class="auk-form-help-text--warning">
+                  <WebComponents::AuIcon @name="alert-triangle"/>
                   {{moment-format row.publishBefore "DD-MM-YYYY"}}
                 </div>
               {{else if (is-before row.publishBefore now)}}
                 <div class="auk-form-help-text--danger">
+                  <WebComponents::AuIcon @name="alert-triangle"/>
                   {{moment-format row.publishBefore "DD-MM-YYYY"}}
                 </div>
               {{else}}

--- a/app/pods/publications/publication/case/route.js
+++ b/app/pods/publications/publication/case/route.js
@@ -8,13 +8,20 @@ export default class CaseRoute extends Route.extend(AuthenticatedRouteMixin) {
     const publicationFlow = parentHash.publicationFlow;
     const _case = await publicationFlow.get('case');
     const contactPersons = await publicationFlow.get('contactPersons');
-    const organizations = await this.store.query('organization', {});
+    // TODO This is not ideal, there are currently +- 60 organizations that come from ACM-IDM, they don't have a name
+    // TODO need a better filter, add a boolean to model maybe ?
+    const organizations = await this.store.query('organization', {
+      page: {
+        size: 200,
+      },
+    });
+    const filteredOrganizations = organizations.filter((orgs) => orgs.name);
     return hash({
       publicationFlow,
       case: _case,
       contactPersons: contactPersons,
       refreshAction: parentHash.refreshAction,
-      organizations: organizations.toArray(),
+      organizations: filteredOrganizations.toArray(),
     });
   }
   async afterModel(model) {

--- a/app/pods/publications/publication/case/template.hbs
+++ b/app/pods/publications/publication/case/template.hbs
@@ -355,7 +355,7 @@
                   @search={{this.customPowerSelectSearchFunction}}
                   @options={{await this.allOrganizations}}
                   @selected={{this.selectedOrganizations}}
-                  @noMatchesMessage={{t "search-organization"}}
+                  @noMatchesMessage={{t "organizations-empty-result"}}
                   @placeholder={{t "search-organization"}}
                   @onchange={{this.selectOrganization}}
                   as |organization|>

--- a/app/pods/publications/publication/controller.js
+++ b/app/pods/publications/publication/controller.js
@@ -170,6 +170,13 @@ export default class PublicationController extends Controller {
 
   @action
   allowedTranslationDate(date) {
+    // If translateBefore has expired, show that date (input is empty without this)
+    const translateBefore = this.model.publicationFlow.get('translateBefore');
+    if (translateBefore && moment(translateBefore).isBefore(moment())) {
+      if (moment(date).isSame(translateBefore)) {
+        return true;
+      }
+    }
     const end = moment(this.model.publicationFlow.get('publishBefore'));
     if (moment(date).isSameOrBefore(end) && moment(date).isSameOrAfter(moment())) {
       return true;
@@ -181,8 +188,9 @@ export default class PublicationController extends Controller {
   allowedPublicationDate(date) {
     const end = moment().add(360, 'days');
     let startRange;
-    if (this.model.publicationFlow.get('translateBefore')) {
-      startRange = moment(this.model.publicationFlow.get('translateBefore'));
+    const translateBefore = this.model.publicationFlow.get('translateBefore');
+    if (translateBefore && moment(translateBefore).isSameOrAfter(moment())) {
+      startRange = moment(translateBefore);
     } else {
       startRange = moment();
     }

--- a/app/pods/publications/publication/template.hbs
+++ b/app/pods/publications/publication/template.hbs
@@ -10,7 +10,14 @@
               this.casePath
             }}
           </span>
-          <WebComponents::AuAbbreviatedText @text={{this.titleText}} @size="150" @custom="true" />
+          <WebComponents::AuAbbreviatedText
+            data-test-publication-detail-menu-short-title
+            @text={{this.titleText}}
+            @size="150"
+            @custom="true"
+            @customTextClass="auk-toolbar-complex__title"
+          >
+          </WebComponents::AuAbbreviatedText>
           <WebComponents::AuTabs @reversed="true">
             <WebComponents::AuTab @isHierarchicalBack="true" @route="publications" data-test-publication-case-nav-go-back></WebComponents::AuTab>
             <WebComponents::AuTab @route="publications.publication.case" data-test-publication-case-nav-case>{{t "agendaitem-case"}}</WebComponents::AuTab>

--- a/app/pods/publications/template.hbs
+++ b/app/pods/publications/template.hbs
@@ -24,7 +24,6 @@
                                       @placeholder={{t "search-placeholder"}}
                                       @value={{this.searchText}}
                                       {{on "input" (perform this.debouncedSearchTask)}}
-                                      {{!-- @enter={{perform this.debouncedSearchTask}} --}}
                                       @autocomplete="off"
               />
               {{#if showSearchResults}}

--- a/app/pods/publications/template.hbs
+++ b/app/pods/publications/template.hbs
@@ -24,7 +24,7 @@
                                       @placeholder={{t "search-placeholder"}}
                                       @value={{this.searchText}}
                                       {{on "input" (perform this.debouncedSearchTask)}}
-                                      @enter={{perform this.debouncedSearchTask}}
+                                      {{!-- @enter={{perform this.debouncedSearchTask}} --}}
                                       @autocomplete="off"
               />
               {{#if showSearchResults}}

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -750,7 +750,7 @@
   "translation-mail-header": "Bericht",
   "files": "Bijlages",
   "no-translation-requests": "Er zijn nog geen vertalingsaanvragen.",
-  "translation-requests": "Vertalingsaanvragen.",
+  "translation-requests": "Vertalingsaanvragen",
   "no-publishpreview-requests": "Er zijn nog geen drukproefaanvragen.",
   "no-corrections": "Er zijn nog geen verbeteringen toegevoegd.",
   "add-correction": "Verbetering toevoegen",

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -701,6 +701,7 @@
   "organization": "Organisatie",
   "add-organization": "Organisatie toevoegen",
   "search-organization": "Zoek een organisatie",
+  "organizations-empty-result": "Geen organisaties gevonden",
   "contacts": "Contactpersonen",
   "add-contact-persons": "Contactpersonen toevoegen",
   "no-added-contact-persons": "Er zijn nog geen contactpersonen toegevoegd",

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -806,5 +806,6 @@
   "publications-table-derived-publicationtype-info": "Wordt afgeleid op basis van de documenten binnen de publicatie",
   "filter-plural": "Filteren",
   "reset": "Reset",
-  "to-case": "Naar dossier"
+  "to-case": "Naar dossier",
+  "config": "Instelling"
 }


### PR DESCRIPTION
# What has changed:
- Sidebar publicatie: verstreken datums tonen niet meer, lege inputfield maar wel melding dat de datum verstreken is
- op het publicatie overzicht de zoekfunctie gebruiken door de enter toets te gebruiken geeft een error  
- pagina titel vertaalaanvragen heeft een . in de titel  
- publicatie overview tabel x2 werknummer, 1 header te veel voor aantal kolommen  
- publicatie overview tabel geen afkorting van lange titels ?  
- publicatie detail, afgekorte titel in header had andere css dan niet afgekorte titel (geen _title css)
- publicatie overview tabel lege kolommen bij geen data  
- publicatie overview tabel hoofding van de grijze balk juiste css ?  
- publicatie overview tabel iconen missen bij verstreken datums  
- saven email template rubberband "missing translation "config""  
- lijst met org data niet juist op accept/dev, prod ?
- agenda acties waarbij een agendapunt wordt verwijdert (agenda afsluiten) => procudurestap "beslist op" bevat geen tekst => De agenda-approve-service verwijdert de behandeling/beslissing bij heragendeerbaar maken procedurestap  

