### PR TITLE
KAS-3381 changed translation pages labels and fixed a small bug

### DIFF
--- a/app/components/publications/publication/case/info/publication-case-info-panel.js
+++ b/app/components/publications/publication/case/info/publication-case-info-panel.js
@@ -48,7 +48,7 @@ export default class PublicationsPublicationCaseInfoPanelComponent extends Compo
     // Limiet publicatie
     this.publicationSubcase = await this.args.publicationFlow
       .publicationSubcase;
-    if (this.isViaCouncilOfMinisters) {
+    if (this.isViaCouncilOfMinisters && this.agendaItemTreatment) {
       // get the models meeting/agenda/agendaitem for clickable link
       this.modelsForAgendaitemRoute = await this.publicationService.getModelsForAgendaitemFromTreatment(this.agendaItemTreatment);
     }

--- a/app/components/publications/publication/decisions/info/decisions-info-panel.js
+++ b/app/components/publications/publication/decisions/info/decisions-info-panel.js
@@ -31,7 +31,7 @@ export default class PublicationsPublicationCaseInfoPanelComponent extends Compo
     this.isViaCouncilOfMinisters =
       await this.publicationService.getIsViaCouncilOfMinisters(this.args.publicationFlow);
     this.agendaItemTreatment = await this.args.publicationFlow.agendaItemTreatment;
-    if (this.isViaCouncilOfMinisters) {
+    if (this.isViaCouncilOfMinisters && this.agendaItemTreatment) {
       // get the models meeting/agenda/agendaitem for clickable link
       this.modelsForAgendaitemRoute = await this.publicationService.getModelsForAgendaitemFromTreatment(this.agendaItemTreatment);
     }

--- a/app/components/publications/publication/translations/translation-request-modal.hbs
+++ b/app/components/publications/publication/translations/translation-request-modal.hbs
@@ -32,7 +32,7 @@
                   for="translationNumberOfPages"
                   class="auk-label--light"
                 >
-                  {{t "number-of-pages"}}
+                  {{t "number-of-pages-to-translate"}}
                 </Auk::Label>
                 <Auk::Input
                   data-test-publication-translation-request-number-of-pages
@@ -50,7 +50,7 @@
                   for="translationNumberOfWords"
                   class="auk-label--light"
                 >
-                  {{t "number-of-words"}}
+                  {{t "number-of-words-to-translate"}}
                 </Auk::Label>
                 <Auk::Input
                   data-test-publication-translation-request-number-of-words

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -129,6 +129,8 @@
   "number-of-documents": "Aantal documenten",
   "number-of-pages": "Aantal bladzijden",
   "number-of-words": "Aantal woorden",
+  "number-of-pages-to-translate": "Aantal te vertalen bladzijden",
+  "number-of-words-to-translate": "Aantal te vertalen woorden",
   "document-add": "Document toevoegen",
   "document-link-old": "Reeds bezorgde documenten koppelen",
   "document-delete": "Document verwijderen",


### PR DESCRIPTION
Vraag van de gebruikers: hernoem de velden “Aantal bladzijden” en “Aantal woorden” uit de “vertaling aanvragen” modal naar “Aantal te vertalen bladzijden” en “Aantal te vertalen woorden” om meer duidelijkheid te scheppen.

+ een kleine fix voor een edge case als er geen agenda-item-treatment is (komt enkel op dev voor denk ik)