### PR TITLE
KAS-3275 Resetting default publication page size to 25

### DIFF
--- a/app/pods/publications/overview/_base/controller.js
+++ b/app/pods/publications/overview/_base/controller.js
@@ -4,7 +4,7 @@ import { tracked } from '@glimmer/tracking';
 
 export default class PublicationsOverviewBaseController extends Controller {
   @tracked page = 0;
-  @tracked size = 50;
+  @tracked size = 25;
   @tracked sort = '-created';
 
   @tracked tableConfig;

--- a/cypress/integration/unit/publication-overview.spec.js
+++ b/cypress/integration/unit/publication-overview.spec.js
@@ -51,7 +51,7 @@ context('Publications overview tests', () => {
   it('should test all the result amount options shown options in overview', () => {
     const elementsToCheck = [
       10,
-      25,
+      50,
       100,
       200
     ];


### PR DESCRIPTION
Default page size 50 takes too long to be workable. It's a lot faster to
load 2 pages of size 25 instead of loading 1 page of size 50.