### PR TITLE
KAS-3222 Fix info about published decision

### DIFF
--- a/app/components/publications/publication/publication-activities/publication-registered-panel.hbs
+++ b/app/components/publications/publication/publication-activities/publication-registered-panel.hbs
@@ -34,27 +34,21 @@
   <Auk::Panel::Body>
     <Auk::List>
       {{#each this.decisions as |decision|}}
-        <div class="auk-o-flex auk-o-flex--spaced-wide">
-          <Auk::List::Item class="auk-o-flex auk-o-flex--spaced-wide">
-            <div class="auk-o-flex auk-o-flex--spaced">
-              <Auk::Badge @icon="document" @size="regular" />
-              {{#if decision.title}}
-                <h5 class="auk-h4 auk-u-m-0">{{decision.title}}</h5>
-              {{/if}}
-              <div class="auk-u-text-muted auk-u-italic">
-                {{moment-format decision.publicationDate "DD-MM-YYYY"}}
-              </div>
-            </div>
-            {{#if decision.isStaatsbladResource}}
-              <Auk::ButtonLink
-                @href={{decision.uri}}
-                @layout="icon-only"
-                @icon="external-link"
-                @target="_blank"
-              />
-            {{/if}}
-          </Auk::List::Item>
-        </div>
+        <Auk::List::Item class="auk-o-flex auk-o-flex--spaced-wide">
+          <Auk::Badge @icon="document" @size="regular" />
+          <h5 class="auk-u-m-0">
+            {{t "published-in-belgian-official-gazette-on"}}
+            {{moment-format decision.publicationDate "DD-MM-YYYY"}}
+          </h5>
+          {{#if decision.isStaatsbladResource}}
+            <Auk::ButtonLink
+              @href={{decision.uri}}
+              @layout="icon-only"
+              @icon="external-link"
+              target="_blank"
+            />
+          {{/if}}
+        </Auk::List::Item>
       {{/each}}
     </Auk::List>
   </Auk::Panel::Body>

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -981,6 +981,7 @@
   "regulation-type": "Type regelgeving",
   "proofprint-corrector": "Drukproef verbeteraar",
   "belgian-official-gazette": "Belgisch Staatsblad",
+  "published-in-belgian-official-gazette-on": "Gepubliceerd in Belgisch Staatsblad op",
   "publication-empty": "Er is nog geen publicatie aangevraagd.",
   "search-error": "Er ging iets mis bij het zoeken",
   "signatures": "Handtekeningen",


### PR DESCRIPTION
Fix on ACC branch:
- we don't have `decision.title` available in data, hence not showing in frontend
- make sure link to BS opens in a new tab