### PR TITLE
add au-kaleidos-css package to sass includePaths

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -119,9 +119,9 @@ $icon-font-location: '/fonts/'; // overrides the default location for flanders-i
 @import 'custom-application/extra-fonts';
 @import 'custom-application/loader';
 
-// Components (from npm package)
-@import "node_modules/@kanselarij-vlaanderen/au-kaleidos-css/auk-standalone";
-@import "au-kaleidos-css/auk-additions";
+// Components
+@import "auk-standalone"; // sourced from "au-kaleidos-css" npm package
+@import "au-kaleidos-css/auk-additions"; // sourced locally
 
 // (not sure about naming/location)
 @import 'custom-application/m-header';

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -12,6 +12,7 @@ module.exports = function (defaults) {
       extension: 'scss',
       sourceMapEmbed: process.env.DEPLOY_ENV !== 'production',
       includePaths: [
+        'node_modules/@kanselarij-vlaanderen/au-kaleidos-css/',
         'node_modules/@lblod/ember-rdfa-editor/app/styles/', // as a workaround for https://github.com/ember-cli/ember-cli/issues/8026#issuecomment-420245390
       ],
     },


### PR DESCRIPTION
Adds the [au-kaleidos-css](https://github.com/kanselarij-vlaanderen/au-kaleidos-css)-package to the projects' ember-cli-sass- `includePaths`. This indirectly includes the css-dependency into the live-reload watch-paths, which should make for easier development.  

Following steps should be followed to develop on the `kanselarij-vlaanderen/au-kaleidos-css`-package directly, eliminating the need to temporarily add all external css-sources to the local repository.
- Navigate to your `kanselarij-vlaanderen/au-kaleidos-css`-repo folder and run `npm link`
- Navigate to your `kanselarij-vlaanderen/kaleidos-frontend`-repo folder and run `npm link @kanselarij-vlaanderen/au-kaleidos-css` (note the namespaced package notation)
- Run you usual `ember serve` command for starting the kaleidos-frontend development server in `kanselarij-vlaanderen/kaleidos-frontend`.
- Edit a source-file in `kanselarij-vlaanderen/au-kaleidos-css` and enjoy to see the result of the change being live-reloaded :blush: 

Note that once you run `npm install` in the frontend-repo, the symlink to the css-repo will be broken. Run the described procedure above again to restore the link.

Could you check if this works out for you @brenner-company ?
