### PR TITLE
KAS-3316 possible improvement in case suggestion is duplicate

### DIFF
--- a/app/components/publications/new-publication-modal.js
+++ b/app/components/publications/new-publication-modal.js
@@ -85,7 +85,11 @@ export default class NewPublicationModal extends Component {
       const identification = yield latestPublication.identification;
       const structuredIdentifier = yield identification.structuredIdentifier;
       this.number = structuredIdentifier.localIdentifier + 1;
+      // Validate in case the suggested number already exists to double down on avoiding duplication
+      // Sort may fail if data types are mixed string/integer, validation check is more strict
+      yield this.validateIsPublicationNumberAlreadyTaken.perform();
     } else {
+      // empty data only
       this.number = 1;
     }
   }


### PR DESCRIPTION
# :warning: started from acceptance

Unsure if this a desired addition to the code.
The suggested next publication number was duplicate because of mixed data types in our database for the sortfield.
Resulting in type integer being sorted on top, then strings and return a wrong number as a result.
We aim to fix the data types, but would it be a good idea to just validate the number we received?
The validation query checks the number+suffix, this should always be a string.