### PR TITLE
KAS-2764 error toast

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -6,42 +6,36 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
   @service intl;
   @service toaster;
 
-  MAX_AJAX_RETRIES = 5;
-
   // eslint-disable-next-line no-unused-vars
   async ajax(url, method) {
     try {
       if (['POST', 'DELETE'].includes(method)) { // methods that cause unwanted effects when executing a request multiple times
         return await super.ajax(...arguments);
       }
-      return await retryOnError(super.ajax.bind(this), arguments); // return-await of importance to be able to catch errors
+      return await this.retryOnError(super.ajax.bind(this), arguments); // return-await of importance to be able to catch errors
     } catch (error) {
       this.toaster.error(this.intl.t('couldnt-answer-net-req'));
       throw error;
     }
   }
 
-  // eslint-disable-next-line no-unused-vars
-  handleResponse(status, headers, payload, requestData) {
-    if (!this.isSuccess(status, headers, payload)) {
-      this.toaster.error(this.intl.t('invalid-net-req-answer'));
+  // from https://github.com/lblod/frontend-gelinkt-notuleren/blob/5d3c17e9c084e13ea8354c81bf378a27043d7e59/app/adapters/application.js
+  async retryOnError(ajax, ajaxArgs, maxRetries = 5, retryCount = 0) {
+    try {
+      return await ajax(...ajaxArgs);
+    } catch (error) {
+      if (retryCount === 0) { // Only warn on first-time occurence in order not to bug users with warnings on each retry.
+        this.toaster.warning(this.intl.t('invalid-net-req-answer'));
+      }
+      if (retryCount < maxRetries) {
+        await sleep(250 * (retryCount + 1));
+        return this.retryOnError(ajax, ajaxArgs, maxRetries, retryCount + 1);
+      }
+      throw error;
     }
-    return super.handleResponse(...arguments);
   }
 }
 
-// from https://github.com/lblod/frontend-gelinkt-notuleren/blob/5d3c17e9c084e13ea8354c81bf378a27043d7e59/app/adapters/application.js
-async function retryOnError(ajax, ajaxArgs, maxRetries = 5, retryCount = 0) {
-  try {
-    return await ajax(...ajaxArgs);
-  } catch (error) {
-    if (retryCount < maxRetries) {
-      await sleep(250 * (retryCount + 1));
-      return retryOnError(ajax, ajaxArgs, maxRetries, retryCount + 1);
-    }
-    throw error;
-  }
-}
 
 function sleep(time) {
   return new Promise((resolve) => later(this, () => resolve(true), time));

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -6,6 +6,8 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
   @service intl;
   @service toaster;
 
+  MAX_AJAX_RETRIES = 5;
+
   // eslint-disable-next-line no-unused-vars
   async ajax(url, method) {
     try {
@@ -29,15 +31,13 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
 }
 
 // from https://github.com/lblod/frontend-gelinkt-notuleren/blob/5d3c17e9c084e13ea8354c81bf378a27043d7e59/app/adapters/application.js
-async function retryOnError(ajax, ajaxArgs, retryCount = 0) {
-  const MAX_RETRIES = 5;
-
+async function retryOnError(ajax, ajaxArgs, maxRetries = 5, retryCount = 0) {
   try {
     return await ajax(...ajaxArgs);
   } catch (error) {
-    if (retryCount < MAX_RETRIES) {
+    if (retryCount < maxRetries) {
       await sleep(250 * (retryCount + 1));
-      return retryOnError(ajax, ajaxArgs, retryCount + 1);
+      return retryOnError(ajax, ajaxArgs, maxRetries, retryCount + 1);
     }
     throw error;
   }

--- a/app/services/toaster.js
+++ b/app/services/toaster.js
@@ -12,9 +12,9 @@ export default class ToasterService extends Service {
   @tracked toasts = A([]);
 
   // TODO: Below "newToasts" & "oldToasts" getters are a temporary to be able to render "old toasts" that
-  // don't have new design yet according to their old design, while already implementing new design for those types that support it.
+  // don't have an equivalent in new design yet, while already implementing new design for those types that support it.
   get newToasts() {
-    return this.toasts.filter((toast) => ['success', 'warning', 'error'].includes(toast.type));
+    return this.toasts.filter((toast) => ['success', 'warning', 'error'].includes(toast.options.type));
   }
 
   get oldToasts() {

--- a/app/services/toaster.js
+++ b/app/services/toaster.js
@@ -104,10 +104,8 @@ export default class ToasterService extends Service {
 
   @action
   clear(toast) {
-    if (toast) {
-      if (this.toasts.includes(toast)) {
-        this.toasts.removeObject(toast);
-      }
+    if (toast && this.toasts.includes(toast)) {
+      return this.toasts.removeObject(toast);
     }
     this.toasts.clear();
   }


### PR DESCRIPTION
Fixes 3 things:
- Only shows a warning toast for a failed request once, instead of on 3 retry-iterations
- property-path to the toast type, making the toasts that show up in new design show accordingly
- clearing one specific toast when clicking the "x" instead of closing them all