### PR TITLE
KAS-3238 Make relation read-only on case side, reload case.subcase af…

### DIFF
--- a/app/components/cases/new-subcase.js
+++ b/app/components/cases/new-subcase.js
@@ -130,6 +130,8 @@ export default class CasesNewSubcase extends Component {
     }
     // We save here in order to set the belongsTo relation between submission-activity and subcase
     await subcase.save();
+    // reload the list of subcases on case, list is not updated automatically
+    await this.args.case.hasMany('subcases').reload();
 
     if (this.latestSubcase && fullCopy) {
       await this.copySubcaseSubmissions(subcase, piecesFromSubmissions);

--- a/app/models/case.js
+++ b/app/models/case.js
@@ -10,7 +10,10 @@ export default class CaseModel extends Model {
 
   @hasMany('publication-flow') publicationFlows;
   @hasMany('concept') governmentAreas;
-  @hasMany('subcase') subcases;
+  // This relation is saved on subcase and should be read-only here
+  @hasMany('subcase', {
+    serialize: false,
+  }) subcases;
   @hasMany('piece') pieces;
   @hasMany('sign-flow') signFlows;
 }


### PR DESCRIPTION
# HOTFIX

## :warning: Branch started from PROD

- Made relation one-way in case by defining `serialize:false`
- Reload the list of subcases on case after adding a new one

Mainly the change in case.js wil prevent further bugs, the reloading is just to keep the data in sync.

More improvements in follow up PR