### PR TITLE
KAS-3489 add search only on urgent publications option

### DIFF
--- a/app/controllers/search/publication-flows.js
+++ b/app/controllers/search/publication-flows.js
@@ -13,6 +13,9 @@ export default class PublicationFlowSearchController extends Controller {
     publicationStatusIds: {
       type: 'array',
     },
+    urgentOnly: {
+      type: 'boolean',
+    },
     page: {
       type: 'number',
     },
@@ -31,12 +34,14 @@ export default class PublicationFlowSearchController extends Controller {
   @tracked sort;
   @tracked regulationTypeIds = [];
   @tracked publicationStatusIds = [];
+  @tracked urgentOnly;
 
   constructor() {
     super(...arguments);
     this.page = 0;
     this.size = this.sizeOptions[2];
     this.sort = '-opening-date';
+    this.urgentOnly = false;
   }
 
   get selectedRegulationTypes() {
@@ -60,6 +65,11 @@ export default class PublicationFlowSearchController extends Controller {
   @action
   updateSelectedPublicationStatuses(publicationStatuses) {
     this.publicationStatusIds = publicationStatuses.map(ps => ps.id);
+  }
+
+  @action
+  toggleUrgentOnly() {
+    this.urgentOnly = !this.urgentOnly;
   }
 
   @action

--- a/app/routes/search/publication-flows.js
+++ b/app/routes/search/publication-flows.js
@@ -11,6 +11,7 @@ import {
 } from 'frontend-kaleidos/utils/publication-auk';
 import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 import { warn } from '@ember/debug';
+import CONSTANTS from 'frontend-kaleidos/config/constants';
 
 export default class PublicationFlowSearchRoute extends Route {
   @service store;
@@ -25,6 +26,10 @@ export default class PublicationFlowSearchRoute extends Route {
     publicationStatusIds: {
       refreshModel: true,
       as: 'statussen',
+    },
+    urgentOnly: {
+      refreshModel: true,
+      as: 'dringend',
     },
     page: {
       refreshModel: true,
@@ -58,6 +63,10 @@ export default class PublicationFlowSearchRoute extends Route {
       'page[size]': PAGE_SIZE.CODE_LISTS,
       sort: 'position',
     });
+    this.urgencyLevelSpeed = await this.store.findRecordByUri(
+      'urgency-level',
+      CONSTANTS.URGENCY_LEVELS.SPEEDPROCEDURE,
+    );
   }
 
   model(filterParams) {
@@ -109,6 +118,10 @@ export default class PublicationFlowSearchRoute extends Route {
       filter[':terms:statusId'] = params.publicationStatusIds;
     }
 
+    if (params.urgentOnly) {
+      filter[':terms:urgencyLevelId'] = this.urgencyLevelSpeed.id;
+    }
+
     this.lastParams.commit();
 
     return search('publication-flows', params.page, params.size, params.sort, filter, (searchData) => {
@@ -155,6 +168,10 @@ export default class PublicationFlowSearchRoute extends Route {
       attributes.status = status;
       attributes.statusPillKey = getPublicationStatusPillKey(status);
       attributes.statusPillStep = getPublicationStatusPillStep(status);
+    }
+    let urgencyLevelId = attributes.urgencyLevelId;
+    if (urgencyLevelId) {
+      attributes.urgent = urgencyLevelId === this.urgencyLevelSpeed.id;
     }
     // post-process numac numbers
     if (!attributes.numacNumbers) {

--- a/app/routes/search/publication-flows.js
+++ b/app/routes/search/publication-flows.js
@@ -119,7 +119,7 @@ export default class PublicationFlowSearchRoute extends Route {
     }
 
     if (params.urgentOnly) {
-      filter[':terms:urgencyLevelId'] = this.urgencyLevelSpeed.id;
+      filter['urgencyLevelId'] = this.urgencyLevelSpeed.id;
     }
 
     this.lastParams.commit();

--- a/app/templates/search/publication-flows.hbs
+++ b/app/templates/search/publication-flows.hbs
@@ -12,12 +12,19 @@
           @didUpdate={{this.updateSelectedRegulationTypes}}
         />
       </div>
-
-      <Auk::CheckboxTree
-        @label={{t "status"}}
-        @items={{this.publicationStatuses}}
-        @selectedItems={{this.selectedPublicationStatuses}}
-        @didUpdate={{this.updateSelectedPublicationStatuses}}
+      <div class="auk-u-mb-2">
+        <Auk::CheckboxTree
+          @label={{t "status"}}
+          @items={{this.publicationStatuses}}
+          @selectedItems={{this.selectedPublicationStatuses}}
+          @didUpdate={{this.updateSelectedPublicationStatuses}}
+        />
+      </div>
+      <Auk::Checkbox
+        @checked={{this.urgentOnly}}
+        @label={{t "publication-urgent"}}
+        @labelSkin="bold"
+        {{on "input" this.toggleUrgentOnly}}
       />
     </div>
   </div>
@@ -38,6 +45,12 @@
         >
           <table.content as |c|>
             <c.header>
+              <ThSortable
+                @class="auk-table__col--1"
+                @currentSorting={{this.sort}}
+                @field="urgencyLevelId"
+                @label={{t "publication-urgent"}}
+              />
               <ThSortable
                 @class="auk-table__col--1"
                 @currentSorting={{this.sort}}
@@ -63,6 +76,13 @@
               <th class="auk-table__col--1"></th>
             </c.header>
             <c.body class="auk-table--clickable-rows" as |row|>
+              <td>
+                {{#if row.urgent}}
+                  <Auk::Icon @skin="warning" @name="alert-triangle" />
+                {{else}}
+                  {{t "dash"}}
+                {{/if}}
+              </td>
               <td data-test-route-search-publication-row-number>
                 {{row.identification}}
               </td>


### PR DESCRIPTION
# :warning: this PR is mutually exclusive with https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1392 :warning: 
Don't merge both

In this PR, Added the option to search on urgent publications only.

Dependent on https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/292