### PR TITLE
KAS-3300: Publicaties overzicht: instellingen knop (onderaan tabel) wordt verkeerd weergegeven

### DIFF
--- a/app/components/publications/overview/publications-table.hbs
+++ b/app/components/publications/overview/publications-table.hbs
@@ -100,6 +100,7 @@
           data-test-route-publications-index-config-modal-icon
           @icon="gear"
           @skin="borderless"
+          @layout="icon-only"
           {{on "click" this.toggleColumnsDisplayConfigPanel}}
         />
         <AttachPopover


### PR DESCRIPTION
**Ticket binnen Jira:** https://kanselarij.atlassian.net/browse/KAS-3300