### PR TITLE
KAS-3363: Button elementen krijgen de verkeerde (achtergrond)kleur binnen Chrome

### DIFF
--- a/app/styles/govflanders/components/_alert.scss
+++ b/app/styles/govflanders/components/_alert.scss
@@ -94,6 +94,7 @@ $alert-padding-small: 1.5rem;
     right: 0.3rem;
     padding: 0.5rem;
     overflow: hidden;
+    background-color: transparent;
 
     &:hover,
     &:focus {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@ember/test-helpers": "^2.6.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
-    "@kanselarij-vlaanderen/au-kaleidos-css": "2.5.9",
+    "@kanselarij-vlaanderen/au-kaleidos-css": "2.5.10",
     "@kanselarij-vlaanderen/au-kaleidos-icons": "3.0.0",
     "@lblod/ember-acmidm-login": "~1.3.0",
     "@lblod/ember-mock-login": "^0.5.0-beta",


### PR DESCRIPTION
**Ticket binnen Jira:** https://kanselarij.atlassian.net/browse/KAS-3363

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.