### PR TITLE
adapt to new publication-flow search index

### DIFF
--- a/app/components/publications/publication-case-search.hbs
+++ b/app/components/publications/publication-case-search.hbs
@@ -18,19 +18,15 @@
         <LinkTo
           data-test-publication-search-result
           @route="publications.publication.documents"
-          @model={{result.publicationFlowId}}
+          @model={{result.id}}
         >
-          {{#if result.subcaseSubTitle}}
-            {{result.subcaseSubTitle}}
-          {{else if result.subcaseTitle}}
-            {{result.subcaseTitle}}
-          {{else if result.shortTitle}}
-            {{result.shortTitle}}
+          {{#if result.shortTile}}
+            {{result.shortTile}}
           {{else if result.title}}
             {{result.title}}
           {{/if}}
           <br>
-          <span class="auk-u-muted auk-u-text-small">{{result.publicationFlowNumber}}</span>
+          <span class="auk-u-muted auk-u-text-small">{{result.identification}}</span>
         </LinkTo>
       </WebComponents::AuDropdown::Item>
     {{else}}

--- a/app/components/publications/publication-case-search.js
+++ b/app/components/publications/publication-case-search.js
@@ -14,13 +14,10 @@ export default class PublicationsPublicationCaseSearchComponent extends Componen
 
   searchFields = Object.freeze([
     'title',
-    'publicationFlowNumber',
-    'publicationFlowRemark',
     'shortTitle',
-    'subcaseTitle',
-    'subcaseSubTitle',
-    'publicationFlowNumacNumbers',
-    'publicationFlowId'
+    'remark',
+    'identification',
+    'numacNumbers'
   ]);
   searchModifier = Object.freeze(':phrase_prefix:');
 
@@ -70,11 +67,9 @@ export default class PublicationsPublicationCaseSearchComponent extends Componen
 
   @restartableTask
   *searchPublications(searchTerm) {
-    const filter = {
-      ':has:publicationFlowNumber': 'true',
-    };
+    const filter = {};
     filter[`${this.searchModifier}${this.searchFields.join(',')}`] = searchTerm;
-    const searchResults = yield search('cases', 0, 10, null, filter, (item) => {
+    const searchResults = yield search('publication-flows', 0, 10, null, filter, (item) => {
       const entry = item.attributes;
       entry.id = item.id;
       return entry;


### PR DESCRIPTION
[KAS-2590](https://kanselarij.atlassian.net/browse/KAS-2590)

Goes with backend pr https://github.com/kanselarij-vlaanderen/kaleidos-project/pull/194

Note that the `title` and `shortTitle` properties used already forsee [KAS-2576](https://kanselarij.atlassian.net/browse/KAS-2576). Without that merged it is normal that the title doens't appear in the search results list.