### PR TITLE
KAS-3421: Elementen rond ‘Reeds bezorgde documenten’ binnen subcase document view wordt niet correct getoond

### DIFF
--- a/app/pods/cases/case/subcases/subcase/documents/template.hbs
+++ b/app/pods/cases/case/subcases/subcase/documents/template.hbs
@@ -53,6 +53,7 @@
         </div>
       {{/if}}
     </div>
+    <Documents::LinkedDocuments @agendaitemOrSubcase={{this.subcase}}/>
   </div>
 </div>
 
@@ -90,4 +91,3 @@
       @disableSave={{eq this.newPieces.length 0}} />
   </WebComponents::VlModal>
 {{/if}}
-<Documents::LinkedDocuments @agendaitemOrSubcase={{this.subcase}}/>


### PR DESCRIPTION
**Ticket binnen Jira:** https://kanselarij.atlassian.net/browse/KAS-3421

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.