### PR TITLE
KAS-3498 check all government-domains and regulation-types for reports by default

### DIFF
--- a/app/components/publications/overview/reports/generate-report-modal.hbs
+++ b/app/components/publications/overview/reports/generate-report-modal.hbs
@@ -102,8 +102,8 @@
             {{#each this.governmentDomains as |governmentDomain|}}
               <Auk::Checkbox
                 @checked={{includes
-                  this.selectedGovernmentDomains
                   governmentDomain
+                  this.selectedGovernmentDomains
                 }}
                 {{on "input" (fn this.selectGovernmentDomain governmentDomain)}}
               >
@@ -120,8 +120,8 @@
             {{#each this.regulationTypes as |regulationType|}}
               <Auk::Checkbox
                 @checked={{includes
-                  this.selectedRegulationTypes
                   regulationType
+                  this.selectedRegulationTypes
                 }}
                 {{on "input" (fn this.selectRegulationType regulationType)}}
               >

--- a/app/components/publications/overview/reports/generate-report-modal.js
+++ b/app/components/publications/overview/reports/generate-report-modal.js
@@ -241,7 +241,7 @@ export default class GenerateReportModalComponent extends Component {
     });
     this.governmentDomains = governmentDomains.toArray().sortBy('label');
     // everything selected by default
-    this.selectedGovernmentDomains = this.governmentDomains.slice();
+    this.selectedGovernmentDomains = this.governmentDomains.slice(0);
   }
 
   @action
@@ -262,7 +262,7 @@ export default class GenerateReportModalComponent extends Component {
     this.regulationTypes = regulationTypes;
     yield; // for linter
     // everything selected by default
-    this.selectedRegulationTypes = this.regulationTypes.slice();
+    this.selectedRegulationTypes = this.regulationTypes.slice(0);
   }
 
   @action

--- a/app/components/publications/overview/reports/generate-report-modal.js
+++ b/app/components/publications/overview/reports/generate-report-modal.js
@@ -240,6 +240,10 @@ export default class GenerateReportModalComponent extends Component {
       'page[size]': 100,
     });
     this.governmentDomains = governmentDomains.toArray().sortBy('label');
+    // everything selected by default
+    for (const governmentDomain of this.governmentDomains) {
+      this.selectedGovernmentDomains.addObject(governmentDomain)
+    }
   }
 
   @action
@@ -259,6 +263,10 @@ export default class GenerateReportModalComponent extends Component {
     regulationTypes = regulationTypes.sortBy('position');
     this.regulationTypes = regulationTypes;
     yield; // for linter
+    // everything selected by default
+    for (const regulationType of this.regulationTypes) {
+      this.selectedRegulationTypes.addObject(regulationType)
+    }
   }
 
   @action

--- a/app/components/publications/overview/reports/generate-report-modal.js
+++ b/app/components/publications/overview/reports/generate-report-modal.js
@@ -241,9 +241,7 @@ export default class GenerateReportModalComponent extends Component {
     });
     this.governmentDomains = governmentDomains.toArray().sortBy('label');
     // everything selected by default
-    for (const governmentDomain of this.governmentDomains) {
-      this.selectedGovernmentDomains.addObject(governmentDomain)
-    }
+    this.selectedGovernmentDomains = this.governmentDomains.slice();
   }
 
   @action
@@ -264,9 +262,7 @@ export default class GenerateReportModalComponent extends Component {
     this.regulationTypes = regulationTypes;
     yield; // for linter
     // everything selected by default
-    for (const regulationType of this.regulationTypes) {
-      this.selectedRegulationTypes.addObject(regulationType)
-    }
+    this.selectedRegulationTypes = this.regulationTypes.slice();
   }
 
   @action


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3498

The `includes` that were already available in the template were the wrong way round.
Had to swap the values to get it to work (the correct syntax is `includes` itemToCheck listToCheck)
https://github.com/DockYard/ember-composable-helpers#includes

![image](https://user-images.githubusercontent.com/22245223/175324967-90198674-5126-491d-b6bb-c6a8bc83aa86.png)

![image](https://user-images.githubusercontent.com/22245223/175325027-f30d2750-5f03-4343-a89e-e1bc63d8e00f.png)
