### PR TITLE
KAS-3291 status-change read-only, persist the inverse belongsTo

### DIFF
--- a/app/components/publications/editable-publication-status-pill.js
+++ b/app/components/publications/editable-publication-status-pill.js
@@ -131,20 +131,20 @@ export default class PublicationStatusPill extends Component {
       this.decision = undefined;
     }
 
-    // update status-change activity
-    const oldChangeActivity = yield this.args.publicationFlow
-      .publicationStatusChange;
-    if (oldChangeActivity) {
-      yield oldChangeActivity.destroyRecord();
-    }
-    const newChangeActivity = this.store.createRecord(
+    // update publication-status-change
+    // reload the relation for possible concurrency
+    const currentStatusChange = yield this.args.publicationFlow
+      .belongsTo('publicationStatusChange')
+      .reload();
+    yield currentStatusChange?.destroyRecord();
+    const newStatusChange = this.store.createRecord(
       'publication-status-change',
       {
         startedAt: date,
         publication: this.args.publicationFlow,
       }
     );
-    yield newChangeActivity.save();
+    yield newStatusChange.save();
 
     yield this.args.publicationFlow.save();
     this.loadStatus.perform();

--- a/app/models/publication-flow.js
+++ b/app/models/publication-flow.js
@@ -20,7 +20,11 @@ export default class PublicationFlow extends Model {
   @belongsTo('publication-mode') mode;
   @belongsTo('regulation-type') regulationType;
   @belongsTo('urgency-level') urgencyLevel;
-  @belongsTo('publication-status-change') publicationStatusChange;
+  // This relation is read-only for concurrency reasons, the linked model is deleted/replaced often
+  // Allowing this relation to serialize with a deleted model results in errors
+  @belongsTo('publication-status-change', {
+    serialize: false,
+  }) publicationStatusChange;
   @belongsTo('publication-subcase') publicationSubcase;
   @belongsTo('translation-subcase') translationSubcase;
   @belongsTo('agenda-item-treatment') agendaItemTreatment;

--- a/app/services/publication-service.js
+++ b/app/services/publication-service.js
@@ -115,17 +115,12 @@ export default class PublicationService extends Service {
     });
     await identifier.save();
 
-    const statusChange = this.store.createRecord('publication-status-change', {
-      startedAt: now,
-    });
-    await statusChange.save();
     const publicationFlow = this.store.createRecord('publication-flow', {
       identification: identifier,
       case: case_,
       agendaItemTreatment: agendaItemTreatment,
       mandatees: mandatees,
       status: initialStatus,
-      publicationStatusChange: statusChange,
       shortTitle: publicationProperties.shortTitle,
       longTitle: publicationProperties.longTitle,
       created: now,
@@ -134,6 +129,13 @@ export default class PublicationService extends Service {
       regulationType: regulationType,
     });
     await publicationFlow.save();
+
+    const statusChange = this.store.createRecord('publication-status-change', {
+      startedAt: now,
+      publication: publicationFlow,
+    });
+    await statusChange.save();
+
     const translationSubcase = this.store.createRecord('translation-subcase', {
       created: now,
       modified: now,
@@ -212,18 +214,19 @@ export default class PublicationService extends Service {
     // already is deleted (by step below)
     await publicationFlow.save();
 
-    const oldChangeActivity = await publicationFlow.publicationStatusChange;
-    if (oldChangeActivity) {
-      await oldChangeActivity.destroyRecord();
-    }
-    const newChangeActivity = this.store.createRecord(
+    // reload the relation for possible concurrency
+    const currentStatusChange = await publicationFlow
+      .belongsTo('publicationStatusChange')
+      .reload();
+    await currentStatusChange?.destroyRecord();
+    const newStatusChange = this.store.createRecord(
       'publication-status-change',
       {
         startedAt: changeDate,
         publication: publicationFlow,
       }
     );
-    await newChangeActivity.save();
+    await newStatusChange.save();
   }
 
   /**
@@ -388,8 +391,8 @@ export default class PublicationService extends Service {
   /**
    * For publications, we want to show a link to the agendaitem but loading the models agendaitem/agenda/meeting should be avoided.
    * Mainly because some of the relations should be loaded a certain way and we just want to generate a link, not work with the models.
-   * 
-   * @param {AgendaItemTreatment} agendaItemTreatment 
+   *
+   * @param {AgendaItemTreatment} agendaItemTreatment
    * @returns [meetingId, agendaId, agendaitemId] an array of id's for a linkTo to route "agenda.agendaitems.agendaitem"
    */
   async getModelsForAgendaitemFromTreatment(agendaItemTreatment) {


### PR DESCRIPTION
[Jira ticket](https://kanselarij.atlassian.net/browse/KAS-3291)

- Set the relation between publicatie-flow and publication-status-change only one-way while still allowing read access
- When replacing the current status change we need to reload the relation, to ensure we are trying to delete an existing status-change since the current one could have gone stale.