### PR TITLE
Put agendaitem (private-)comment on separate lines

### DIFF
--- a/app/components/agenda/agenda-overview/agenda-overview-item.hbs
+++ b/app/components/agenda/agenda-overview/agenda-overview-item.hbs
@@ -113,25 +113,18 @@
         {{/if}}
       {{/if}}
       {{#unless @isEditingFormallyOkStatus}}
-        {{#if @agendaitem.explanation}}
+        {{#if @agendaitem.comment}}
           <p>
             <strong class="auk-u-text-bold">
-              {{t "remark-title"}}:
+              {{t "comment-title"}}:
             </strong>
-            {{@agendaitem.explanation}}
+            {{@agendaitem.comment}}
           </p>
         {{/if}}
         <div class="auk-hr">
           <hr />
         </div>
         <div class="vlc-agenda-items__remarks">
-          <div>
-            {{#if @agendaitem.comment}}
-              <span class="auk-u-text-bold">
-                {{t "comment-title"}}:
-              </span> {{@agendaitem.comment}}
-            {{/if}}
-          </div>
           {{#if @agendaitem.privateComment}}
             <p class="auk-u-text-muted">
               <strong class="auk-u-text-bold">


### PR DESCRIPTION
Hotfix to show the comment and privatecomment of an agendaitem on separate lines in the overview page. Must've been merged incorrectly when merging PRs, because remnants of the previous name (`explanation`) still existed.