### PR TITLE
KAS-2900: Counter bij 'Documenten' heeft verkeerde styling (Publicaties tabs)

### DIFF
--- a/app/components/publications/publication/publication-navigation.hbs
+++ b/app/components/publications/publication/publication-navigation.hbs
@@ -5,20 +5,17 @@
     data-test-publication-nav-go-back />
   <Auk::Tab
     @route="publications.publication.case"
-    data-test-publication-nav-case>
+    data-test-publication-nav-case
+  >
     {{t "agendaitem-case"}}
   </Auk::Tab>
   {{#if @publicationFlow.case.subcases}}
     <Auk::Tab
       @route="publications.publication.documents"
+      @counter={{this.documentsCount}}
       data-test-publication-nav-documents
     >
-      <div class="auk-o-flex auk-o-flex--center">
-        <span class="auk-u-mr-2">{{t "documents"}}</span>
-        {{#unless this.loadData.isRunning}}
-          <p>({{this.documentsCount}})</p>
-        {{/unless}}
-      </div>
+      {{t "documents"}}
     </Auk::Tab>
   {{/if}}
   <Auk::Tab

--- a/app/components/publications/publication/publication-navigation.js
+++ b/app/components/publications/publication/publication-navigation.js
@@ -6,7 +6,7 @@ import { inject as service } from '@ember/service';
 export default class PublicationNavigation extends Component {
   @service store;
 
-  @tracked documentsCount = 0;
+  @tracked documentsCount = undefined;
 
   constructor() {
     super(...arguments);


### PR DESCRIPTION
**Ticket binnen Jira:** https://kanselarij.atlassian.net/browse/KAS-2900

@ValenberghsSven: Heel kort even, het weglaten van de `this.loadData.isRunning` check en het gebruik van `undefined` tracked `documentsCount` heeft hier hetzelfde resultaat vermoed ik? Er gaat nooit een counter zichtbaar zijn binnen de tab tot dat er effectief een value op `documentsCount` komt te staan?