### PR TITLE
KAS-2797: Styling van elementen in en rond Auk::Modal gelijk trekken of corrigeren

### DIFF
--- a/app/components/cases/new-case.hbs
+++ b/app/components/cases/new-case.hbs
@@ -28,13 +28,12 @@
     <Auk::Toolbar @size="large">
       <Auk::Toolbar::Group @position="left">
         <Auk::Toolbar::Item>
-          <Auk::Button
-            @skin="borderless"
+          <Auk::ButtonLink
             {{action "closeAction"}}
             data-test-new-case-cancel
           >
             {{t "cancel"}}
-          </Auk::Button>
+          </Auk::ButtonLink>
         </Auk::Toolbar::Item>
       </Auk::Toolbar::Group>
       <Auk::Toolbar::Group @position="right">

--- a/app/components/publications/new-publication-modal.hbs
+++ b/app/components/publications/new-publication-modal.hbs
@@ -109,17 +109,16 @@
     </Utils::LoadableContent>
   </Auk::Modal::Body>
   <Auk::Modal::Footer @custom={{true}}>
-    <Auk::Toolbar>
+    <Auk::Toolbar @size="large">
       <Auk::Toolbar::Group @position="left">
         <Auk::Toolbar::Item>
-          <Auk::Button
-            @skin="borderless"
+          <Auk::ButtonLink
             disabled={{this.save.isRunning}}
             data-test-publication-button-cancel
             {{on "click" @onCancel}}
           >
             {{t "cancel"}}
-          </Auk::Button>
+          </Auk::ButtonLink>
         </Auk::Toolbar::Item>
       </Auk::Toolbar::Group>
       <Auk::Toolbar::Group @position="right">

--- a/app/components/publications/publication-sidebar.hbs
+++ b/app/components/publications/publication-sidebar.hbs
@@ -254,12 +254,12 @@
       {{t "discharge-publication-flow-confirm"}}
     </Auk::Modal::Body>
     <Auk::Modal::Footer @custom={{true}}>
-      <Auk::Toolbar>
+      <Auk::Toolbar @size="large">
         <Auk::Toolbar::Group @position="left" n>
           <Auk::Toolbar::Item>
-            <Auk::Button @skin="borderless" {{on "click" this.cancelWithdraw}}>
+            <Auk::ButtonLink {{on "click" this.cancelWithdraw}}>
               {{t "cancel"}}
-            </Auk::Button>
+            </Auk::ButtonLink>
           </Auk::Toolbar::Item>
         </Auk::Toolbar::Group>
         <Auk::Toolbar::Group @position="right">

--- a/app/components/publications/publication/case/contact-person-add-modal.hbs
+++ b/app/components/publications/publication/case/contact-person-add-modal.hbs
@@ -63,12 +63,11 @@
     <Auk::Toolbar @size="large">
       <Auk::Toolbar::Group @position="left">
         <Auk::Toolbar::Item>
-          <Auk::Button
-            @skin="borderless"
+          <Auk::ButtonLink
             disabled={{this.save.isRunning}}
             {{on "click" @onCancel}}>
             {{t "cancel"}}
-          </Auk::Button>
+          </Auk::ButtonLink>
         </Auk::Toolbar::Item>
       </Auk::Toolbar::Group>
       <Auk::Toolbar::Group @position="right">

--- a/app/components/publications/publication/case/link-mandatee-modal.hbs
+++ b/app/components/publications/publication/case/link-mandatee-modal.hbs
@@ -16,13 +16,13 @@
     </Utils::LoadableContent>
   </Auk::Modal::Body>
   <Auk::Modal::Footer @custom={{true}}>
-    <Auk::Toolbar>
+    <Auk::Toolbar @size="large">
       <Auk::Toolbar::Group @position="left">
         <Auk::Toolbar::Item>
-          <Auk::Button @skin="borderless" {{on "click" @onClose}}
+          <Auk::ButtonLink {{on "click" @onClose}}
             @disabled={{this.onLink.isRunning}}>
             {{t "cancel"}}
-          </Auk::Button>
+          </Auk::ButtonLink>
         </Auk::Toolbar::Item>
       </Auk::Toolbar::Group>
       <Auk::Toolbar::Group @position="right">

--- a/app/components/publications/publication/case/organization-add-modal.hbs
+++ b/app/components/publications/publication/case/organization-add-modal.hbs
@@ -29,15 +29,14 @@
     </Utils::LoadableContent>
   </Auk::Modal::Body>
   <Auk::Modal::Footer @custom={{true}}>
-    <Auk::Toolbar>
+    <Auk::Toolbar @size="large">
       <Auk::Toolbar::Group @position="left">
         <Auk::Toolbar::Item>
-          <Auk::Button
-            @skin="borderless"
+          <Auk::ButtonLink
             disabled={{this.save.isRunning}}
             {{on "click" @onCancel}}>
             {{t "cancel"}}
-          </Auk::Button>
+          </Auk::ButtonLink>
         </Auk::Toolbar::Item>
       </Auk::Toolbar::Group>
       <Auk::Toolbar::Group @position="right">

--- a/app/components/publications/publication/translations/documents-edit-modal.hbs
+++ b/app/components/publications/publication/translations/documents-edit-modal.hbs
@@ -77,13 +77,11 @@
       </div>
     </div>
   </Auk::Modal::Body>
-  <Auk::Modal::Footer
-          @onCancel={{@onCancel}}
-  >
+  <Auk::Modal::Footer @onCancel={{@onCancel}}>
     <Auk::Button
-            @skin="primary"
-            @disabled={{this.saveIsDisabled}}
-            @loading={{this.saveEditDocument.isRunning}}
+      @skin="primary"
+      @disabled={{this.saveIsDisabled}}
+      @loading={{this.saveEditDocument.isRunning}}
       {{on "click" (perform this.saveEditDocument)}}
     >
       {{t "save"}}

--- a/app/components/publications/publications-filter-modal.hbs
+++ b/app/components/publications/publications-filter-modal.hbs
@@ -66,16 +66,15 @@
   </Auk::Modal::Body>
   {{!-- TODO, use the template, yield the buttons in the right toolbar--}}
   <Auk::Modal::Footer @custom={{true}}>
-    <Auk::Toolbar>
+    <Auk::Toolbar @size="large">
       <Auk::Toolbar::Group @position="left">
         <Auk::Toolbar::Item>
-          <Auk::Button
-            @skin="borderless"
+          <Auk::ButtonLink
             data-test-publication-button-cancel
             {{on "click" @onCancel}}
           >
             {{t "cancel"}}
-          </Auk::Button>
+          </Auk::ButtonLink>
         </Auk::Toolbar::Item>
       </Auk::Toolbar::Group>
       <Auk::Toolbar::Group @position="right">

--- a/app/components/utils/edit-mandatee.hbs
+++ b/app/components/utils/edit-mandatee.hbs
@@ -54,13 +54,12 @@
   <Auk::Toolbar @size="large">
     <Auk::Toolbar::Group @position="left">
       <Auk::Toolbar::Item>
-        <Auk::Button
-          @skin="borderless"
+        <Auk::ButtonLink
           {{action "closeModal"}}
           data-test-edit-mandatee-cancel
         >
           {{t "cancel"}}
-        </Auk::Button>
+        </Auk::ButtonLink>
       </Auk::Toolbar::Item>
     </Auk::Toolbar::Group>
     <Auk::Toolbar::Group @position="right">

--- a/app/components/web-components/vl-modal-verify.hbs
+++ b/app/components/web-components/vl-modal-verify.hbs
@@ -33,9 +33,12 @@
           <Auk::Toolbar @size="large">
             <Auk::Toolbar::Group @position="left">
               <Auk::Toolbar::Item>
-                <Auk::Button @skin="borderless" {{action "cancel"}} data-test-vl-modal-verify-cancel>
+                <Auk::ButtonLink
+                  {{action "cancel"}}
+                  data-test-vl-modal-verify-cancel
+                >
                   {{t "cancel"}}
-                </Auk::Button>
+                </Auk::ButtonLink>
               </Auk::Toolbar::Item>
             </Auk::Toolbar::Group>
             {{#if showVerify}}

--- a/app/pods/settings/system-alerts/index/template.hbs
+++ b/app/pods/settings/system-alerts/index/template.hbs
@@ -19,12 +19,9 @@
     <Auk::Toolbar @size="large">
       <Auk::Toolbar::Group @position="left">
         <Auk::Toolbar::Item>
-          <Auk::Button
-            @skin="borderless"
-            @route="settings.overview"
-          >
+          <Auk::ButtonLink @route="settings.overview">
             {{t "cancel"}}
-          </Auk::Button>
+          </Auk::ButtonLink>
         </Auk::Toolbar::Item>
       </Auk::Toolbar::Group>
       <Auk::Toolbar::Group @position="right">

--- a/app/pods/styleguide/modal/template.hbs
+++ b/app/pods/styleguide/modal/template.hbs
@@ -13,13 +13,7 @@
       <p>Weet je zeker dat je dit dossier wilt goedkeuren voor co-agendering?</p>
     </Auk::Modal::Body>
     <Auk::Modal::Footer @onCancel={{this.onClick}}>
-      <Auk::Toolbar>
-        <Auk::Toolbar::Group @position="right">
-          <Auk::Toolbar::Item>
-            <Auk::Button @skin="primary">Goedkeuren</Auk::Button>
-          </Auk::Toolbar::Item>
-        </Auk::Toolbar::Group>
-      </Auk::Toolbar>
+      <Auk::Button @skin="primary">Goedkeuren</Auk::Button>
     </Auk::Modal::Footer>
   </Auk::Modal>
   {{!-- END-SNIPPET --}}
@@ -38,13 +32,7 @@
       <p>Deze actie zal het document definitief verwijderen en kan niet ongedaan gemaakt worden. Weet u zeker dat u het document wilt verwijderen?</p>
     </Auk::Modal::Body>
     <Auk::Modal::Footer @onCancel={{this.onClick}}>
-      <Auk::Toolbar>
-        <Auk::Toolbar::Group @position="right">
-          <Auk::Toolbar::Item>
-            <Auk::Button @skin="danger-primary" @icon="delete">Verwijderen</Auk::Button>
-          </Auk::Toolbar::Item>
-        </Auk::Toolbar::Group>
-      </Auk::Toolbar>
+      <Auk::Button @skin="danger-primary" @icon="delete">Verwijderen</Auk::Button>
     </Auk::Modal::Footer>
   </Auk::Modal>
   {{!-- END-SNIPPET --}}


### PR DESCRIPTION
Aanpassingen zijn enkel op vlak van design/styling, niet functioneel.

Onder andere:
- Cancel-buttons (links gealigneerd) aanpassen naar het correcte type button (Auk::ButtonLink)
- Toolbar size `large` waar nodig toevoegen
- Verkeerde (geneste) structuur corrigeren

**Ticket binnen Jira:** https://kanselarij.atlassian.net/browse/KAS-2797