### PR TITLE
KAS-3461 don't copy mandatees or requestedBy for a certain subcase-type when making new subcase

### DIFF
--- a/app/components/cases/new-subcase.js
+++ b/app/components/cases/new-subcase.js
@@ -141,10 +141,12 @@ export default class CasesNewSubcase extends Component {
 
   @action
   async copySubcaseProperties(subcase, latestSubcase, fullCopy, pieces) {
+    const subcaseTypeWithoutMandatees = [CONSTANTS.SUBCASE_TYPES.BEKRACHTIGING].includes(subcase.type?.get('uri'));
     // Everything to copy from latest subcase
-    subcase.mandatees = await latestSubcase.mandatees;
-    subcase.requestedBy = await latestSubcase.requestedBy;
-
+    if (!subcaseTypeWithoutMandatees) {
+      subcase.mandatees = await latestSubcase.mandatees;
+      subcase.requestedBy = await latestSubcase.requestedBy;
+    }
     if (fullCopy) {
       subcase.linkedPieces = await latestSubcase.linkedPieces;
       subcase.subcaseName = latestSubcase.subcaseName;

--- a/app/components/cases/new-subcase.js
+++ b/app/components/cases/new-subcase.js
@@ -141,9 +141,10 @@ export default class CasesNewSubcase extends Component {
 
   @action
   async copySubcaseProperties(subcase, latestSubcase, fullCopy, pieces) {
+    const type = await subcase.type;
     const subcaseTypeWithoutMandatees = [
       CONSTANTS.SUBCASE_TYPES.BEKRACHTIGING,
-    ].includes(subcase.type?.get('uri'));
+    ].includes(type?.uri);
     // Everything to copy from latest subcase
     if (!subcaseTypeWithoutMandatees) {
       subcase.mandatees = await latestSubcase.mandatees;

--- a/app/components/cases/new-subcase.js
+++ b/app/components/cases/new-subcase.js
@@ -141,7 +141,9 @@ export default class CasesNewSubcase extends Component {
 
   @action
   async copySubcaseProperties(subcase, latestSubcase, fullCopy, pieces) {
-    const subcaseTypeWithoutMandatees = [CONSTANTS.SUBCASE_TYPES.BEKRACHTIGING].includes(subcase.type?.get('uri'));
+    const subcaseTypeWithoutMandatees = [
+      CONSTANTS.SUBCASE_TYPES.BEKRACHTIGING,
+    ].includes(subcase.type?.get('uri'));
     // Everything to copy from latest subcase
     if (!subcaseTypeWithoutMandatees) {
       subcase.mandatees = await latestSubcase.mandatees;


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3461

Used the same logic as recent changes to check if we have the "Bekrachtiging" subcase-type.
Used a constant so the if statement would be more readable + future tickets might bring more exclusions rules for copying mandatees (f.e. if they are old).

note: The `get('uri')` is needed because of proxy.


Tested it with:
- no subcase-type selected (mandatees copied)
- other subcase-type selected (mandatees copied)
- bekrachting subcase-type selected (mandatees not copied)
