### PR TITLE
KAS-3437 change translation to avoid confusion

### DIFF
--- a/app/components/subcases/subcase-item.hbs
+++ b/app/components/subcases/subcase-item.hbs
@@ -42,7 +42,7 @@
           </p>
           {{#if @subcase.requestedForMeeting.plannedStart}}
             <p>
-              {{t "on-agenda"}}
+              {{t "on-agenda-for-meeting"}}
               {{moment-format @subcase.requestedForMeeting.plannedStart}}
             </p>
           {{/if}}

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -283,7 +283,7 @@
   "notifications": "Meldingen",
   "number-session": "Nummer vergadering: ",
   "of": "van",
-  "on-agenda": "Geagendeerd",
+  "on-agenda-for-meeting": "Geagendeerd voor de zitting van",
   "on-agenda-of": "Op agenda van",
   "on-agenda-for": "Geagendeerd voor:",
   "other-agenda": "Andere agenda",


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3437

Instead of making a new translation I changed the existing one since it only had 1 use


local result:
![image](https://user-images.githubusercontent.com/22245223/173328876-2ca2669e-85b1-4478-9167-f783abd6ee9c.png)


