### PR TITLE
KAS-3325: Align service names in scripts and backend calls

### DIFF
--- a/Jenkinsfile.ci
+++ b/Jenkinsfile.ci
@@ -46,10 +46,10 @@ pipeline {
                 sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName} up -d --build"
 
                 sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName}  exec -T triplestore chmod -R 1777 /data"
-                sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName}  exec -T musearch chmod 1777 -R /data"
+                sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName}  exec -T search chmod 1777 -R /data"
                 //sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName}  exec -T elasticsearch chown -R elasticsearch:root /usr/share/elasticsearch/data"
                 //sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName}  exec -T elasticsearch chmod 1777 -R /usr/share/elasticsearch/data"
-                sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName}  exec -T file-bundling-service chmod 777 -R /share"
+                sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName}  exec -T file-bundling chmod 777 -R /share"
 
                 sh "cp ${WORKSPACE}/ci/.env.cypress ${WORKSPACE}/.env.cypress"
 
@@ -60,8 +60,8 @@ pipeline {
                 // sh "cd ${WORKSPACE}/kaleidos-project && docker-compose  -p ${projectName} exec -T elasticsearch chmod 1777 -R /usr/share/elasticsearch/data"
 
                 // Reset the contents of DB an search
-                sh "cd ${WORKSPACE}/kaleidos-project && docker-compose  -p ${projectName} rm -fs elasticsearch  musearch"
-                sh "cd ${WORKSPACE}/kaleidos-project && docker-compose  -p ${projectName} kill triplestore file cache resource yggdrasil migrations-service"
+                sh "cd ${WORKSPACE}/kaleidos-project && docker-compose  -p ${projectName} rm -fs elasticsearch  search"
+                sh "cd ${WORKSPACE}/kaleidos-project && docker-compose  -p ${projectName} kill triplestore file cache resource yggdrasil migrations"
                 sh "cd ${WORKSPACE}/kaleidos-project && rm -rf testdata"
                 sh "cd ${WORKSPACE}/kaleidos-project && unzip -o testdata.zip -d ${WORKSPACE}/kaleidos-project"
                 sh "cd ${WORKSPACE}/kaleidos-project && chmod 1777 -R data"

--- a/JenkinsfileParemeterized.ci
+++ b/JenkinsfileParemeterized.ci
@@ -53,8 +53,8 @@ pipeline {
                 sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName} up -d --build"
 
                 sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName}  exec -T triplestore chmod -R 1777 /data"
-                sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName}  exec -T musearch chmod 1777 -R /data"
-                sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName}  exec -T file-bundling-service chmod 777 -R /share"
+                sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName}  exec -T search chmod 1777 -R /data"
+                sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName}  exec -T file-bundling chmod 777 -R /share"
 
                 sh "cp ${WORKSPACE}/ci/.env.cypress ${WORKSPACE}/.env.cypress"
 
@@ -62,8 +62,8 @@ pipeline {
                 sh "sleep 45"
 
                 // Reset the contents of DB an search
-                sh "cd ${WORKSPACE}/kaleidos-project && docker-compose  -p ${projectName} rm -fs elasticsearch  musearch"
-                sh "cd ${WORKSPACE}/kaleidos-project && docker-compose  -p ${projectName} kill triplestore file cache resource yggdrasil migrations-service"
+                sh "cd ${WORKSPACE}/kaleidos-project && docker-compose  -p ${projectName} rm -fs elasticsearch  search"
+                sh "cd ${WORKSPACE}/kaleidos-project && docker-compose  -p ${projectName} kill triplestore file cache resource yggdrasil migrations"
                 sh "cd ${WORKSPACE}/kaleidos-project && rm -rf testdata"
                 sh "cd ${WORKSPACE}/kaleidos-project && unzip -o testdata.zip -d ${WORKSPACE}/kaleidos-project"
                 sh "cd ${WORKSPACE}/kaleidos-project && chmod 1777 -R data"

--- a/Makefile
+++ b/Makefile
@@ -7,15 +7,15 @@ reset-cache-resource-only:
 	- sleep 5
 
 reset-cache:
-	- docker-compose ${COMPOSE_FILE} kill yggdrasil triplestore file cache resource migrations-service
+	- docker-compose ${COMPOSE_FILE} kill yggdrasil triplestore file cache resource migrations
 	- rm -rf ${PROJECT_PATH}/testdata/db && rm -rf ${PROJECT_PATH}/testdata/files
 	- unzip -o ${PROJECT_PATH}/testdata.zip -x "elasticsearch/*" -d ${PROJECT_PATH}
 	- docker-compose ${COMPOSE_FILE} up -d
 	- sleep 5
 
 reset-elastic-and-cache:
-	- docker-compose ${COMPOSE_FILE} kill yggdrasil triplestore elasticsearch musearch file cache resource migrations-service
-	- docker-compose ${COMPOSE_FILE} rm -f yggdrasil triplestore elasticsearch musearch file cache resource migrations-service
+	- docker-compose ${COMPOSE_FILE} kill yggdrasil triplestore elasticsearch search file cache resource migrations
+	- docker-compose ${COMPOSE_FILE} rm -f yggdrasil triplestore elasticsearch search file cache resource migrations
 	- rm -rf ${PROJECT_PATH}/testdata
 	- unzip -o ${PROJECT_PATH}/testdata.zip -d ${PROJECT_PATH}
 	- docker-compose ${COMPOSE_FILE} up -d

--- a/app/pods/settings/users/index/controller.js
+++ b/app/pods/settings/users/index/controller.js
@@ -44,7 +44,7 @@ export default class UsersSettingsController extends Controller {
   @task
   *uploadUserFile(file) {
     try {
-      const response = yield file.upload('/user-management-service/import-users');
+      const response = yield file.upload('/user-management/import-users');
       if (response && response.status === 200) {
         this.toaster.success(this.intl.t('import-users-success'), this.intl.t('successfully-created-title'));
         this.send('refresh');

--- a/app/services/agenda-service.js
+++ b/app/services/agenda-service.js
@@ -17,10 +17,10 @@ export default Service.extend({
   addedPieces: null,
   addedAgendaitems: null,
 
-  /* API: session-service */
+  /* API: session-number-service */
 
   async getActiveAgendas(date) {
-    const response = await fetch(`/session-service/activeAgendas?date=${date}`, {
+    const response = await fetch(`/session-number/activeAgendas?date=${date}`, {
       method: 'GET',
       headers: {
         Accept: 'application/vnd.api+json',

--- a/app/utils/meeting-utils.js
+++ b/app/utils/meeting-utils.js
@@ -1,7 +1,7 @@
 import fetch from 'fetch';
 
 export const fetchClosestMeetingAndAgendaId = async function (date) {
-  const response = await fetch(`/session-service/closestMeeting?date=${date}`, {
+  const response = await fetch(`/session-number/closestMeeting?date=${date}`, {
     method: 'GET',
   });
   const payload = await response.json();
@@ -9,7 +9,7 @@ export const fetchClosestMeetingAndAgendaId = async function (date) {
 };
 
 export const assignNewSessionNumbers = async function () {
-  const response = await fetch('/session-service/assignNewSessionNumbers', {
+  const response = await fetch('/session-number/assignNewSessionNumbers', {
     method: 'GET',
   });
   return response;

--- a/ci/docker-compose.override.yml
+++ b/ci/docker-compose.override.yml
@@ -50,11 +50,11 @@ services:
     entrypoint: "echo 'service disabled'"
     restart: "no"
     user: ${HOST_UID_GID}
-  newsletter-service:
+  newsletter:
     entrypoint: "echo 'service disabled'"
     restart: "no"
     user: ${HOST_UID_GID}
-  musearch:
+  search:
     user: ${HOST_UID_GID}
     environment:
       UPDATE_WAIT_INTERVAL_MINUTES: 0

--- a/cypress/integration/unit/search.spec.js
+++ b/cypress/integration/unit/search.spec.js
@@ -10,7 +10,7 @@ function currentTimestamp() {
 }
 
 context('Search tests', () => {
-  // INFO: enable musearch, elasticsearch and tika for this spec
+  // INFO: enable search, elasticsearch and tika for this spec
   const options = [5, 10, 25, 50, 100];
 
   const dateToCreateAgenda = Cypress.dayjs().add(2, 'weeks')

--- a/cypress/support/commands/document-commands.js
+++ b/cypress/support/commands/document-commands.js
@@ -391,7 +391,7 @@ function uploadFile(folder, fileName, extension, mimeType = 'application/pdf') {
  */
 function uploadUsersFile(folder, fileName, extension) {
   cy.log('uploadUsersFile');
-  cy.intercept('POST', 'user-management-service/import-users').as('createNewFile');
+  cy.intercept('POST', 'user-management/import-users').as('createNewFile');
   cy.intercept('GET', 'users?include**').as('getNewFile');
   const fileFullName = `${fileName}.${extension}`;
   const filePath = `${folder}/${fileFullName}`;

--- a/cypress/support/commands/reset-database.commands.js
+++ b/cypress/support/commands/reset-database.commands.js
@@ -24,7 +24,7 @@ function resetCache() {
       kaleidosProject + '/docker-compose.override.yml'
   };
 
-  cy.exec('docker-compose kill yggdrasil triplestore file cache resource migrations-service', { env })
+  cy.exec('docker-compose kill yggdrasil triplestore file cache resource migrations', { env })
     .exec(`rm -rf ${kaleidosProject}/testdata/db && rm -rf ${kaleidosProject}/testdata/files`)
     .exec(`unzip -o ${kaleidosProject}/testdata.zip -x "elasticsearch/*" -d ${kaleidosProject}`)
     .exec('docker-compose up -d', { env })
@@ -46,7 +46,7 @@ function resetSearch() {
       kaleidosProject + '/docker-compose.override.yml'
   };
 
-  cy.exec('docker-compose kill triplestore elasticsearch musearch file cache resource', { env })
+  cy.exec('docker-compose kill triplestore elasticsearch search file cache resource', { env })
     .exec(`rm -rf ${kaleidosProject}/testdata`)
     .exec(`unzip -o ${kaleidosProject}/testdata.zip -d ${kaleidosProject}`)
     .exec('docker-compose up -d', { env })


### PR DESCRIPTION
Backend PR: https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/269

Changes helper bash scripts & Makefile to be inline with service names (i.e. no `-service` suffix for containers). Also updates `user-management(-service)` endpoint.