### PR TITLE
Sass deprecation warning 'Slash as division' oplossen

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@ember/render-modifiers": "^1.0.2",
     "@glimmer/component": "^1.0.0",
     "@glimmer/tracking": "^1.0.0",
-    "@kanselarij-vlaanderen/au-kaleidos-css": "^1.22.0",
+    "@kanselarij-vlaanderen/au-kaleidos-css": "^1.22.1",
     "@kanselarij-vlaanderen/au-kaleidos-icons": "^1.3.2",
     "@lblod/ember-acmidm-login": "^1.1.1",
     "@lblod/ember-mock-login": "^0.5.0-beta",


### PR DESCRIPTION
Aanpassingen zijn quasi alleen binnen `au-kaleidos-css` gedaan.

Deze PR is dus vooral even om de tests te laten lopen (om 100% zeker te zijn dat alles goed zit).