### PR TITLE
KAS-3256 check for publication-flow before allowing delete case

### DIFF
--- a/app/components/subcases/subcase-header.js
+++ b/app/components/subcases/subcase-header.js
@@ -188,13 +188,19 @@ export default Component.extend({
       this.set('isAssigningToOtherCase', false);
 
       const subCases = await oldCase.hasMany('subcases').reload();
-      if (subCases.length > 0) {
-        this.router.transitionTo('cases.case.subcases');
-        this.onMoveSubcase();
-      } else {
-        this.set('caseToDelete', oldCase);
-        this.triggerDeleteCaseDialog();
+      if (subCases.length === 0) {
+        const publicationFlow = await this.store.queryOne('publication-flow', {
+          'filter[case][:id:]': oldCase.id,
+        });
+        // TODO KAS-3315 The deletion of case is only possible in this situation
+        if (!publicationFlow) {
+          this.set('caseToDelete', oldCase);
+          this.triggerDeleteCaseDialog();
+          return;
+        }
       }
+      this.router.transitionTo('cases.case.subcases');
+      this.onMoveSubcase();
     },
 
     cancelDeleteCase() {


### PR DESCRIPTION
[Jira ticket](https://kanselarij.atlassian.net/browse/KAS-3256)

Done: check publication-flow existence before allowing delete of case
Not done: Octane refactor (defined in follow up ticket) to keep this PR small. Deleting cases can break publications

## What has changed:

subcase-header.js:
- Query for publication-flow
- Delete case only possible when there is no publication-flow
- reversed IF logic to avoid duplicating `transitionTo` & `onMoveSubcase`