### PR TITLE
KAS-3267 use action instead of task, use a less complex way to set th…

### DIFF
--- a/app/components/agenda/agendaitem/agendaitem-decision.hbs
+++ b/app/components/agenda/agendaitem/agendaitem-decision.hbs
@@ -38,8 +38,8 @@
         @piece={{this.report}}
         @hideNewerVersions={{true}}
         @onOpenUploadModal={{@onOpenUploadModal}}
-        @onAddPiece={{perform this.attachNewReportVersion}}
-        @didDeletePiece={{perform this.attachPreviousReportVersion}}
+        @onAddPiece={{this.attachNewReportVersion}}
+        @didDeletePiece={{this.attachPreviousReportVersion}}
         @didDeleteContainer={{perform this.loadReport}}
       />
     {{else}}

--- a/app/components/agenda/agendaitem/agendaitem-decision.js
+++ b/app/components/agenda/agendaitem/agendaitem-decision.js
@@ -84,6 +84,10 @@ export default class AgendaitemDecisionComponent extends Component {
     await piece.save();
     this.args.treatment.report = piece;
     await this.args.treatment.save();
+    // This reload is a workaround for file-service "deleteDocumentContainer" having a stale list of pieces
+    // when deleting the full container right after adding a new report version without the version history open.
+    const documentContainer = await piece.documentContainer;
+    await documentContainer.hasMany('pieces').reload();
     await this.loadReport.perform();
   }
 

--- a/app/components/agenda/agendaitem/agendaitem-decision.js
+++ b/app/components/agenda/agendaitem/agendaitem-decision.js
@@ -81,7 +81,6 @@ export default class AgendaitemDecisionComponent extends Component {
 
   @action
   async attachNewReportVersion(piece) {
-    await piece.previousPiece;
     await piece.save();
     this.args.treatment.set('report', piece);
     await this.args.treatment.save();

--- a/app/components/agenda/agendaitem/agendaitem-decision.js
+++ b/app/components/agenda/agendaitem/agendaitem-decision.js
@@ -3,7 +3,6 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency-decorators';
-import { sortPieces } from 'frontend-kaleidos/utils/documents';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 
 export default class AgendaitemDecisionComponent extends Component {
@@ -11,6 +10,7 @@ export default class AgendaitemDecisionComponent extends Component {
   @service store;
 
   @tracked report;
+  @tracked previousReport;
 
   @tracked isEditing = false;
   @tracked isVerifyingDelete = null;
@@ -56,6 +56,7 @@ export default class AgendaitemDecisionComponent extends Component {
   @task
   *loadReport() {
     this.report = yield this.args.treatment.report;
+    this.previousReport = yield this.report?.previousPiece;
   }
 
   @action
@@ -73,31 +74,34 @@ export default class AgendaitemDecisionComponent extends Component {
     });
     await piece.save();
     this.args.treatment.set('report', piece);
-    this.args.treatment.save();
+    await this.args.treatment.save();
     this.isAddingReport = false;
     await this.loadReport.perform();
   }
 
-  @task
-  *attachNewReportVersion(piece) {
-    yield piece.save();
+  @action
+  async attachNewReportVersion(piece) {
+    await piece.previousPiece;
+    await piece.save();
     this.args.treatment.set('report', piece);
-    yield this.args.treatment.save();
-    yield this.loadReport.perform();
+    await this.args.treatment.save();
+    await this.loadReport.perform();
   }
 
-  @task
-  *attachPreviousReportVersion(piece) {
-    // TODO: Assess if we need to go over container. `previousVersion` (if existant) might suffice?
-    const container = yield piece.documentContainer;
-    let remainingVersions = yield container.pieces;
-    if (remainingVersions.length) {
-      remainingVersions = remainingVersions.toArray();
-      const sortedPieces = sortPieces(remainingVersions);
-      this.args.treatment.set('report', sortedPieces[0]);
-      yield this.args.treatment.save();
+  @action
+  // eslint-disable-next-line no-unused-vars
+  async attachPreviousReportVersion(piece) {
+    /*
+      the deleted piece comes in from params, but not used here because we tracked the previous version.
+      Note: this used to be a task but something kept going wrong.
+      Trying to get piece.documentContainer after piece was destroyed kept failing after an ember upgrade:
+      "Cannot create a new tag for '<(unknown):ember890>' after it has been destroyed"
+    */
+    if (this.previousReport) {
+      this.args.treatment.set('report', this.previousReport);
+      await this.args.treatment.save();
     } // else no previous version available. Treatment no longer has a report
-    yield this.loadReport.perform();
+    await this.loadReport.perform();
   }
 
   @action

--- a/app/components/agenda/agendaitem/agendaitem-decision.js
+++ b/app/components/agenda/agendaitem/agendaitem-decision.js
@@ -73,7 +73,7 @@ export default class AgendaitemDecisionComponent extends Component {
       documentContainer,
     });
     await piece.save();
-    this.args.treatment.set('report', piece);
+    this.args.treatment.report = piece;
     await this.args.treatment.save();
     this.isAddingReport = false;
     await this.loadReport.perform();
@@ -82,7 +82,7 @@ export default class AgendaitemDecisionComponent extends Component {
   @action
   async attachNewReportVersion(piece) {
     await piece.save();
-    this.args.treatment.set('report', piece);
+    this.args.treatment.report = piece;
     await this.args.treatment.save();
     await this.loadReport.perform();
   }
@@ -97,7 +97,7 @@ export default class AgendaitemDecisionComponent extends Component {
       "Cannot create a new tag for '<(unknown):ember890>' after it has been destroyed"
     */
     if (this.previousReport) {
-      this.args.treatment.set('report', this.previousReport);
+      this.args.treatment.report = this.previousReport;
       await this.args.treatment.save();
     } // else no previous version available. Treatment no longer has a report
     await this.loadReport.perform();

--- a/app/components/web-components/vl-document.js
+++ b/app/components/web-components/vl-document.js
@@ -64,7 +64,7 @@ export default class VlDocument extends Component {
     await this.fileService.get('deletePieceWithUndo').perform(this.piece);
     // when cancelled, the aboutToDelete flag will be false
     if (this.args.didDeletePiece && this.piece.aboutToDelete) {
-      this.args.didDeletePiece(this.piece);
+      await this.args.didDeletePiece(this.piece);
     }
     // TODO delete orphan container if last piece is deleted
   }

--- a/app/services/file-service.js
+++ b/app/services/file-service.js
@@ -31,7 +31,7 @@ export default Service.extend({
   deletePieceWithUndo: task(function *(pieceToDelete) {
     this.objectsToDelete.push(pieceToDelete);
     pieceToDelete.set('aboutToDelete', true);
-    yield timeout(15000);
+    yield timeout(100);
     if (this.findObjectToDelete(pieceToDelete.get('id'))) {
       yield this.deletePiece(pieceToDelete);
     } else {

--- a/app/services/file-service.js
+++ b/app/services/file-service.js
@@ -31,7 +31,7 @@ export default Service.extend({
   deletePieceWithUndo: task(function *(pieceToDelete) {
     this.objectsToDelete.push(pieceToDelete);
     pieceToDelete.set('aboutToDelete', true);
-    yield timeout(100);
+    yield timeout(15000);
     if (this.findObjectToDelete(pieceToDelete.get('id'))) {
       yield this.deletePiece(pieceToDelete);
     } else {

--- a/cypress/integration/unit/decision.spec.js
+++ b/cypress/integration/unit/decision.spec.js
@@ -79,14 +79,14 @@ context('Decision tests', () => {
     cy.get('@docCards').should('have.length', 1);
 
     // TODO-command addNewPieceToTreatment
-    cy.addNewPieceToSignedDocumentContainer('test', {
+    cy.addNewPieceToDecision('test', {
       folder: 'files', fileName: 'test', fileExtension: 'pdf',
     });
     cy.get(document.documentCard.name.value).eq(0)
       .contains(/BIS/);
 
     // Delete the TER piece, the BIS should then become the report
-    cy.addNewPieceToSignedDocumentContainer('test', {
+    cy.addNewPieceToDecision('test', {
       folder: 'files', fileName: 'test', fileExtension: 'pdf',
     });
     cy.get('@docCards').should('have.length', 1);

--- a/cypress/integration/unit/decision.spec.js
+++ b/cypress/integration/unit/decision.spec.js
@@ -133,6 +133,7 @@ context('Decision tests', () => {
       timeout: 20000,
     });
 
+    cy.get(agenda.agendaitemDecision.uploadFile);
     cy.get(document.documentCard.card).should('have.length', 0);
   });
 

--- a/cypress/integration/unit/file-upload.spec.js
+++ b/cypress/integration/unit/file-upload.spec.js
@@ -166,6 +166,7 @@ context('Add files to an agenda', () => { // At the meeting-level
         cy.get(document.documentCard.versionHistory)
           .find(auk.accordion.header.button)
           .click();
+        cy.get(document.vlDocument.showPieceViewer); // this line fixes flakyness since the delete button is showing while still loading data
         cy.get(document.vlDocument.piece).should('have.length', 1);
         cy.get(document.vlDocument.delete).click(); // no eq(0) needed when this is the only vl-document
       });

--- a/cypress/support/commands/document-commands.js
+++ b/cypress/support/commands/document-commands.js
@@ -412,15 +412,15 @@ function uploadUsersFile(folder, fileName, extension) {
 }
 
 /**
- * @description Opens the new piece dialog and adds the file when it is a signed document.
- * @name addNewPieceToSignedDocumentContainer
+ * @description Add a new piece to a decision.
+ * @name addNewPieceToDecision
  * @memberOf Cypress.Chainable#
  * @function
  * @param {String} oldFileName - The relative path to the file in the cypress/fixtures folder excluding the fileName
  * @param {String} file - The name of the file without the extension
  */
-function addNewPieceToSignedDocumentContainer(oldFileName, file) {
-  cy.log('addNewPieceToSignedDocumentContainer');
+function addNewPieceToDecision(oldFileName, file) {
+  cy.log('addNewPieceToDecision');
   const randomInt = Math.floor(Math.random() * Math.floor(10000));
   cy.intercept('POST', 'pieces').as(`createNewPiece_${randomInt}`);
 
@@ -443,7 +443,8 @@ function addNewPieceToSignedDocumentContainer(oldFileName, file) {
     })
       .wait(`@createNewPiece_${randomInt}`);
   });
-  cy.log('/addNewPieceToSignedDocumentContainer');
+  cy.wait(2500); // need to wait for model reload
+  cy.log('/addNewPieceToDecision');
 }
 
 /**
@@ -553,7 +554,7 @@ Cypress.Commands.add('addNewPieceToMeeting', addNewPieceToMeeting);
 Cypress.Commands.add('addNewPieceToAgendaitem', addNewPieceToAgendaitem);
 Cypress.Commands.add('addNewPieceToApprovalItem', addNewPieceToApprovalItem);
 Cypress.Commands.add('addNewPieceToSubcase', addNewPieceToSubcase);
-Cypress.Commands.add('addNewPieceToSignedDocumentContainer', addNewPieceToSignedDocumentContainer);
+Cypress.Commands.add('addNewPieceToDecision', addNewPieceToDecision);
 Cypress.Commands.add('uploadFile', uploadFile);
 Cypress.Commands.add('uploadUsersFile', uploadUsersFile);
 Cypress.Commands.add('openAgendaitemDocumentTab', openAgendaitemDocumentTab);


### PR DESCRIPTION
Quick write-up, will go into details later.

Assuming ember upgrade did something different when working with deleted models.
Also assuming the reason it still works for agendaitem pieces restore is that it's an `@action` and not a `@task` because we do something very similar there and it still works (for now?)

New way of preparing to restore the previous version on delete is to load the previous report.
When actually deleting, we no longer have to use the deleted piece to fetch relations to previousPiece or documentContainer.
We use the previous version that we fetched earlier.
