### PR TITLE
KAS-2663 signature folder first table

### DIFF
--- a/app/pods/signatures/index/controller.js
+++ b/app/pods/signatures/index/controller.js
@@ -1,0 +1,60 @@
+import Controller from '@ember/controller';
+import { action, set } from '@ember/object';
+import { inject as service } from '@ember/service';
+// import { tracked } from '@glimmer/tracking';
+
+export default class SignaturesIndexController extends Controller {
+  @service router;
+
+  queryParams = {
+    page: {
+      type: 'number',
+    },
+    size: {
+      type: 'number',
+    },
+    sort: {
+      type: 'string',
+    },
+  };
+  page = 0;
+  size = 10;
+  // sort = '-created';
+
+  @action
+  prevPage() {
+    if (this.page > 0) {
+      set(this, 'page', this.page - 1); // TODO: setter instead of @tracked on qp's before updating to Ember 3.22+ (https://github.com/emberjs/ember.js/issues/18715)
+    }
+  }
+
+  @action
+  nextPage() {
+    set(this, 'page', this.page + 1);  // TODO: setter instead of @tracked on qp's before updating to Ember 3.22+ (https://github.com/emberjs/ember.js/issues/18715)
+  }
+
+  @action
+  setSizeOption(size) {
+    // TODO: setters instead of @tracked on qp's before updating to Ember 3.22+ (https://github.com/emberjs/ember.js/issues/18715)
+    set(this, 'size', size);
+    set(this, 'page', 0);
+  }
+
+  @action
+  changeSorting(sort) {
+    // TODO: remove setter once "sort" is tracked
+    set(this, 'sort', sort);
+  }
+
+  @action
+  async navigateToDecision(treatment) {
+    const agendaitem = await this.store.queryOne('agendaitem', {
+      'filter[treatments][:id:]': treatment.get('id'),
+      'filter[:has-no:next-version]': 't',
+      sort: '-created',
+    });
+    const agenda = await agendaitem.get('agenda');
+    const meeting = await agenda.get('createdFor');
+    this.router.transitionTo('agenda.agendaitems.agendaitem.decisions', meeting.id, agenda.id, agendaitem.id);
+  }
+}

--- a/app/pods/signatures/index/controller.js
+++ b/app/pods/signatures/index/controller.js
@@ -1,7 +1,6 @@
 import Controller from '@ember/controller';
 import { action, set } from '@ember/object';
 import { inject as service } from '@ember/service';
-// import { tracked } from '@glimmer/tracking';
 
 export default class SignaturesIndexController extends Controller {
   @service router;
@@ -19,7 +18,6 @@ export default class SignaturesIndexController extends Controller {
   };
   page = 0;
   size = 10;
-  // sort = '-created';
 
   @action
   prevPage() {
@@ -30,7 +28,7 @@ export default class SignaturesIndexController extends Controller {
 
   @action
   nextPage() {
-    set(this, 'page', this.page + 1);  // TODO: setter instead of @tracked on qp's before updating to Ember 3.22+ (https://github.com/emberjs/ember.js/issues/18715)
+    set(this, 'page', this.page + 1); // TODO: setter instead of @tracked on qp's before updating to Ember 3.22+ (https://github.com/emberjs/ember.js/issues/18715)
   }
 
   @action
@@ -55,6 +53,11 @@ export default class SignaturesIndexController extends Controller {
     });
     const agenda = await agendaitem.get('agenda');
     const meeting = await agenda.get('createdFor');
-    this.router.transitionTo('agenda.agendaitems.agendaitem.decisions', meeting.id, agenda.id, agendaitem.id);
+    this.router.transitionTo(
+      'agenda.agendaitems.agendaitem.decisions',
+      meeting.id,
+      agenda.id,
+      agendaitem.id
+    );
   }
 }

--- a/app/pods/signatures/index/route.js
+++ b/app/pods/signatures/index/route.js
@@ -14,7 +14,7 @@ export default class SignaturesIndexRoute extends Route {
       refreshModel: true,
       as: 'sorteer',
     },
-  }
+  };
 
   model(params) {
     return this.store.query('sign-flow', {
@@ -27,7 +27,7 @@ export default class SignaturesIndexRoute extends Route {
         'creator',
         'sign-subcase.sign-marking-activity.piece',
         'sign-subcase.sign-marking-activity.piece.document-container.type',
-        'decision-activity'
+        'decision-activity',
       ].join(','),
     });
   }

--- a/app/pods/signatures/index/route.js
+++ b/app/pods/signatures/index/route.js
@@ -1,4 +1,34 @@
 import Route from '@ember/routing/route';
 
 export default class SignaturesIndexRoute extends Route {
+  queryParams = {
+    page: {
+      refreshModel: true,
+      as: 'pagina',
+    },
+    size: {
+      refreshModel: true,
+      as: 'aantal',
+    },
+    sort: {
+      refreshModel: true,
+      as: 'sorteer',
+    },
+  }
+
+  model(params) {
+    return this.store.query('sign-flow', {
+      sort: params.sort,
+      page: {
+        number: params.page,
+        size: params.size,
+      },
+      include: [
+        'creator',
+        'sign-subcase.sign-marking-activity.piece',
+        'sign-subcase.sign-marking-activity.piece.document-container.type',
+        'decision-activity'
+      ].join(','),
+    });
+  }
 }

--- a/app/pods/signatures/index/template.hbs
+++ b/app/pods/signatures/index/template.hbs
@@ -1,0 +1,150 @@
+<Auk::Navbar
+  class="auk-signature-overview-navbar"
+  @skin="gray-100"
+  @auto={{true}}
+>
+  <Auk::Toolbar>
+    <Auk::Toolbar::Group @position="left">
+      <Auk::Toolbar::Item>
+        <div class="auk-o-flex auk-o-flex--vertical">
+          <h4 class="auk-toolbar-complex__title">
+            {{t "signature-folder"}}
+          </h4>
+        </div>
+      </Auk::Toolbar::Item>
+    </Auk::Toolbar::Group>
+    <Auk::Toolbar::Group @position="right">
+      <Auk::Toolbar::Item>
+        {{! search here}}
+      </Auk::Toolbar::Item>
+      <Auk::Toolbar::Item>
+        {{!-- <Auk::Button
+          @skin="secondary"
+          @icon="filter"
+          {{on "click" this.showFilterModal}}
+        >
+          {{t "filter-content"}}
+        </Auk::Button> --}}
+      </Auk::Toolbar::Item>
+
+      <Auk::Toolbar::Item>
+        {{! bundle signature here}}
+      </Auk::Toolbar::Item>
+    </Auk::Toolbar::Group>
+  </Auk::Toolbar>
+</Auk::Navbar>
+
+<div class="auk-scroll-wrapper">
+  <div class="auk-scroll-wrapper__body">
+    <div class="auk-u-m-4">
+      {{#if this.model.length}}
+        <table class="auk-table">
+          <thead>
+            <tr>
+              <th class="auk-u-text-nowrap">{{t "document-name"}}</th>
+              <Utils::ThSortable
+                @label={{t "document-type"}}
+                @field="sign-subcase.sign-marking-activity.piece.document-container.type.label"
+                @currentSorting={{this.sort}}
+                @onChange={{this.changeSorting}}
+              />
+              <Utils::ThSortable
+                @label={{t "counselor"}}
+                @field="creator"
+                @currentSorting={{this.sort}}
+                @onChange={{this.changeSorting}}
+              />
+              <Utils::ThSortable
+                @label={{t "date-approved"}}
+                @field="decision-activity.start-date"
+                @currentSorting={{this.sort}}
+                @onChange={{this.changeSorting}}
+              />
+              <th>{{! Actions}}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{#each this.model as |signFlow|}}
+              <tr class="auk-table__row">
+                <td>{{signFlow.signSubcase.signMarkingActivity.piece.name}}</td>
+                <td>
+                  {{signFlow.signSubcase.signMarkingActivity.piece.documentContainer.type.label}}
+                </td>
+                <td>
+                  <Auk::Avatar @icon="user" @size="small">
+                    {{signFlow.creator.fullName}}
+                  </Auk::Avatar>
+                </td>
+                <td>
+                  {{moment-format
+                    signFlow.decisionActivity.startDate
+                    "DD-MM-YYYY"
+                  }}
+                </td>
+                <td>
+                  <WebComponents::AuButtonToolbar>
+                    <Auk::Button
+                      @skin="borderless"
+                      @layout="icon-only"
+                      @icon="book"
+                      @href={{signFlow.signSubcase.signMarkingActivity.piece.viewDocumentURL}}
+                      target="_blank"
+                    >
+                      {{t "read"}}
+                    </Auk::Button>
+                    <DropdownMenu @skin="borderless" @icon="more" as |Menu|>
+                      <Menu.Item
+                        {{on
+                          "click"
+                          (fn this.navigateToDecision signFlow.decisionActivity)
+                        }}
+                      >
+                        {{t "consult-agendaitem-decision"}}
+                      </Menu.Item>
+                    </DropdownMenu>
+                  </WebComponents::AuButtonToolbar>
+                </td>
+              </tr>
+            {{/each}}
+          </tbody>
+        </table>
+      {{else}}
+        <Auk::Panel>
+          <Auk::Panel::Body>
+            <Auk::EmptyState @message={{t "no-results-found"}} />
+          </Auk::Panel::Body>
+        </Auk::Panel>
+      {{/if}}
+    </div>
+  </div>
+</div>
+<div>
+  <hr />
+</div>
+<div class="auk-u-mx-4">
+  <Auk::Toolbar>
+    <Auk::Toolbar::Group @position="left">
+      <Auk::Toolbar::Item>
+        <Auk::Pagination
+          @page={{this.page}}
+          @size={{this.size}}
+          @nbOfItems={{this.model.length}}
+          @total={{this.model.meta.count}}
+          @onNextPage={{this.nextPage}}
+          @onPreviousPage={{this.prevPage}}
+        />
+      </Auk::Toolbar::Item>
+    </Auk::Toolbar::Group>
+    <Auk::Toolbar::Group @position="right">
+      <Auk::Toolbar::Item>
+        {{t "amount-showed"}}
+      </Auk::Toolbar::Item>
+      <Auk::Toolbar::Item>
+        <WebComponents::AuPageSize
+          @selectedSize={{this.size}}
+          @onChange={{this.setSizeOption}}
+        />
+      </Auk::Toolbar::Item>
+    </Auk::Toolbar::Group>
+  </Auk::Toolbar>
+</div>

--- a/app/styles/au-kaleidos-css/_auk-additions.scss
+++ b/app/styles/au-kaleidos-css/_auk-additions.scss
@@ -216,6 +216,15 @@ p {
   }
 }
 
+/* Signature overview navbar (to be removed)
+   ========================================================================== */
+
+.auk-signature-overview-navbar {
+  ul.auk-menu {
+    background-color: transparent !important;
+  }
+}
+
 
 /* Color badge - default color (to be removed)
    ========================================================================== */

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -930,5 +930,8 @@
   "validation-signature": "Validatie handtekening",
   "signature-needed": "Handtekening nodig?",
   "signature-not-possible": "Het is niet mogelijk om dit document te laten handtekenen.",
-  "unmarking-not-possible": "Dit document is reeds voorbereid om te laten tekenen en kan niet ongedaan gemaakt worden."
+  "unmarking-not-possible": "Dit document is reeds voorbereid om te laten tekenen en kan niet ongedaan gemaakt worden.",
+  "counselor": "Raadgever",
+  "date-approved": "Datum goedgekeurd",
+  "consult-agendaitem-decision": "Laatste agendering bekijken"
 }


### PR DESCRIPTION
Eerste tabel in de handteken map.
Om alle data te kunnen tonen moeten we heel veel gelinkte modellen ophalen.
Lokaal is het sorteren op sommige zaken traag (zoals type document).
Het werkt wel, maar zou performanter moeten kunnen.

Die data apart gaan loaden zou volgens mij niet werken omdat de traagheid niet komt van het data laden, maar eerder de complexiteit van die sortering
we sorteren op:
`signflow.signSubcase.signMarkingActivity.piece.documentContainer.type.label`