### PR TITLE
Bugfix/kas 2601 pieces go missing overview

### DIFF
--- a/app/pods/agenda/agendaitems/agendaitem/index/route.js
+++ b/app/pods/agenda/agendaitems/agendaitem/index/route.js
@@ -43,11 +43,15 @@ export default class DetailAgendaitemAgendaitemsAgendaRoute extends Route {
         this.submitter = await this.subcase.requestedBy;
       }
     }
-    const agendaItemTreatment = await model.treatments;
+    const agendaItemTreatment = await model.hasMany('treatments').reload();
     const anyTreatment = agendaItemTreatment.firstObject;
     if (anyTreatment) {
       this.newsletterInfo = await anyTreatment.newsletterInfo;
     }
+    // When routing here from agenda overview with stale data, we need to reload several relations
+    // The reload in model refreshes only the attributes and includes relations, makes saves with stale relation data possible
+    await model.hasMany('mandatees').reload();
+    await model.hasMany('pieces').reload();
     this.mandatees = (await model.mandatees).sortBy('priority');
   }
 

--- a/app/pods/agenda/template.hbs
+++ b/app/pods/agenda/template.hbs
@@ -6,6 +6,7 @@
 {{agenda/agenda-header
   loading=(action "loadingAgendaitems")
   onCreateAgendaitem=(action "refresh")
+  onApproveAllAgendaitems=(action "refresh")
   onApproveAgenda=(action "navigateToAgenda")
   navigateToPressAgenda=(action "navigateToPressAgenda")
   navigateToDecisions=(action "navigateToDecisions")

--- a/cypress/integration/unit/agenda.spec.js
+++ b/cypress/integration/unit/agenda.spec.js
@@ -61,6 +61,7 @@ context('Agenda tests', () => {
       cy.get(auk.alert.message).should('exist');
     });
     cy.get(agenda.agendaHeader.confirm.approveAgenda).contains('Goedkeuren');
+    cy.get(auk.loader).should('not.exist');
     cy.get(auk.modal.footer.cancel).contains('Annuleren')
       .click();
     // instead of confirming the opened modal, we cancel and let the command handle it

--- a/cypress/support/commands/agenda-commands.js
+++ b/cypress/support/commands/agenda-commands.js
@@ -311,6 +311,7 @@ function setAllItemsFormallyOk(amountOfFormallyOks) {
   cy.get(agenda.agendaHeader.showActionOptions).click();
   cy.route('PATCH', '/agendaitems/**').as('patchAgendaitems');
   cy.get(agenda.agendaHeader.actions.approveAllAgendaitems).click();
+  cy.get(auk.loader).should('not.exist'); // new loader when refreshing data
   cy.contains(`Bent u zeker dat u ${amountOfFormallyOks} agendapunten formeel wil goedkeuren`);
   cy.get(utils.vlModalVerify.save).click();
   cy.wait('@patchAgendaitems');
@@ -384,6 +385,7 @@ function approveDesignAgenda(shouldConfirm = true) {
   // TODO add boolean for when not all items are formally ok, click through the confirmation modal
   cy.get(agenda.agendaHeader.showAgendaOptions).click();
   cy.get(agenda.agendaHeader.agendaActions.approveAgenda).click();
+  cy.get(auk.loader).should('not.exist'); // new loader when refreshing data
   if (shouldConfirm) {
     cy.get(auk.modal.container).within(() => {
       cy.get(agenda.agendaHeader.confirm.approveAgenda).click();
@@ -428,6 +430,7 @@ function approveAndCloseDesignAgenda(shouldConfirm = true) {
   // TODO add boolean for when not all items are formally ok, click through the confirmation modal
   cy.get(agenda.agendaHeader.showAgendaOptions).click();
   cy.get(agenda.agendaHeader.agendaActions.approveAndCloseAgenda).click();
+  cy.get(auk.loader).should('not.exist'); // new loader when refreshing data
   if (shouldConfirm) {
     cy.get(auk.modal.container).within(() => {
       cy.get(agenda.agendaHeader.confirm.approveAndCloseAgenda).click();

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -549,7 +549,7 @@
   "agenda-reopen-previous-version-message": "De vorige agenda versie wordt geopend. Dit kan even duren.",
   "agenda-approve-and-close-message": "De agenda wordt goedgekeurd en daarna afgesloten. Dit kan even duren.",
   "agenda-add-message": "Nieuwe ontwerpagenda aanmaken. Dit kan even duren.",
-  "approve-all-agendaitems-message": "Agendaitems formeel goedkeuren. Dit kan even duren.",
+  "approve-all-agendaitems-message": "Agendapunten formeel goedkeuren. Dit kan even duren.",
   "explanation": "Toelichting",
   "error-delete-agenda": "Er ging iets mis tijdens het verwijderen van de agenda. Contacteer de administrator of probeer het opnieuw.",
   "no-themes-selected": "Geen thema's geselecteerd",


### PR DESCRIPTION
# :warning: STARTED FROM ACC BRANCH 

## What has changed:

agenda-header.js:
- removed commented loader in existing method
- added the reloading of agendaitem relations to existing method (only for items not "formeel ok")
- try catch in approvallAgendaitems method, could get stuck with infinite overlay modal when errors were thrown

nl-be.json:
- correct business translation
