### PR TITLE
KAS-3495 add transition to publication search for ovrb users

### DIFF
--- a/app/routes/search/index.js
+++ b/app/routes/search/index.js
@@ -5,7 +5,7 @@ export default class IndexSearchRoute extends Route {
   @service currentSession;
   @service router
 
-  beforeModel() {
+  beforeModel(transition) {
     /* It is assumed here that explicitly navigating to the index-route
      * expresses a desire to "reset", to "start a new search-session".
      * Therefore all parameters except filters -such as "type" of agenda-item- are cleared.
@@ -16,15 +16,24 @@ export default class IndexSearchRoute extends Route {
      * of the "search" route, even though the queryParams are marked `refreshModel: true`.
      * As a result "searchTextBuffer" doesn't get cleared.
      */
+    // We have to mention the arrays or we run into the problem that clicking multiple times
+    // results in these arrays being transformed to strings "[]"
     const queryParams = {
       searchText: null,
       mandatees: null,
       dateFrom: null,
       dateTo: null,
       page: 0,
+      regulationTypeIds: [],
+      publicationStatusIds: [],
     }
     // ovrb users get directed to publication search
     if (this.currentSession.isOvrb) {
+      // clicking search route while filters are selected will clear filters but not he checkboxes
+      // This workaround blocks transitions to the same route to prevent this.
+      if (this.router.currentRouteName === 'search.publication-flows') {
+        transition.abort();
+      }
       return this.router.transitionTo('search.publication-flows', {
         queryParams: queryParams,
       });

--- a/app/routes/search/index.js
+++ b/app/routes/search/index.js
@@ -1,6 +1,10 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class IndexSearchRoute extends Route {
+  @service currentSession;
+  @service router
+
   beforeModel() {
     /* It is assumed here that explicitly navigating to the index-route
      * expresses a desire to "reset", to "start a new search-session".
@@ -12,14 +16,21 @@ export default class IndexSearchRoute extends Route {
      * of the "search" route, even though the queryParams are marked `refreshModel: true`.
      * As a result "searchTextBuffer" doesn't get cleared.
      */
-    this.transitionTo('search.agenda-items', {
-      queryParams: {
-        searchText: null,
-        mandatees: null,
-        dateFrom: null,
-        dateTo: null,
-        page: 0,
-      },
+    const queryParams = {
+      searchText: null,
+      mandatees: null,
+      dateFrom: null,
+      dateTo: null,
+      page: 0,
+    }
+    // ovrb users get directed to publication search
+    if (this.currentSession.isOvrb) {
+      return this.router.transitionTo('search.publication-flows', {
+        queryParams: queryParams,
+      });
+    }
+    this.router.transitionTo('search.agenda-items', {
+      queryParams: queryParams,
     });
   }
 }

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -76,7 +76,7 @@ export default class CurrentSessionService extends Service {
   }
 
   get isOvrb() {
-    return [ADMIN, OVRB].includes(this.groupUri);
+    return [OVRB].includes(this.groupUri);
   }
 
   get isOverheid() {


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3495

`isOvrb` was not used anywhere anymore since using roles, so decided to change this to make the conditional logic easier.

If not, we would need to check that the user was `isOvrb` and not also `isAdmin`


