### PR TITLE
Feature/kas 3448 small improvements on publications table

### DIFF
--- a/app/components/publications/overview/publications-table.hbs
+++ b/app/components/publications/overview/publications-table.hbs
@@ -42,7 +42,7 @@
           <tbody>
             {{#if @isLoading}}
               <tr data-test-route-publications-index-loading>
-                <td colspan={{add @tableColumns.length 1}}>
+                <td colspan={{add @tableConfig.visibleColumns.length 1}}>
                   {{t "loading"}}
                 </td>
               </tr>

--- a/app/config/publications/overview-table-columns.js
+++ b/app/config/publications/overview-table-columns.js
@@ -16,8 +16,7 @@ export default [
     translationKeySmall: 'publications-table-publication-number-small',
     sortKey: 'identification.structured-identifier.local-identifier,-created',
     apiFieldPaths: [
-      'identification.structured-identifier.local-identifier',
-      'identification.structured-identifier.version-identifier',
+      'identification.id-name',
       'created',
     ],
   },
@@ -26,7 +25,10 @@ export default [
     translationKey: 'publications-table-numac-number',
     translationKeySmall: 'publications-table-numac-number-small',
     sortKey: 'numac-numbers.id-name,-created',
-    apiFieldPaths: ['numac-numbers.id-name', 'created'],
+    apiFieldPaths: [
+      'numac-numbers.id-name',
+      'created'
+    ],
   },
   {
     keyName: 'shortTitle',
@@ -146,6 +148,6 @@ export default [
     translationKey: 'publications-table-status',
     translationKeySmall: 'publications-table-status-small',
     sortKey: 'status.position,publication-status-change.started-at',
-    apiFieldPaths: ['status.position', 'publication-status-change.started-at'],
+    apiFieldPaths: ['status.position'],
   },
 ];

--- a/app/pods/publications/overview/_base/route.js
+++ b/app/pods/publications/overview/_base/route.js
@@ -52,7 +52,8 @@ export default class PublicationsOverviewBaseRoute extends Route {
     });
 
     const uniqueIncludes = [...new Set(pathsRequiringInclude)];
-    this.includes = uniqueIncludes;
+    // Sort includes to increase cache-hit chances
+    this.includes = uniqueIncludes.sort();
   }
 
   model(params) {


### PR DESCRIPTION
Made some minor improvements on data loading for the publications table while doing analysis for KAS-3448. 

- Fix colspan attribute when displaying loading message in publications table
- Sort include statements to increase chances on a cache hit
- Only include relations that are needed for data display, not for sorting