### PR TITLE
KAS-3419 Link existing publication (not via MR) to agendaitem document afterwards

### DIFF
--- a/app/components/publications/batch-documents-publication-modal.js
+++ b/app/components/publications/batch-documents-publication-modal.js
@@ -104,15 +104,40 @@ export default class PublicationsBatchDocumentsPublicationModalComponent extends
 
   @action
   async linkPublicationFlow(piece, publicationFlow) {
+    let publicationFlowHasChanged = false;
+
     const regulationType = await publicationFlow.regulationType;
     if (!regulationType) {
       const regulationTypeFromDocument =
         await this.getRegulationTypeThroughReferenceDocument(piece);
       if (regulationTypeFromDocument) {
         publicationFlow.regulationType = regulationTypeFromDocument;
-        await publicationFlow.save();
+        publicationFlowHasChanged = true;
       }
     }
+
+    // Ensure the publication-flow is linked to the same agenda-item-treatment as
+    // the document. This might differ if the publication-flow has been created before
+    // the subcase was handled on an agenda and a dummy agenda-item-treatment was
+    // created back then. A dummy agenda-item-treatment can be recognized because it
+    // doesn't have a related agendaitem in Kaleidos.
+    const agendaItemTreatment = await publicationFlow.agendaItemTreatment;
+    if (agendaItemTreatment.id != this.agendaItemTreatment.id) {
+      const agendaitem = await this.store.queryOne('agendaitem', {
+        'filter[treatments][:id:]': agendaItemTreatment.id
+      });
+      if (!agendaitem) {
+        publicationFlow.agendaItemTreatment = this.agendaItemTreatment;
+        publicationFlowHasChanged = true;
+        // destroy the dummy agenda-item-treatment
+        await agendaItemTreatment.destroyRecord();
+      }
+    }
+
+    if (publicationFlowHasChanged) {
+      await publicationFlow.save();
+    }
+
     piece.publicationFlow = publicationFlow;
     await piece.save();
   }

--- a/app/components/publications/batch-documents-publication-modal.js
+++ b/app/components/publications/batch-documents-publication-modal.js
@@ -128,13 +128,14 @@ export default class PublicationsBatchDocumentsPublicationModalComponent extends
       } else {
         // Publication-flow is already linked to an agenda-item-treatment that has been
         // handled on an agenda. We cannot relink the publication-flow in that case.
-        // In practice, this scenario will not occur since they are not able to select
-        // such a publication-flow in the publication-flow-selector.
+        // In practice this scenario will only occur in concurrency scenarios where
+        // multiple users try to link the same publication at the same time to
+        // different cases.
         this.toaster.error(
           this.intl.t('unable-to-relink-publication-flow'),
           this.intl.t('warning-title')
         );
-        throw Error('Unable to relink publication flow');
+        return;
       }
     }
 

--- a/app/components/publications/publication-flow-selector.js
+++ b/app/components/publications/publication-flow-selector.js
@@ -29,7 +29,7 @@ export default class PublicationsPublicationFlowSelectorComponent extends Compon
     // the (sub)case was handled on an agenda
     const filterNotViaCouncilOfMinisters = {
       'agenda-item-treatment': {
-        ':has:agendaitem': 'yes',
+        ':has-no:agendaitem': 'yes',
       },
     };
 

--- a/app/components/publications/publication-flow-selector.js
+++ b/app/components/publications/publication-flow-selector.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { timeout, restartableTask } from 'ember-concurrency';
+import { timeout, restartableTask, all } from 'ember-concurrency';
 import { isBlank } from '@ember/utils';
 import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 
@@ -16,23 +16,54 @@ export default class PublicationsPublicationFlowSelectorComponent extends Compon
   *debouncedSearch(searchText) {
     yield timeout(300);
 
-    const filter = {
-      // multiple reference documents on 1 publication-flow must belong to the same case
+    // Filter on all publication-flows linked to the same case
+    // because multiple reference documents on 1 publication-flow must belong to the same case
+    const filterByCase = {
       case: {
         ':id:': this.args.case.get('id'),
       },
     };
+
+    // Filter on all publication-flows 'niet via MR'
+    // to support relinking a publication-flow that was created before
+    // the (sub)case was handled on an agenda
+    const filterNotViaCouncilOfMinisters = {
+      'agenda-item-treatment': {
+        ':has:agendaitem': 'yes',
+      },
+    };
+
     if (!isBlank(searchText)) {
-      filter.identification = {
-        'id-name': searchText,
-      };
+      [filterByCase, filterNotViaCouncilOfMinisters].forEach((filter) => {
+          filter.identification = {
+            'id-name': searchText,
+          };
+      });
     }
-    const publicationFlows = yield this.store.query('publication-flow', {
-      filter,
+
+    // We need to do both queries seperately and combine the results afterwards,
+    // since multiple filters can not be combined using 'OR' in mu-cl-resources
+    const searchByCase = this.store.query('publication-flow', {
+      filter: filterByCase,
       'page[size]': PAGE_SIZE.PUBLICATION_FLOWS,
       sort: 'identification.id-name',
       include: 'identification',
     });
-    return publicationFlows;
+    const searchNotViaCouncilOfMinisters = this.store.query('publication-flow', {
+      filter: filterNotViaCouncilOfMinisters,
+      'page[size]': PAGE_SIZE.PUBLICATION_FLOWS,
+      sort: 'identification.id-name',
+      include: 'identification',
+    });
+
+    const [publicationsByCase, publicationsNotViaCouncilOfMinisters] = yield all([
+      searchByCase,
+      searchNotViaCouncilOfMinisters
+    ]);
+
+    return [
+      ...publicationsByCase.toArray(),
+      ...publicationsNotViaCouncilOfMinisters.toArray()
+    ];
   }
 }

--- a/app/components/publications/publication-flow-selector.js
+++ b/app/components/publications/publication-flow-selector.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { timeout, restartableTask, all } from 'ember-concurrency';
+import { timeout, restartableTask } from 'ember-concurrency';
 import { isBlank } from '@ember/utils';
 import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 
@@ -56,7 +56,7 @@ export default class PublicationsPublicationFlowSelectorComponent extends Compon
       include: 'identification',
     });
 
-    const [publicationsByCase, publicationsNotViaCouncilOfMinisters] = yield all([
+    const [publicationsByCase, publicationsNotViaCouncilOfMinisters] = yield Promise.all([
       searchByCase,
       searchNotViaCouncilOfMinisters
     ]);

--- a/app/components/publications/publication/case/info/publication-case-info-panel.hbs
+++ b/app/components/publications/publication/case/info/publication-case-info-panel.hbs
@@ -9,18 +9,20 @@
             </h4>
           </Auk::Toolbar::Item>
         </Auk::Toolbar::Group>
-        {{#unless this.isEditing}}
-          <Auk::Toolbar::Group @position="right">
-            <Auk::Toolbar::Item>
-              <Auk::Button
-                data-test-publication-case-info-panel-edit
-                @skin="tertiary"
-                @icon="pencil"
-                @layout="icon-only"
-                {{on "click" this.openEditingPanel}}
-              />
-            </Auk::Toolbar::Item>
-          </Auk::Toolbar::Group>
+        {{#unless this.initFields.isRunning}}
+          {{#unless this.isEditing}}
+            <Auk::Toolbar::Group @position="right">
+              <Auk::Toolbar::Item>
+                <Auk::Button
+                  data-test-publication-case-info-panel-edit
+                  @skin="tertiary"
+                  @icon="pencil"
+                  @layout="icon-only"
+                  {{on "click" this.openEditingPanel}}
+                />
+              </Auk::Toolbar::Item>
+            </Auk::Toolbar::Group>
+          {{/unless}}
         {{/unless}}
       </Auk::Toolbar>
     </Auk::Panel::Header>

--- a/app/components/publications/publication/case/info/publication-case-info-panel.js
+++ b/app/components/publications/publication/case/info/publication-case-info-panel.js
@@ -25,32 +25,33 @@ export default class PublicationsPublicationCaseInfoPanelComponent extends Compo
   constructor() {
     super(...arguments);
 
-    this.initFields();
+    this.initFields.perform();
   }
 
-  async initFields() {
+  @task
+  *initFields() {
     this.isViaCouncilOfMinisters =
-      await this.publicationService.getIsViaCouncilOfMinisters(
+      yield this.publicationService.getIsViaCouncilOfMinisters(
         this.args.publicationFlow
       );
     // Publication number
-    this.identification = await this.args.publicationFlow.identification;
-    this.structuredIdentifier = await this.identification.structuredIdentifier;
+    this.identification = yield this.args.publicationFlow.identification;
+    this.structuredIdentifier = yield this.identification.structuredIdentifier;
     // using local tracked values because validation of these fields is delayed.
     // identification and structured-identifier are only updated after validation succeeds
     this.publicationNumber = this.structuredIdentifier.localIdentifier;
     this.publicationNumberSuffix = this.structuredIdentifier.versionIdentifier;
     // Numac-nummers
-    this.numacNumbers = await this.args.publicationFlow.numacNumbers;
+    this.numacNumbers = yield this.args.publicationFlow.numacNumbers;
     // Datum beslissing
-    this.agendaItemTreatment = await this.args.publicationFlow
+    this.agendaItemTreatment = yield this.args.publicationFlow
       .agendaItemTreatment;
     // Limiet publicatie
-    this.publicationSubcase = await this.args.publicationFlow
+    this.publicationSubcase = yield this.args.publicationFlow
       .publicationSubcase;
     if (this.isViaCouncilOfMinisters && this.agendaItemTreatment) {
       // get the models meeting/agenda/agendaitem for clickable link
-      this.modelsForAgendaitemRoute = await this.publicationService.getModelsForAgendaitemFromTreatment(this.agendaItemTreatment);
+      this.modelsForAgendaitemRoute = yield this.publicationService.getModelsForAgendaitemFromTreatment(this.agendaItemTreatment);
     }
   }
 

--- a/app/config/publications/overview-table-columns.js
+++ b/app/config/publications/overview-table-columns.js
@@ -132,7 +132,7 @@ export default [
     keyName: 'source',
     translationKey: 'publications-table-source',
     translationKeySmall: 'publications-table-source-small',
-    apiFieldPaths: ['case.subcases.uri'],
+    apiFieldPaths: [], // data is fetched using queryOne in publication-service
   },
   {
     keyName: 'lastEdited',

--- a/app/pods/application/route.js
+++ b/app/pods/application/route.js
@@ -5,6 +5,7 @@ import CONSTANTS from '../../config/constants';
 import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 
 export default class ApplicationRoute extends Route {
+  @service store;
   @service moment;
   @service intl;
   @service session;

--- a/app/pods/publications/overview/_base/route.js
+++ b/app/pods/publications/overview/_base/route.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 import PublicationTableConfig from 'frontend-kaleidos/utils/publication-table-config';
 
 /**
@@ -10,6 +11,8 @@ import PublicationTableConfig from 'frontend-kaleidos/utils/publication-table-co
 
 /** @abstract */
 export default class PublicationsOverviewBaseRoute extends Route {
+  @service store;
+
   defaultColumns;
   tableConfigStorageKey;
 

--- a/app/services/publication-service.js
+++ b/app/services/publication-service.js
@@ -190,9 +190,10 @@ export default class PublicationService extends Service {
   }
 
   async getIsViaCouncilOfMinisters(publicationFlow) {
-    const _case = await publicationFlow.case;
-    const subcases = await _case.subcases;
-    return !!subcases.length;
+    const agendaitem = await this.store.queryOne('agendaitem', {
+      'filter[treatments][publication-flows][:id:]': publicationFlow.id,
+    });
+    return agendaitem != null;
   }
 
   async updatePublicationStatus(publicationFlow, targetStatusUri, changeDate) {

--- a/app/services/publication-service.js
+++ b/app/services/publication-service.js
@@ -191,8 +191,18 @@ export default class PublicationService extends Service {
   }
 
   async getIsViaCouncilOfMinisters(publicationFlow) {
+    // Not using the query below since a bug in mu-cache/mu-cl-resources
+    // doesn't invalidate the cache entry when a publication gets linked
+    // to an agendaitem. As a workaround querying via agenda-item-treatment id
+    // for now.
+
+    // const agendaitem = await this.store.queryOne('agendaitem', {
+    //   'filter[treatments][publication-flows][:id:]': publicationFlow.id,
+    // });
+
+    const agendaItemTreatment = await publicationFlow.agendaItemTreatment;
     const agendaitem = await this.store.queryOne('agendaitem', {
-      'filter[treatments][publication-flows][:id:]': publicationFlow.id,
+      'filter[treatments][:id:]': agendaItemTreatment.id
     });
     return agendaitem != null;
   }

--- a/cypress/integration/unit/publication-via-MR.spec.js
+++ b/cypress/integration/unit/publication-via-MR.spec.js
@@ -100,6 +100,8 @@ context('Publications via MR tests', () => {
     }).should('not.exist');
     cy.get(publication.publicationTableRow.row.publicationNumber).contains(publicationNumber1)
       .click();
+    cy.url().should('include', '/publicatie')
+      .should('include', '/dossier');
 
     // check data
     cy.get(publication.publicationCaseInfo.publicationNumber).contains(publicationNumber1);
@@ -140,6 +142,8 @@ context('Publications via MR tests', () => {
     }).should('not.exist');
     cy.get(publication.publicationTableRow.row.publicationNumber).contains(publicationNumber1)
       .click();
+    cy.url().should('include', '/publicatie')
+      .should('include', '/dossier');
 
     // check rollback after cancel edit
     cy.get(publication.publicationCaseInfo.edit).click();
@@ -219,10 +223,13 @@ context('Publications via MR tests', () => {
       .click();
     cy.get('@row').find(publication.publicationsFlowSelector)
       .click();
-    cy.intercept('GET', `/publication-flows**?filter**${publicationNumber2}**`).as('getFilteredId');
+    cy.intercept('GET', `/publication-flows**?filter**case**${publicationNumber2}**`).as('getFilteredIdCase');
+    cy.intercept('GET', `/publication-flows**?filter**agenda*item*treatment**${publicationNumber2}**`).as('getFilteredIdTreatment');
     cy.intercept('PATCH', '/pieces/**').as('patchPieces');
     cy.get(dependency.emberPowerSelect.searchInput).type(publicationNumber2)
-      .wait('@getFilteredId');
+      .wait('@getFilteredIdCase')
+      .wait('@getFilteredIdTreatment');
+    cy.get(dependency.emberPowerSelect.optionLoadingMessage).should('not.exist');
     cy.get(dependency.emberPowerSelect.option).contains(publicationNumber2)
       .scrollIntoView()
       .trigger('mouseover')
@@ -283,16 +290,22 @@ context('Publications via MR tests', () => {
     // check if the regulation type is inherited correctly on all publications
     cy.get(publication.publicationTableRow.row.publicationNumber).contains(publicationNumber2)
       .click();
+    cy.url().should('include', '/publicatie')
+      .should('include', '/dossier');
     cy.get(publication.publicationNav.decisions).click();
     cy.get(publication.decisionsInfoPanel.view.regulationType).contains('Besluit van de Vlaamse Regering');
     cy.get(publication.publicationNav.goBack).click();
     cy.get(publication.publicationTableRow.row.publicationNumber).contains(publicationNumber3)
       .click();
+    cy.url().should('include', '/publicatie')
+      .should('include', '/dossier');
     cy.get(publication.publicationNav.decisions).click();
     cy.get(publication.decisionsInfoPanel.view.regulationType).contains('Ministerieel besluit');
     cy.get(publication.publicationNav.goBack).click();
     cy.get(publication.publicationTableRow.row.publicationNumber).contains(publicationNumber4)
       .click();
+    cy.url().should('include', '/publicatie')
+      .should('include', '/dossier');
     cy.get(publication.publicationNav.decisions).click();
     cy.get(publication.decisionsInfoPanel.view.regulationType).contains('Decreet');
 

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -519,6 +519,7 @@
   "release-to-public": "Vrijgeven",
   "publish-to-public": "Publiceren",
   "retract-from-public": "Terugtrekken",
+  "unable-to-relink-publication-flow": "De publicatie kan niet gekoppeld worden aan dit dossier",
   "no-accessLevel": "Nog geen openbaarheid",
   "faulty-agendaitems-message": "Er zijn agendapunten gevonden zonder procedurestap. Verwijder deze manueel om verder te gaan",
   "faulty-agendaitems": "Problemen in deze agenda",


### PR DESCRIPTION
Add support to link a publication 'not via MR' to a document on the agenda afterwards.

Search box for publications now also returns 'publications not via MR'. In case a publication 'not via MR' is selected, the publication gets relinked to the case/agenda-item-treatment the document belongs to. The dummy data (case/agenda-item-treatment) [created before](https://github.com/kanselarij-vlaanderen/frontend-kaleidos/blob/development/app/services/publication-service.js#L70-L79) is removed.

Also updated to condition to classify a publication as 'via MR'/'not via MR'. Instead of checking for the presence of a subcase, the presence of an agendaitem is now checked, which is more correct semantically.