### PR TITLE
Remove redundant route naming

### DIFF
--- a/app/pods/publications/overview/_base/controller.js
+++ b/app/pods/publications/overview/_base/controller.js
@@ -19,53 +19,16 @@ export default class PublicationsOverviewBaseController extends Controller {
 
   @tracked isLoadingModel = false;
 
-  constructor() {
-    super(...arguments);
-    this.initColumnsDisplayConfig();
-  }
-
-  initColumnsDisplayConfig() {
-    let columnsDisplayConfig = this.loadColumnsDisplayConfig();
-    if (!columnsDisplayConfig) {
-      columnsDisplayConfig = this.getDefaultColumnsDisplayConfig();
-    }
-    this.columnsDisplayConfig = columnsDisplayConfig;
-  }
-
-  get columnsDisplayConfigStorageKey() {
-    return `publications.overview.${this.routeName}/columnsDisplayConfig`;
-  }
-
   @action
   changeColumnsDisplayConfig(config) {
-    this.columnsDisplayConfig = config;
     this.saveColumnsDisplayConfig(this.columnsDisplayConfig);
+    this.columnsDisplayConfig = config;
   }
 
   @action
   resetColumnsDisplayConfig() {
-    this.columnsDisplayConfig = this.getDefaultColumnsDisplayConfig();
     this.saveColumnsDisplayConfig(this.columnsDisplayConfig);
-  }
-
-  loadColumnsDisplayConfig() {
-    const serializedColumnsDisplayConfig = localStorage.getItem(
-      this.columnsDisplayConfigStorageKey
-    );
-    if (serializedColumnsDisplayConfig) {
-      const columnsDisplayConfig = JSON.parse(serializedColumnsDisplayConfig);
-      return columnsDisplayConfig;
-    } else {
-      return null;
-    }
-  }
-
-  saveColumnsDisplayConfig(columnsDisplayConfig) {
-    const serializedColumnsDisplayConfig = JSON.stringify(columnsDisplayConfig);
-    localStorage.setItem(
-      this.columnsDisplayConfigStorageKey,
-      serializedColumnsDisplayConfig
-    );
+    this.columnsDisplayConfig = this.getDefaultColumnsDisplayConfig();
   }
 
   getDefaultColumnsDisplayConfig() {
@@ -76,6 +39,14 @@ export default class PublicationsOverviewBaseController extends Controller {
       columnsDisplayConfig[column.keyName] = isColumnShown;
     }
     return columnsDisplayConfig;
+  }
+
+  saveColumnsDisplayConfig(columnsDisplayConfig) {
+    const serializedColumnsDisplayConfig = JSON.stringify(columnsDisplayConfig);
+    localStorage.setItem(
+      this.columnsDisplayConfigStorageKey,
+      serializedColumnsDisplayConfig
+    );
   }
 
   @action

--- a/app/pods/publications/overview/_base/controller.js
+++ b/app/pods/publications/overview/_base/controller.js
@@ -7,9 +7,6 @@ export default class PublicationsOverviewBaseController extends Controller {
   /** @abstract @type {string[]} */
   @tracked defaultColumns = [];
 
-  /** @abstract @type {string} */
-  @tracked routeName = 'base';
-
   @tracked page = 0;
   @tracked size = 10;
   @tracked sort = '-created';

--- a/app/pods/publications/overview/_base/controller.js
+++ b/app/pods/publications/overview/_base/controller.js
@@ -24,8 +24,9 @@ export default class PublicationsOverviewBaseController extends Controller {
 
   @action
   resetColumnsDisplayConfig() {
-    this.saveColumnsDisplayConfig(this.columnsDisplayConfig);
-    this.columnsDisplayConfig = this.getDefaultColumnsDisplayConfig();
+    const defaultDisplayConfig = this.getDefaultColumnsDisplayConfig();
+    this.saveColumnsDisplayConfig(defaultDisplayConfig);
+    this.columnsDisplayConfig = defaultDisplayConfig;
   }
 
   getDefaultColumnsDisplayConfig() {

--- a/app/pods/publications/overview/_base/route.js
+++ b/app/pods/publications/overview/_base/route.js
@@ -82,7 +82,6 @@ export default class PublicationsOverviewBaseRoute extends Route {
   }
 
   loadColumnsDisplayConfig() {
-    console.log("loading display config for route in route", this.columnsDisplayConfigStorageKey);
     const serializedColumnsDisplayConfig = localStorage.getItem(
       this.columnsDisplayConfigStorageKey
     );

--- a/app/pods/publications/overview/_base/route.js
+++ b/app/pods/publications/overview/_base/route.js
@@ -67,4 +67,30 @@ export default class PublicationsOverviewBaseRoute extends Route {
       return true;
     }
   }
+
+  setupController(controller) {
+    controller.columnsDisplayConfigStorageKey = this.columnsDisplayConfigStorageKey;
+    let columnsDisplayConfig = this.loadColumnsDisplayConfig();
+    if (!columnsDisplayConfig) {
+      columnsDisplayConfig = controller.getDefaultColumnsDisplayConfig();
+    }
+    controller.columnsDisplayConfig = columnsDisplayConfig;
+  }
+
+  get columnsDisplayConfigStorageKey() {
+    return `${this.routeName}/columnsDisplayConfig`;
+  }
+
+  loadColumnsDisplayConfig() {
+    console.log("loading display config for route in route", this.columnsDisplayConfigStorageKey);
+    const serializedColumnsDisplayConfig = localStorage.getItem(
+      this.columnsDisplayConfigStorageKey
+    );
+    if (serializedColumnsDisplayConfig) {
+      const columnsDisplayConfig = JSON.parse(serializedColumnsDisplayConfig);
+      return columnsDisplayConfig;
+    } else {
+      return null;
+    }
+  }
 }

--- a/app/pods/publications/overview/all/controller.js
+++ b/app/pods/publications/overview/all/controller.js
@@ -10,5 +10,4 @@ const DEFAULT_COLUMNS = [
 
 export default class PublicationsOverviewAllController extends PublicationsOverviewBaseController {
   @tracked defaultColumns = DEFAULT_COLUMNS;
-  @tracked  routeName = 'all';
 }

--- a/app/pods/publications/overview/late/controller.js
+++ b/app/pods/publications/overview/late/controller.js
@@ -11,6 +11,5 @@ const DEFAULT_COLUMNS = [
 
 export default class PublicationsOverviewLateController extends PublicationsOverviewBaseController {
   @tracked defaultColumns = DEFAULT_COLUMNS;
-  @tracked routeName = 'late';
   @tracked sort = 'publication-subcase.due-date';
 }

--- a/app/pods/publications/overview/proof/controller.js
+++ b/app/pods/publications/overview/proof/controller.js
@@ -13,5 +13,4 @@ const DEFAULT_COLUMNS = [
 
 export default class PublicationsOverviewProofController extends PublicationsOverviewBaseController {
   @tracked defaultColumns = DEFAULT_COLUMNS;
-  @tracked routeName = 'proof';
 }

--- a/app/pods/publications/overview/proofread/controller.js
+++ b/app/pods/publications/overview/proofread/controller.js
@@ -14,5 +14,4 @@ const DEFAULT_COLUMNS = [
 
 export default class PublicationsOverviewProofreadController extends PublicationsOverviewBaseController {
   @tracked defaultColumns = DEFAULT_COLUMNS;
-  @tracked routeName = 'proofread';
 }

--- a/app/pods/publications/overview/translation/controller.js
+++ b/app/pods/publications/overview/translation/controller.js
@@ -13,5 +13,4 @@ const DEFAULT_COLUMNS = [
 
 export default class PublicationsOverviewTranslationController extends PublicationsOverviewBaseController {
   @tracked defaultColumns = DEFAULT_COLUMNS;
-  @tracked routeName = 'translation';
 }

--- a/app/pods/publications/overview/urgent/controller.js
+++ b/app/pods/publications/overview/urgent/controller.js
@@ -11,5 +11,4 @@ const DEFAULT_COLUMNS = [
 
 export default class PublicationsOverviewUrgentController extends PublicationsOverviewBaseController {
   @tracked defaultColumns = DEFAULT_COLUMNS;
-  @tracked routeName = 'urgent';
 }


### PR DESCRIPTION
In aanloop naar https://kanselarij.atlassian.net/browse/KAS-3125 wilde ik alvast de redundante benoeming van publicatie overzicht-routes eruit halen. Het verschuiven van een deel van de logica naar de route was hiervoor een requirement, die in het verder verloop van de story nog goed van pas zal komen.