### PR TITLE
Feature/kas 3474 batch edit access levels

### DIFF
--- a/app/components/documents/batch-details/batch-documents-details-modal.js
+++ b/app/components/documents/batch-details/batch-documents-details-modal.js
@@ -14,6 +14,7 @@ export default class BatchDocumentsDetailsModal extends Component {
   @service store;
   @service currentSession;
   @service fileService;
+  @service pieceAccessLevelService;
 
   @tracked rows;
   @tracked selectedRows = [];
@@ -114,6 +115,7 @@ export default class BatchDocumentsDetailsModal extends Component {
       } else {
         piece.name = row.name;
         // does not check for relationship changes
+        let accessLevelHasChanged = false;
         let hasChanged = piece.dirtyType === 'updated';
         if (documentContainer.type !== row.documentType) {
           hasChanged = true;
@@ -121,11 +123,15 @@ export default class BatchDocumentsDetailsModal extends Component {
         }
         if (piece.accessLevel !== row.accessLevel) {
           hasChanged = true;
+          accessLevelHasChanged = true;
           piece.accessLevel = row.accessLevel;
         }
         if (hasChanged) {
           await piece.save();
           await documentContainer.save();
+          if (accessLevelHasChanged) {
+            await this.pieceAccessLevelService.updatePreviousAccessLevels(piece);
+          }
         }
       }
     });

--- a/app/components/documents/batch-details/document-details-row.hbs
+++ b/app/components/documents/batch-details/document-details-row.hbs
@@ -12,7 +12,7 @@
   {{/if}}
   <td>
     {{#if @isEditingEnabled}}
-      <Auk::Input data-test-document-details-input type="text" @block @value={{mut @row.name}} />
+      <Auk::Input data-test-document-details-input type="text" @block={{true}} @value={{mut @row.name}} />
     {{else}}
       {{@row.name}}
     {{/if}}

--- a/app/components/documents/batch-document-edit.js
+++ b/app/components/documents/batch-document-edit.js
@@ -17,11 +17,14 @@ class DocumentHistory {
    * Piece until which the document history of the container should be shown
   */
   @tracked lastPiece
+  // Original accessLevel of the document's last piece
+  accessLevel;
 }
 
 export default class DocumentsBatchDocumentEdit extends Component {
   @service store;
   @service fileService;
+  @service pieceAccessLevelService;
 
   @tracked documentHistories = A([]);
 
@@ -103,6 +106,8 @@ export default class DocumentsBatchDocumentEdit extends Component {
       const matchingPiece = allPieces.find((piece) => piece.get('id') === containerPiece.get('id'));
       if (matchingPiece) {
         history.lastPiece = matchingPiece;
+        const accessLevel = yield matchingPiece.accessLevel;
+        history.accessLevel = accessLevel;
         break;
       }
     }
@@ -119,6 +124,9 @@ export default class DocumentsBatchDocumentEdit extends Component {
       } else {
         await history.lastPiece.save();
         await history.documentContainer.save();
+        if (history.accessLevel !== history.lastPiece.accessLevel) {
+          await this.pieceAccessLevelService.updatePreviousAccessLevels(history.lastPiece);
+        }
       }
     });
     yield all(updatePromises);

--- a/app/templates/agenda/agendaitems/agendaitem/documents.hbs
+++ b/app/templates/agenda/agendaitems/agendaitem/documents.hbs
@@ -13,6 +13,7 @@
           <Auk::Button
             data-test-route-agenda---agendaitem-documents-batch-edit
             @icon="pencil"
+            @loading={{this.ensureFreshData.isRunning}}
             {{on "click" this.openBatchDetails}}
           >
             {{t "batch-edit"}}


### PR DESCRIPTION
Ensures that access level changes get propagated to older piece versions when batch editing

This is both the case for editing for agendaitem level documents (agenda > detail > documenten), as well as agenda level documents (agenda > documenten)

Also solves some small issues with the batch editing modal:

-  document name input box is full-width
-  display some indication of loading-state while the ensureFreshData promise is getting resolved