### PR TITLE
KAS-3286 Opladen van extra bestanden onder 'Besluiten' tab voor publicaties via MR

### DIFF
--- a/app/components/publications/documents/document-list-steps.hbs
+++ b/app/components/publications/documents/document-list-steps.hbs
@@ -11,7 +11,10 @@
     <div>
       <Publications::Documents::DocumentCardStep
         @piece={{piece}}
-        @isEnabledDelete={{@isEnabledDeletePiece}}
+        @isEnabledDelete={{or
+          (not @isViaCouncilOfMinisters)
+          (and @isViaCouncilOfMinisters (not piece.accessLevel))
+        }}
         @onDelete={{fn @onDeletePiece piece}}
       />
     </div>

--- a/app/pods/publications/publication/decisions/index/template.hbs
+++ b/app/pods/publications/publication/decisions/index/template.hbs
@@ -9,24 +9,22 @@
         </Group.Item>
       </Toolbar.Group>
       <Toolbar.Group @position="right" as |Group|>
-        {{#unless this.isViaCouncilOfMinisters}}
-          <Group.Item>
-            <Auk::Button
-              @skin="primary"
-              @icon="plus"
-              {{on "click" this.openReferenceDocumentUploadModal}}
-            >
-              {{t "document-add"}}
-            </Auk::Button>
-          </Group.Item>
-        {{/unless}}
+        <Group.Item>
+          <Auk::Button
+            @skin="primary"
+            @icon="plus"
+            {{on "click" this.openReferenceDocumentUploadModal}}
+          >
+            {{t "document-add"}}
+          </Auk::Button>
+        </Group.Item>
       </Toolbar.Group>
     </Auk::Toolbar>
   </Auk::Panel::Header>
   <Auk::Panel::Body class="auk-u-bg-alt">
     <Publications::Documents::DocumentListSteps
       @pieces={{this.model}}
-      @isEnabledDeletePiece={{not this.isViaCouncilOfMinisters}}
+      @isViaCouncilOfMinisters={{this.isViaCouncilOfMinisters}}
       @onDeletePiece={{perform this.deletePiece}}
     />
   </Auk::Panel::Body>


### PR DESCRIPTION
Allow uploads of extra pieces to publications via MR

Only enable delete of pieces via MR if they don't have an access-level
relation.