### PR TITLE
KAS-2973 enable search for model with more results than default page …

### DIFF
--- a/app/components/documents/batch-details/batch-editing-row.hbs
+++ b/app/components/documents/batch-details/batch-editing-row.hbs
@@ -9,7 +9,7 @@
     <Utils::ModelSelector
       @modelName="document-type"
       @allowClear={{true}}
-      @hideSearch={{true}}
+      @searchField="label"
       @propertyToShow="label"
       @sortField="priority"
       @readOnly={{this.isDisabled}}

--- a/app/components/documents/batch-details/document-details-row.hbs
+++ b/app/components/documents/batch-details/document-details-row.hbs
@@ -23,7 +23,7 @@
         data-test-document-details-row-type
         @modelName="document-type"
         @allowClear={{true}}
-        @hideSearch={{true}}
+        @searchField="label"
         @propertyToShow="label"
         @sortField="priority"
         @selectedItems={{@row.documentType}}

--- a/app/components/documents/document-preview/details-tab.hbs
+++ b/app/components/documents/document-preview/details-tab.hbs
@@ -16,7 +16,7 @@
         <Utils::ModelSelector
           @modelName="document-type"
           @allowClear={{true}}
-          @hideSearch={{true}}
+          @searchField="label"
           @propertyToShow="label"
           @sortField="priority"
           @selectedItems={{this.documentType}}


### PR DESCRIPTION
Niet alle document-types konden gekozen worden wegens default page-size van 20.
Om dit tegen te gaan is er normaal een search voorzien, maar die stond niet aan.
