### PR TITLE
computed are no longer retriggered, added .content to fix

### DIFF
--- a/app/models/agenda.js
+++ b/app/models/agenda.js
@@ -59,14 +59,14 @@ export default Model.extend(LoadableModel, {
 
   isFinal: computed.alias('status.isFinal'),
 
-  canBeApproved: computed('agendaitems.@each.formallyOk', function() {
+  canBeApproved: computed('agendaitems.content.@each.formallyOk', function() {
     return this.get('agendaitems').then((agendaitems) => {
       const approvedAgendaitems = agendaitems.filter((agendaitem) => [CONSTANTS.ACCEPTANCE_STATUSSES.OK].includes(agendaitem.get('formallyOk')));
       return approvedAgendaitems.get('length') === agendaitems.get('length');
     });
   }),
 
-  allAgendaitemsNotOk: computed('agendaitems.@each.formallyOk', function() {
+  allAgendaitemsNotOk: computed('agendaitems.content.@each.formallyOk', function() {
     return this.get('agendaitems').then((agendaitems) => {
       const allAgendaitemsNotOk = agendaitems.filter((agendaitem) => [CONSTANTS.ACCEPTANCE_STATUSSES.NOT_OK, CONSTANTS.ACCEPTANCE_STATUSSES.NOT_YET_OK].includes(agendaitem.get('formallyOk')));
       return allAgendaitemsNotOk.sortBy('number');

--- a/app/models/agendaitem.js
+++ b/app/models/agendaitem.js
@@ -60,12 +60,12 @@ export default ModelWithModifier.extend({
   linkedPieces: hasMany('piece'),
 
   // TODO only used in print agenda function
-  sortedPieces: computed('pieces.@each.name', function() {
+  sortedPieces: computed('pieces.content.@each.name', function() {
     return A(this.get('pieces').toArray()).sort((pieceA, pieceB) => compareFunction(new VRDocumentName(pieceA.get('name')), new VRDocumentName(pieceB.get('name'))));
   }),
 
   // TODO KAS-2975 only used for compare function
-  documentContainers: computed('pieces.@each.name', 'id', function() {
+  documentContainers: computed('pieces.content.@each.name', 'id', function() {
     return PromiseArray.create({
       promise: this.get('pieces').then((pieces) => {
         if (pieces && pieces.get('length') > 0) {
@@ -158,7 +158,7 @@ export default ModelWithModifier.extend({
     return documentContainers && documentContainers.some((documentContainers) => documentContainers.checkAdded);
   }),
 
-  newsletterInfo: computed('treatments.@each.newsletterInfo', 'treatments', 'id', async function() {
+  newsletterInfo: computed('treatments.content.@each.newsletterInfo', 'treatments', 'id', async function() {
     const newsletterInfos = await this.store.query('newsletter-info', {
       'filter[agenda-item-treatment][agendaitem][:id:]': this.get('id'),
     });

--- a/app/models/meeting.js
+++ b/app/models/meeting.js
@@ -84,7 +84,7 @@ export default Model.extend({
     });
   }),
 
-  sortedAgendas: computed('agendas.@each.agendaName', function() {
+  sortedAgendas: computed('agendas.content.@each.agendaName', function() {
     return PromiseArray.create({
       promise: this.get('agendas').then((agendas) => agendas.sortBy('agendaName').reverse()),
     });

--- a/app/models/subcase.js
+++ b/app/models/subcase.js
@@ -54,7 +54,7 @@ export default ModelWithModifier.extend({
 
   // TODO don't use this computed, refactor subcase-description-view.hbs && subcase-item.hbs
   // eslint-disable-next-line ember/use-brace-expansion
-  phases: computed('agendaActivities.agendaitems', 'agendaActivities.agendaitems.[]', 'latestActivity.agendaitems.@each.retracted', 'approved', async function() {
+  phases: computed('agendaActivities.agendaitems', 'agendaActivities.agendaitems.[]', 'latestActivity.agendaitems.content.@each.retracted', 'approved', async function() {
     return await this.get('subcasesService').getSubcasePhases(this);
   }),
 
@@ -76,7 +76,7 @@ export default ModelWithModifier.extend({
   }),
 
   // TODO don't use this computed, used in 5 places, make util?
-  approved: computed('treatments', 'treatments.@each.decisionResultCode', 'requestedForMeeting', async function() {
+  approved: computed('treatments', 'treatments.content.@each.decisionResultCode', 'requestedForMeeting', async function() {
     const meeting = await this.get('requestedForMeeting');
     if (meeting?.isFinal) {
       const treatments = await this.get('treatments');

--- a/app/pods/agenda/print/controller.js
+++ b/app/pods/agenda/print/controller.js
@@ -14,7 +14,7 @@ function equalContentArrays(array1, array2) {
 // eslint-disable-next-line ember/no-classic-classes
 export default Controller.extend({
 
-  notaGroups: computed('model.notas.@each.sortedMandatees', function() {
+  notaGroups: computed('model.notas.content.@each.sortedMandatees', function() {
     const agendaitems = this.get('model.notas');
     if (agendaitems.length > 0) {
       let currentSubmittersArray = agendaitems.firstObject.sortedMandatees;


### PR DESCRIPTION
During cypress refactor noticed that certain computeds were no longer being re-triggered.
fe. approve agenda with not formal ok > warning message > change to formal ok > warning message still present when it shouldn't be.
Traced it back to the `agenda` computed not recalculating after the `agendaitem` model had a new `formallyOk`.
Added `.content` to the computed before the `@each` fixed it.
Added `.content` to all computed with `@each`, assuming they might also be broken.