### PR TITLE
KAS-2895: Bewerken knop bij Ministers en Beleidsvelden heeft verkeerde icoon & tekst is overbodig

### DIFF
--- a/app/components/mandatees/mandatees-domains-panel/mandatees-domains-panel-view.hbs
+++ b/app/components/mandatees/mandatees-domains-panel/mandatees-domains-panel-view.hbs
@@ -11,12 +11,11 @@
           <Auk::Toolbar::Item>
             <Auk::Button
               @skin="tertiary"
-              @icon="settings"
+              @icon="edit"
+              @layout="icon-only"
               data-test-mandatee-panel-view-edit={{true}}
               {{on "click" @onClickEdit}}
-            >
-              {{t "edit-2"}}
-            </Auk::Button>
+            />
           </Auk::Toolbar::Item>
         </Auk::Toolbar::Group>
       {{/if}}


### PR DESCRIPTION
**Ticket binnen Jira:** https://kanselarij.atlassian.net/browse/KAS-2895