### PR TITLE
KAS-3116: Incorrecte weergave button-link binnen Publicatiedetail pagina

### DIFF
--- a/app/components/auk/button-link.hbs
+++ b/app/components/auk/button-link.hbs
@@ -29,7 +29,7 @@
     disabled={{@disabled}}
     ...attributes
   >
-    <Auk::Button::InnerLayout @layout={{@layout}} @icon={{@icon}}>{{yield}}</Auk::Button::InnerLayout>
+    <Auk::Button::InnerLayout @layout={{@layout}} @icon={{@icon}} @size={{@size}}>{{yield}}</Auk::Button::InnerLayout>
     {{#if (has-block "floater")}}
       {{yield to="floater"}}
     {{/if}}

--- a/app/pods/publications/publication/template.hbs
+++ b/app/pods/publications/publication/template.hbs
@@ -6,7 +6,7 @@
     <Auk::Toolbar::Group @position="left">
       <Auk::Toolbar::Item>
         <div class="auk-o-flex auk-o-flex--vertical auk-u-mt-2">
-          <span class="auk-o-flex auk-o-flex--horizontal auk-o-flex--align-baseline auk-o-flex--spaced">
+          <span class="auk-o-flex auk-o-flex--horizontal auk-o-flex--vertical-center auk-o-flex--spaced">
              <span class="auk-overline auk-u-muted" data-test-route-publications-publication-header-number>
                 {{uppercase (t "publication-flow")}}
                 -


### PR DESCRIPTION
**Ticket binnen Jira:** https://kanselarij.atlassian.net/browse/KAS-3116

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.