### PR TITLE
KAS-3453 make relation read-only, update inverse

### DIFF
--- a/app/models/agenda-item-treatment.js
+++ b/app/models/agenda-item-treatment.js
@@ -15,7 +15,7 @@ export default class AgendaItemTreatment extends Model {
   @belongsTo('agendaitem') agendaitem;
   @belongsTo('subcase') subcase;
   @belongsTo('piece') report;
-  @belongsTo('newsletter-info') newsletterInfo;
+  @belongsTo('newsletter-info', { serialize: false }) newsletterInfo;
   @belongsTo('decision-result-code', { inverse: null }) decisionResultCode;
   @hasMany('publication-flow') publicationFlows;
   @hasMany('sign-flow') signFlows;

--- a/app/pods/agenda/agendaitems/agendaitem/decisions/controller.js
+++ b/app/pods/agenda/agendaitems/agendaitem/decisions/controller.js
@@ -6,6 +6,7 @@ import { tracked } from '@glimmer/tracking';
 export default class DecisionAgendaitemAgendaitemsAgendaController extends Controller {
   @service currentSession;
   @service store;
+  @service newsletterService;
 
   @tracked agendaitem;
   @tracked meeting;
@@ -20,16 +21,15 @@ export default class DecisionAgendaitemAgendaitemsAgendaController extends Contr
     const now = new Date();
     const agendaActivity = await this.agendaitem.agendaActivity;
     const subcase = await agendaActivity?.subcase
-    const newsletterInfo = await this.treatments.firstObject.newsletterInfo;
     const newTreatment = this.store.createRecord('agenda-item-treatment', {
       created: now,
       modified: now,
       startDate: startDate,
       agendaitem: this.agendaitem,
       subcase: subcase,
-      newsletterInfo: newsletterInfo,
     });
     await newTreatment.save();
+    await this.newsletterService.linkNewsItemToNewTreatment(this.agendaitem);
     this.refresh();
   }
 

--- a/app/pods/agenda/agendaitems/agendaitem/news-item/route.js
+++ b/app/pods/agenda/agendaitems/agendaitem/news-item/route.js
@@ -25,7 +25,9 @@ export default class NewsitemAgendaitemAgendaitemsAgendaRoute extends Route {
   }
 
   async model() {
-    const newsletterInfo = await this.agendaItemTreatment.newsletterInfo;
+    const newsletterInfo = await this.store.queryOne('newsletter-info', {
+      'filter[agenda-item-treatment][:id:]': this.agendaItemTreatment.id,
+    });
     return newsletterInfo;
   }
 

--- a/app/pods/print-overviews/decisions/agendaitems/controller.js
+++ b/app/pods/print-overviews/decisions/agendaitems/controller.js
@@ -7,6 +7,7 @@ import { inject } from '@ember/service';
 export default Controller.extend({
   intl: inject(),
   store: inject(),
+  newsletterService: inject(),
 
   columns: computed(function() {
     return [{
@@ -80,6 +81,7 @@ export default Controller.extend({
         subcase: subcase,
       });
       await treatment.save();
+      await this.newsletterService.linkNewsItemToNewTreatment(agendaitem);
     },
   },
 });

--- a/app/services/newsletter-service.js
+++ b/app/services/newsletter-service.js
@@ -16,10 +16,10 @@ export default class NewsletterService extends Service {
         type: 'mail-campaigns',
         relationships: {
           meeting: {
-            data: { type: 'meetings', id: meeting.id }
-          }
-        }
-      }
+            data: { type: 'meetings', id: meeting.id },
+          },
+        },
+      },
     };
     const response = await fetch(endpoint, {
       method: 'POST',
@@ -36,7 +36,7 @@ export default class NewsletterService extends Service {
           this.intl.t('warning-title')
         );
       }
-     throw new Error('An exception ocurred: ' + JSON.stringify(result.errors));
+      throw new Error('An exception ocurred: ' + JSON.stringify(result.errors));
     }
     const mailCampaign = this.store.createRecord('mail-campaign', {
       campaignId: result.data.id,
@@ -78,10 +78,10 @@ export default class NewsletterService extends Service {
         type: 'belga-newsletters',
         relationships: {
           meeting: {
-            data: { type: 'meetings', id: meetingId }
-          }
-        }
-      }
+            data: { type: 'meetings', id: meetingId },
+          },
+        },
+      },
     };
     const response = await fetch(endpoint, {
       method: 'POST',
@@ -172,6 +172,23 @@ export default class NewsletterService extends Service {
     }
   }
 
+  /**
+   * Update the hasMany('agenda-item-treatment') of newsletter-info when adding a new treatment
+   * @param {Agendaitem} agendaitem
+   */
+  async linkNewsItemToNewTreatment(agendaitem) {
+    const newsletterInfo = await this.store.queryOne('newsletter-info', {
+      'filter[agenda-item-treatment][agendaitem][:id:]': agendaitem.id,
+    });
+    if (newsletterInfo) {
+      const agendaItemTreatments = await agendaitem
+        .hasMany('treatments')
+        .reload();
+      newsletterInfo.agendaItemTreatment = agendaItemTreatments;
+      await newsletterInfo.save();
+    }
+  }
+
   async deleteCampaign(id) {
     const endpoint = `/newsletter/mail-campaigns/${id}`;
     try {
@@ -189,7 +206,6 @@ export default class NewsletterService extends Service {
       );
     }
   }
-
 
   async createNewsItemForMeeting(meeting) {
     if (this.currentSession.isEditor) {


### PR DESCRIPTION
### :warning:  WARNING! branch started from production

# HOTFIX https://kanselarij.atlassian.net/browse/KAS-3453


### What has changed:
models/agenda-item-treatments.js:
- Make relation read-only by not serializing it.

agenda/agendaitems/agendaitem/decisions/controller.js:
- instead of creating a new treatment with a newsletter, we call the new method in the newsletter service.

agenda/agendaitems/agendaitem/news-item/route.js:
- Model was dependent on a possible stale relation, use query instead.

print-overviews/decisions/agendaitems/controller.js:
- instead of creating a new treatment with a newsletter, we call the new method in the newsletter service.
(connecting existing newsletter was actually missing here, assuming this route is not really used to add treatments)

services/newsletter-service.js:
- linter
- new method that checks if there is an existing newsletter for the agendaitem in params. If it exists, we refresh its treatments and save the newsletter with the list of treatments

--

Jenkins PR will fail, use custom builds against production backend

1st build
http://kal-kastaar.s.redpencil.io:8080/job/kaleidos/job/custom_frontend_backend_combination/242/
