### PR TITLE
Hotfix/kas 3307 cant attach pvv to its previous self

### DIFF
--- a/app/components/meeting/edit-meeting-modal.hbs
+++ b/app/components/meeting/edit-meeting-modal.hbs
@@ -22,7 +22,7 @@
             @sortField="-planned-start"
             @selectedItems={{this.selectedMainMeeting}}
             @selectModel={{this.selectMainMeeting}}
-            @filterResults={{fn this.filterMainMeetingResults @meeting}}
+            @filterOptions={{fn this.filterMainMeetingResults @meeting}}
             @isLoading={{this.initializeMainMeeting.isRunning}}
             as |model|
           >

--- a/app/components/meeting/edit-meeting-modal.hbs
+++ b/app/components/meeting/edit-meeting-modal.hbs
@@ -22,6 +22,7 @@
             @sortField="-planned-start"
             @selectedItems={{this.selectedMainMeeting}}
             @selectModel={{this.selectMainMeeting}}
+            @filterResults={{fn this.filterMainMeetingResults @meeting}}
             @isLoading={{this.initializeMainMeeting.isRunning}}
             as |model|
           >

--- a/app/components/meeting/edit-meeting-modal.js
+++ b/app/components/meeting/edit-meeting-modal.js
@@ -132,6 +132,10 @@ export default class MeetingEditMeetingComponent extends Component {
     }
   }
 
+  filterMainMeetingResults(meeting, results) {
+    return results.filter((result) => result.id != meeting.id);
+  }
+
   @action
   selectMainMeeting(mainMeeting) {
     this.selectedMainMeeting = mainMeeting;

--- a/app/components/utils/model-selector.js
+++ b/app/components/utils/model-selector.js
@@ -20,7 +20,7 @@ export default Component.extend({
    * @argument isLoading
    * @argument selectedItems
    * @argument selectModel
-   * @argument filterResults: a function that will filter out results from the dropwdown menu
+   * @argument filterOptions: a function that will filter out results from the dropwdown menu
    */
   classNameBindings: ['classes'],
   store: inject(),
@@ -45,8 +45,8 @@ export default Component.extend({
     } = this;
     if (modelName) {
       let items = yield this.store.query(modelName, queryOptions);
-      if (this.filterResults) {
-        items = this.filterResults(items);
+      if (this.filterOptions) {
+        items = this.filterOptions(items);
       }
       this.set('items', items);
     }
@@ -89,8 +89,8 @@ export default Component.extend({
     }
 
     let results = yield this.store.query(modelName, queryOptions);
-    if (this.filterResults) {
-      results = this.filterResults(results);
+    if (this.filterOptions) {
+      results = this.filterOptions(results);
     }
     return results;
   }),

--- a/app/components/utils/model-selector.js
+++ b/app/components/utils/model-selector.js
@@ -11,6 +11,17 @@ import { isPresent } from '@ember/utils';
 // TODO: octane-refactor
 // eslint-disable-next-line ember/no-classic-classes, ember/require-tagless-components
 export default Component.extend({
+  /**
+   * @argument modelName
+   * @argument searchField
+   * @argument sortField
+   * @argument readOnly
+   * @argument allowClear
+   * @argument isLoading
+   * @argument selectedItems
+   * @argument selectModel
+   * @argument filterResults: a function that will filter out results from the dropwdown menu
+   */
   classNameBindings: ['classes'],
   store: inject(),
   modelName: null,
@@ -33,7 +44,10 @@ export default Component.extend({
       modelName, queryOptions,
     } = this;
     if (modelName) {
-      const items = yield this.store.query(modelName, queryOptions);
+      let items = yield this.store.query(modelName, queryOptions);
+      if (this.filterResults) {
+        items = this.filterResults(items);
+      }
       this.set('items', items);
     }
   }),
@@ -74,7 +88,11 @@ export default Component.extend({
       queryOptions.filter = filter;
     }
 
-    return this.store.query(modelName, queryOptions);
+    let results = yield this.store.query(modelName, queryOptions);
+    if (this.filterResults) {
+      results = this.filterResults(results);
+    }
+    return results;
   }),
 
   // TODO: octane-refactor


### PR DESCRIPTION
When editing a meeting and setting its type to PVV, it was possible to chose itself as its main meeting, which doesn't make sense. See the screenshots here for further context https://kanselarij.atlassian.net/browse/KAS-3307

We filter out the meeting being edited from the list of results of the "main meeting" selection