### PR TITLE
Cancelling publication documents upload was not working properly

### DIFF
--- a/app/components/publications/publication/proofs/proof-request-modal.js
+++ b/app/components/publications/publication/proofs/proof-request-modal.js
@@ -148,8 +148,8 @@ export default class PublicationsPublicationProofsProofRequestModalComponent ext
 
   @task
   *deleteUploadedPiece(piece) {
-    this.uploadedPieces.removeObject(piece);
     yield this.publicationService.deletePiece(piece);
+    this.uploadedPieces.removeObject(piece);
   }
 
   @action

--- a/app/components/publications/publication/proofs/proof-upload-modal.js
+++ b/app/components/publications/publication/proofs/proof-upload-modal.js
@@ -73,7 +73,7 @@ export default class PublicationsPublicationProofsProofUploadModalComponent exte
 
   @task
   *deleteUploadedPiece(piece) {
-    this.uploadedPieces.removeObject(piece);
     yield this.publicationService.deletePiece(piece);
+    this.uploadedPieces.removeObject(piece);
   }
 }

--- a/app/components/publications/publication/publication-activities/publication-request-modal.js
+++ b/app/components/publications/publication/publication-activities/publication-request-modal.js
@@ -137,8 +137,8 @@ export default class PublicationsPublicationPublicationActivitiesPublicationRequ
 
   @task
   *deleteUploadedPiece(piece) {
-    this.uploadedPieces.removeObject(piece);
     yield this.publicationService.deletePiece(piece);
+    this.uploadedPieces.removeObject(piece);
   }
 
   @action

--- a/app/components/publications/publication/translations/translation-request-modal.js
+++ b/app/components/publications/publication/translations/translation-request-modal.js
@@ -105,9 +105,9 @@ export default class PublicationsTranslationRequestModalComponent extends Compon
 
   @task
   *deleteUploadedPiece(piece) {
+    yield this.publicationService.deletePiece(piece);
     this.uploadedPieces.removeObject(piece);
     this.setEmailFields.perform();
-    yield this.publicationService.deletePiece(piece);
   }
 
   initValidators() {

--- a/app/components/publications/publication/translations/translation-upload-modal.js
+++ b/app/components/publications/publication/translations/translation-upload-modal.js
@@ -67,7 +67,7 @@ export default class PublicationsTranslationTranslationUploadModalComponent exte
 
   @task
   *deleteUploadedPiece(piece) {
-    this.uploadedPieces.removeObject(piece);
     yield this.publicationService.deletePiece(piece);
+    this.uploadedPieces.removeObject(piece);
   }
 }

--- a/app/services/publication-service.js
+++ b/app/services/publication-service.js
@@ -380,10 +380,8 @@ export default class PublicationService extends Service {
   async deletePiece(piece) {
     const file = await piece.file;
     const documentContainer = await piece.documentContainer;
-    await Promise.all([
-      piece.destroyRecord(),
-      file.destroyRecord(),
-      documentContainer.destroyRecord(),
-    ]);
+    await file.destroyRecord();
+    await documentContainer.destroyRecord();
+    await piece.destroyRecord();
   }
 }


### PR DESCRIPTION
Discovered in PR#1257 that the deletion of documents(file/container/piece) was not happening correctly in publication flow views.

One of the reasons was the approach in the separate components.
the `this.uploadedPieces.removeObject(piece);` was happening too fast, the list we were mapping changed during operation.
f.e. when you uploaded 5 documents and cancelled, we only hit the `deleteUploadedPiece` task twice instead of 5 times.
Fixed that by moving the `removeObject` after the actual deletes.

Even with this fix, sometimes large amounts of documents would fail on cancelling.
Deletes to piece were failing.
Didn't dug too deep into it. Suspecting that the random order of deletes due to the promise.all was causing issues.
From experience in this project, the correct order to delete the models is:
1. file
2. document-container
3. piece


Manually tested every publication modal that I changed with 10+ documents, deleting single ones with the trash icon in the modal and cancelling. No more errors occurred.
I did see that there is a time when all documents are uploaded but not loaded in the view. So you could technically hit save with only 3 out of 10 properly saved. Tested hitting cancel once and not every document got deleted. 
out of scope since this is partially caused by user behavior, not really a bug.