### PR TITLE
KAS-2796 (DES-802): Elementen/structuur omzetten naar Octane componenten - checkboxes

### DIFF
--- a/app/pods/styleguide/panel/template.hbs
+++ b/app/pods/styleguide/panel/template.hbs
@@ -102,11 +102,7 @@
         </Auk::Toolbar::Group>
         <Auk::Toolbar::Group @position="right">
           <Auk::Toolbar::Item>
-            <label class="auk-checkbox" for="checkbox-1">
-              <input class="auk-checkbox__toggle" type="checkbox" id="checkbox-1" name="checkbox-1" value="1" />
-              Toon opties
-              <span class="auk-checkbox__box"></span>
-            </label>
+            <Auk::Checkbox @label="Toon opties" />
           </Auk::Toolbar::Item>
         </Auk::Toolbar::Group>
       </Auk::Toolbar>


### PR DESCRIPTION
**Aanpassingen binnen deze PR:**
- Alle statische versies van elementen die `auk-checkbox[-...]` classes bevatten omzetten (met enkele uitzonderingen waar dit niet mogelijk is of waar dit met een latere refactor aan bod komt). Hier binnen werden ook de nog-bestaande legacy `vl-checkbox` componenten niet mee gerefactored.

**Ticket binnen Jira:** https://kanselarij.atlassian.net/browse/KAS-2796
**Issue (algemeen) binnen repo:** **https://github.com/kanselarij-vlaanderen/kaleidos-frontend/issues/802**