### PR TITLE
KAS-2403 AuthenticatedRouteMixin verwijderen van alle publication sub…

### DIFF
--- a/app/pods/publications/publication/case/route.js
+++ b/app/pods/publications/publication/case/route.js
@@ -1,8 +1,7 @@
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import Route from '@ember/routing/route';
 import { hash } from 'rsvp';
 
-export default class CaseRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class CaseRoute extends Route {
   async model() {
     const parentHash = this.modelFor('publications.publication');
     const publicationFlow = parentHash.publicationFlow;

--- a/app/pods/publications/publication/documents/route.js
+++ b/app/pods/publications/publication/documents/route.js
@@ -1,4 +1,3 @@
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import Route from '@ember/routing/route';
 import { hash } from 'rsvp';
 import { A } from '@ember/array';
@@ -6,7 +5,7 @@ import {
   set, action
 } from '@ember/object';
 
-export default class PublicationDocumentsRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class PublicationDocumentsRoute extends Route {
   async model() {
     const parentHash = this.modelFor('publications.publication');
     const publicationFlow = parentHash.publicationFlow;

--- a/app/pods/publications/publication/publishpreview/route.js
+++ b/app/pods/publications/publication/publishpreview/route.js
@@ -1,9 +1,8 @@
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import Route from '@ember/routing/route';
 import CONFIG from 'frontend-kaleidos/utils/config';
 import { hash } from 'rsvp';
 
-export default class PublicationPublishPreviewRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class PublicationPublishPreviewRoute extends Route {
   async model() {
     const parentHash = this.modelFor('publications.publication');
     const publicationFlow = parentHash.publicationFlow;

--- a/app/pods/publications/publication/translations/route.js
+++ b/app/pods/publications/publication/translations/route.js
@@ -1,9 +1,8 @@
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import Route from '@ember/routing/route';
 import CONFIG from 'frontend-kaleidos/utils/config';
 import { hash } from 'rsvp';
 
-export default class PublicationTranslationRoute extends Route.extend(AuthenticatedRouteMixin) {
+export default class PublicationTranslationRoute extends Route {
   async model() {
     const parentHash = this.modelFor('publications.publication');
     const publicationFlow = parentHash.publicationFlow;


### PR DESCRIPTION
AuthenticatedRouteMixin werd verwijderd uit alle publication subroutes, aangezien dit al werd geinclude op de parent route.
Zie https://kanselarij.atlassian.net/browse/KAS-2403