### PR TITLE
KAS-2938: Kolomheaders fixeren (publicaties overzicht)

### DIFF
--- a/app/pods/publications/index/template.hbs
+++ b/app/pods/publications/index/template.hbs
@@ -60,7 +60,7 @@
   <div class="auk-scroll-wrapper__body">
     <div class="auk-u-m-4">
       {{#if this.model.length}}
-        <table data-test-route-publications-index-data-table class="auk-table">
+        <table data-test-route-publications-index-data-table class="auk-table auk-table--sticky-header">
           <thead>
             <tr>
               {{#each this.tableColumns as |column|}}

--- a/app/styles/au-kaleidos-css/_auk-additions.scss
+++ b/app/styles/au-kaleidos-css/_auk-additions.scss
@@ -124,6 +124,32 @@ p {
   }
 }
 
+/* Table with sticky header
+
+    Remark:
+    Fixing the border-related issue (as seen here: https://stackoverflow.com/questions/50361698/border-style-do-not-work-with-sticky-position-element) caused by putting `position: sticky` on th's is done here by switching border-collapse to `separate`.
+    We can use this switch without creating visual issues because there are no consecutive borders within the auk-table styling.
+
+    If this should change in the future, we could also rely on the following fix:
+
+    th {
+      border-bottom-width: 0;
+      padding-bottom: 1.4rem;
+      box-shadow: inset 0 -2px 0 $au-gray-300;
+    }
+
+   ========================================================================== */
+
+.auk-table--sticky-header {
+  border-collapse: separate;
+
+  th {
+    position: sticky;
+    top: 0;
+    background-color: #fff;
+  }
+}
+
 
 /* Block-link (to be removed in favor of list element)
    ========================================================================== */

--- a/app/styles/fixes/_fix-ember-data-table.scss
+++ b/app/styles/fixes/_fix-ember-data-table.scss
@@ -4,3 +4,8 @@
 .data-table__actions--top {
   border-bottom: none;
 }
+
+td,
+th {
+  border-radius: 0;
+}


### PR DESCRIPTION
**Ticket binnen Jira:** https://kanselarij.atlassian.net/browse/KAS-2938

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.