### PR TITLE
Feature/kas 3489 urgency search both values

### DIFF
--- a/app/controllers/search/publication-flows.js
+++ b/app/controllers/search/publication-flows.js
@@ -13,6 +13,9 @@ export default class PublicationFlowSearchController extends Controller {
     publicationStatusIds: {
       type: 'array',
     },
+    urgencyLevelIds: {
+      type: 'array',
+    },
     page: {
       type: 'number',
     },
@@ -31,6 +34,7 @@ export default class PublicationFlowSearchController extends Controller {
   @tracked sort;
   @tracked regulationTypeIds = [];
   @tracked publicationStatusIds = [];
+  @tracked urgencyLevelIds = [];
 
   constructor() {
     super(...arguments);
@@ -47,6 +51,10 @@ export default class PublicationFlowSearchController extends Controller {
     return this.publicationStatusIds.map((statusId) => this.publicationStatuses.find(status => status.id === statusId));
   }
 
+  get selectedUrgencyLevels() {
+    return this.urgencyLevelIds.map((urgencyLevelId) => this.urgencyLevels.find(urgency => urgency.id === urgencyLevelId));
+  }
+
   @action
   selectSize(size) {
     this.size = size;
@@ -60,6 +68,11 @@ export default class PublicationFlowSearchController extends Controller {
   @action
   updateSelectedPublicationStatuses(publicationStatuses) {
     this.publicationStatusIds = publicationStatuses.map(ps => ps.id);
+  }
+
+  @action
+  updateSelectedUrgencyLevels(urgencyLevels) {
+    this.urgencyLevelIds = urgencyLevels.map(ps => ps.id);
   }
 
   @action

--- a/app/routes/search/publication-flows.js
+++ b/app/routes/search/publication-flows.js
@@ -11,6 +11,7 @@ import {
 } from 'frontend-kaleidos/utils/publication-auk';
 import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 import { warn } from '@ember/debug';
+import CONSTANTS from 'frontend-kaleidos/config/constants';
 
 export default class PublicationFlowSearchRoute extends Route {
   @service store;
@@ -25,6 +26,10 @@ export default class PublicationFlowSearchRoute extends Route {
     publicationStatusIds: {
       refreshModel: true,
       as: 'statussen',
+    },
+    urgencyLevelIds: {
+      refreshModel: true,
+      as: 'dringend',
     },
     page: {
       refreshModel: true,
@@ -58,6 +63,10 @@ export default class PublicationFlowSearchRoute extends Route {
       'page[size]': PAGE_SIZE.CODE_LISTS,
       sort: 'position',
     });
+    this.urgencyLevels = await this.store.query('urgency-level', {
+      'page[size]': PAGE_SIZE.CODE_LISTS,
+      sort: 'position',
+    });
   }
 
   model(filterParams) {
@@ -88,13 +97,16 @@ export default class PublicationFlowSearchRoute extends Route {
      * mu-search(/elastic?) (semtech/mu-search:0.6.0-beta.11, semtech/mu-search-elastic-backend:1.0.0)
      * returns an off-by-one result (1 to many) in case of two open ranges combined.
      */
-    if (!isEmpty(params.date)) {
-      const from = moment(params.date, 'DD-MM-YYYY').startOf('day');
-      const to = moment(params.date, 'DD-MM-YYYY').endOf('day'); // "To" interpreted as inclusive
-      filter[':lte,gte:' + params.publicationDateTypeKey] = [
-        to.utc().toISOString(),
-        from.utc().toISOString(),
-      ].join(',');
+    if (!isEmpty(params.dateFrom) && !isEmpty(params.dateTo)) {
+      const from = moment(params.dateFrom, 'DD-MM-YYYY').startOf('day');
+      const to = moment(params.dateTo, 'DD-MM-YYYY').endOf('day'); // "To" interpreted as inclusive
+      filter[':lte,gte:' + params.publicationDateTypeKey] = [to.utc().toISOString(), from.utc().toISOString()].join(',');
+    } else if (!isEmpty(params.dateFrom)) {
+      const date = moment(params.dateFrom, 'DD-MM-YYYY').startOf('day');
+      filter[':gte:' + params.publicationDateTypeKey] = date.utc().toISOString();
+    } else if (!isEmpty(params.dateTo)) {
+      const date = moment(params.dateTo, 'DD-MM-YYYY').endOf('day'); // "To" interpreted as inclusive
+      filter[':lte:' + params.publicationDateTypeKey] = date.utc().toISOString();
     }
 
     // ":terms:" required to be able to filter on multiple values as "OR"
@@ -104,6 +116,10 @@ export default class PublicationFlowSearchRoute extends Route {
 
     if (!isEmpty(params.publicationStatusIds)) {
       filter[':terms:statusId'] = params.publicationStatusIds;
+    }
+
+    if (!isEmpty(params.urgencyLevelIds)) {
+      filter[':terms:urgencyLevelId'] = params.urgencyLevelIds;
     }
 
     this.lastParams.commit();
@@ -121,6 +137,7 @@ export default class PublicationFlowSearchRoute extends Route {
 
     controller.publicationStatuses = this.publicationStatuses.toArray();
     controller.regulationTypes = this.regulationTypes.toArray();
+    controller.urgencyLevels = this.urgencyLevels.toArray();
 
     if (controller.page !== this.lastParams.committed.page) {
       controller.page = this.lastParams.committed.page;
@@ -152,6 +169,11 @@ export default class PublicationFlowSearchRoute extends Route {
       attributes.status = status;
       attributes.statusPillKey = getPublicationStatusPillKey(status);
       attributes.statusPillStep = getPublicationStatusPillStep(status);
+    }
+    let urgencyLevelId = attributes.urgencyLevelId;
+    if (urgencyLevelId) {
+      const urgencyLevel = this.urgencyLevels.find((urgencyLevel) => urgencyLevel.id === urgencyLevelId);
+      attributes.urgent = urgencyLevel.uri === CONSTANTS.URGENCY_LEVELS.SPEEDPROCEDURE;
     }
     // post-process numac numbers
     if (!attributes.numacNumbers) {

--- a/app/routes/search/publication-flows.js
+++ b/app/routes/search/publication-flows.js
@@ -97,16 +97,13 @@ export default class PublicationFlowSearchRoute extends Route {
      * mu-search(/elastic?) (semtech/mu-search:0.6.0-beta.11, semtech/mu-search-elastic-backend:1.0.0)
      * returns an off-by-one result (1 to many) in case of two open ranges combined.
      */
-    if (!isEmpty(params.dateFrom) && !isEmpty(params.dateTo)) {
-      const from = moment(params.dateFrom, 'DD-MM-YYYY').startOf('day');
-      const to = moment(params.dateTo, 'DD-MM-YYYY').endOf('day'); // "To" interpreted as inclusive
-      filter[':lte,gte:' + params.publicationDateTypeKey] = [to.utc().toISOString(), from.utc().toISOString()].join(',');
-    } else if (!isEmpty(params.dateFrom)) {
-      const date = moment(params.dateFrom, 'DD-MM-YYYY').startOf('day');
-      filter[':gte:' + params.publicationDateTypeKey] = date.utc().toISOString();
-    } else if (!isEmpty(params.dateTo)) {
-      const date = moment(params.dateTo, 'DD-MM-YYYY').endOf('day'); // "To" interpreted as inclusive
-      filter[':lte:' + params.publicationDateTypeKey] = date.utc().toISOString();
+    if (!isEmpty(params.date)) {
+      const from = moment(params.date, 'DD-MM-YYYY').startOf('day');
+      const to = moment(params.date, 'DD-MM-YYYY').endOf('day'); // "To" interpreted as inclusive
+      filter[':lte,gte:' + params.publicationDateTypeKey] = [
+        to.utc().toISOString(),
+        from.utc().toISOString(),
+      ].join(',');
     }
 
     // ":terms:" required to be able to filter on multiple values as "OR"

--- a/app/templates/search/publication-flows.hbs
+++ b/app/templates/search/publication-flows.hbs
@@ -12,12 +12,19 @@
           @didUpdate={{this.updateSelectedRegulationTypes}}
         />
       </div>
-
+      <div class="auk-u-mb-2">
+        <Auk::CheckboxTree
+          @label={{t "status"}}
+          @items={{this.publicationStatuses}}
+          @selectedItems={{this.selectedPublicationStatuses}}
+          @didUpdate={{this.updateSelectedPublicationStatuses}}
+        />
+      </div>
       <Auk::CheckboxTree
-        @label={{t "status"}}
-        @items={{this.publicationStatuses}}
-        @selectedItems={{this.selectedPublicationStatuses}}
-        @didUpdate={{this.updateSelectedPublicationStatuses}}
+        @label={{t "publication-urgent"}}
+        @items={{this.urgencyLevels}}
+        @selectedItems={{this.selectedUrgencyLevels}}
+        @didUpdate={{this.updateSelectedUrgencyLevels}}
       />
     </div>
   </div>
@@ -38,6 +45,12 @@
         >
           <table.content as |c|>
             <c.header>
+              <ThSortable
+                @class="auk-table__col--1"
+                @currentSorting={{this.sort}}
+                @field="urgencyLevelId"
+                @label={{t "publication-urgent"}}
+              />
               <ThSortable
                 @class="auk-table__col--1"
                 @currentSorting={{this.sort}}
@@ -63,6 +76,13 @@
               <th class="auk-table__col--1"></th>
             </c.header>
             <c.body class="auk-table--clickable-rows" as |row|>
+              <td>
+                {{#if row.urgent}}
+                  <Auk::Icon @skin="warning" @name="alert-triangle" />
+                {{else}}
+                  {{t "dash"}}
+                {{/if}}
+              </td>
               <td data-test-route-search-publication-row-number>
                 {{row.identification}}
               </td>


### PR DESCRIPTION
 # :warning: this PR is mutually exclusive with https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1391 :warning: 
Don't merge both

In this PR, added the option to search on urgency-level value
Due to bad data, this option does not work properly without migrations
most data has no `urgency-level` by default, urgent publications have `urgency-level` 'spoedprocedure', very few publications have `urgency-level` "standaard" (when you edit an urgent publication to no longer be urgent, we replace the `urgency-level` instead of deleting it)

This leaves us with 3 states, so searching for `urgency-level` "standaard" will yield far less results then expected

Dependent on https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/292