### PR TITLE
Feature/kas 3242 translations/proofs/publication without request

### DIFF
--- a/app/pods/publications/publication/proofs/index/template.hbs
+++ b/app/pods/publications/publication/proofs/index/template.hbs
@@ -14,7 +14,6 @@
             <Auk::Button
               @skin="secondary"
               @icon="plus"
-              @disabled={{this.isProofUploadDisabled}}
               {{on "click" this.openProofUploadModal}}
             >
               {{t "upload-proof"}}

--- a/app/pods/publications/publication/translations/index/controller.js
+++ b/app/pods/publications/publication/translations/index/controller.js
@@ -17,10 +17,6 @@ export default class PublicationsPublicationTranslationsIndexController extends 
   @tracked showTranslationUploadModal = false;
   @tracked showTranslationRequestModal = false;
 
-  get isTranslationUploadDisabled() {
-    return this.latestTranslationActivity == null;
-  }
-
   get latestTranslationActivity() {
     const timelineActivity = this.model.find(
       (activity) => activity.isTranslationActivity
@@ -30,7 +26,23 @@ export default class PublicationsPublicationTranslationsIndexController extends 
 
   @task
   *saveTranslationUpload(translationUpload) {
-    const translationActivity = this.latestTranslationActivity;
+    let translationActivity = this.latestTranslationActivity;
+
+    if (!translationActivity) {
+      // Uploading translated documents without a request
+      const french = yield this.store.findRecordByUri(
+        'language',
+        CONSTANTS.LANGUAGES.FR
+      );
+      translationActivity = this.store.createRecord('translation-activity', {
+        startDate: new Date(),
+        subcase: this.translationSubcase,
+        language: french,
+      });
+    }
+
+    translationActivity.endDate = translationUpload.receivedDate;
+    yield translationActivity.save();
 
     const pieceSaves = [];
 
@@ -42,10 +54,6 @@ export default class PublicationsPublicationTranslationsIndexController extends 
       pieceSaves.push(piece.save());
     }
 
-    translationActivity.endDate = translationUpload.receivedDate;
-    const translationActivitySave = translationActivity.save();
-
-    let translationSubcaseSave;
     if (translationUpload.mustUpdatePublicationStatus) {
       yield this.publicationService.updatePublicationStatus(
         this.publicationFlow,
@@ -54,14 +62,10 @@ export default class PublicationsPublicationTranslationsIndexController extends 
       );
 
       this.translationSubcase.endDate = translationUpload.receivedDate;
-      translationSubcaseSave = this.translationSubcase.save();
+      yield this.translationSubcase.save();
     }
 
-    yield Promise.all([
-      translationActivitySave,
-      ...pieceSaves,
-      translationSubcaseSave,
-    ]);
+    yield Promise.all([...pieceSaves]);
 
     this.send('refresh');
     this.showTranslationUploadModal = false;

--- a/app/pods/publications/publication/translations/index/template.hbs
+++ b/app/pods/publications/publication/translations/index/template.hbs
@@ -34,7 +34,10 @@
       </Auk::Toolbar>
     </Auk::Panel::Header>
 
-    <Auk::Panel::Body class="auk-u-bg-alt">
+    <Auk::Panel::Body
+      data-test-route-publications---translations-panel-body
+      class="auk-u-bg-alt"
+    >
       {{#each @model as |event|}}
         {{#if event.isShown}}
           {{#if event.isRequestActivity}}

--- a/app/pods/publications/publication/translations/index/template.hbs
+++ b/app/pods/publications/publication/translations/index/template.hbs
@@ -15,7 +15,6 @@
               data-test-route-publications---translations-upload-translation
               @skin="secondary"
               @icon="plus"
-              @disabled={{this.isTranslationUploadDisabled}}
               {{on "click" this.openTranslationUploadModal}}
             >
               {{t "upload-translation"}}

--- a/cypress/integration/unit/publication-translations.spec.js
+++ b/cypress/integration/unit/publication-translations.spec.js
@@ -23,7 +23,6 @@ context('Publications translation tests', () => {
     const file = {
       folder: 'files', fileName: 'test', fileExtension: 'pdf',
     };
-    const emptyStateMessage = 'Er zijn nog geen vertalingen.';
     const numberOfPages = 5;
     const numberOfWords = 1000;
     const translationEndDate = Cypress.dayjs();
@@ -33,9 +32,11 @@ context('Publications translation tests', () => {
     cy.createPublication(fields);
     cy.get(publication.publicationNav.translations).click()
       .wait('@getTranslationsModel');
+    // Make sure the page transitioned
+    cy.url().should('contain', '/vertalingen');
     cy.get(publication.statusPill.contentLabel).should('contain', 'Opgestart');
-    // page may not have transitioned yet
-    cy.get(auk.emptyState.message).contains(emptyStateMessage);
+    // Check empty state message
+    cy.get(publication.translationsDocuments.panelBody).find(auk.emptyState.message);
 
     // check rollback after cancel request
     cy.get(publication.translationsDocuments.requestTranslation).click();
@@ -53,7 +54,7 @@ context('Publications translation tests', () => {
     cy.get(auk.modal.footer.cancel).click();
     cy.wait('@deleteFile');
     cy.get(auk.modal.container).should('not.exist');
-    cy.get(auk.emptyState.message).contains(emptyStateMessage);
+    cy.get(publication.translationsDocuments.panelBody).find(auk.emptyState.message);
 
     // new request
     cy.get(publication.translationsDocuments.requestTranslation).click();
@@ -97,7 +98,7 @@ context('Publications translation tests', () => {
       .wait('@deleteFiles')
       .wait('@deleteDocumentContainers')
       .wait('@deleteRequestActivities');
-    cy.get(auk.emptyState.message).contains(emptyStateMessage);
+    cy.get(publication.translationsDocuments.panelBody).find(auk.emptyState.message);
 
     // new request
     cy.get(publication.translationsDocuments.requestTranslation).click();

--- a/cypress/integration/unit/publication-translations.spec.js
+++ b/cypress/integration/unit/publication-translations.spec.js
@@ -35,7 +35,6 @@ context('Publications translation tests', () => {
       .wait('@getTranslationsModel');
     cy.get(publication.statusPill.contentLabel).should('contain', 'Opgestart');
     // page may not have transitioned yet
-    cy.get(publication.translationsDocuments.upload).should('be.disabled');
     cy.get(auk.emptyState.message).contains(emptyStateMessage);
 
     // check rollback after cancel request

--- a/cypress/selectors/publication.selectors.js
+++ b/cypress/selectors/publication.selectors.js
@@ -32,6 +32,7 @@ const selectors = {
   // publications\publication\translations\index\template
   // TODO KAS-3248 Rename to translationsIndex
   translationsDocuments: {
+    panelBody: '[data-test-route-publications---translations-panel-body]',
     upload: '[data-test-route-publications---translations-upload-translation]',
     requestTranslation: '[data-test-route-publications---translations-request-translation]',
   },


### PR DESCRIPTION
Ticket: https://kanselarij.atlassian.net/browse/KAS-3242

On routes translations/proofs/publications:
- Removed/changed the disabled button logic to be enabled without the need for a `"your type here"-activity` (normally created when making a request)
- Changed the upload method logic to create the necessary models when needed.
- Moved some saves around to avoid POST/PATCH on same model

Test locally in this order:
Test 1:
- Translation docs upload without request
- Proof docs upload without request
- Publication registration without request
- Translation request + translation docs upload (sorting looked ok, no change needed)
- Proof request from translation tab + proofs doc upload (sorting looked ok, no change needed)

**Note: It is possible to request a publication even though the registration has already happened. Should I disable the button in that case?**

Test 2:
- Proof docs upload without request
- Publication request from proof upload
- Publication registration


documentation updated:
https://github.com/kanselarij-vlaanderen/kaleidos-documentation/pull/4