### PR TITLE
KAS-3501 change default sort field for late-in-bs tab

### DIFF
--- a/app/components/publications/overview/publications-table-row.hbs
+++ b/app/components/publications/overview/publications-table-row.hbs
@@ -219,7 +219,7 @@ request the whole row and not only the arrow at the end to be clickable }}
       class="auk-u-text-nowrap"
     >
       {{#if @publicationFlow.publicationSubcase.dueDate}}
-        <div class="{{if this.isPublicationOverdue 'auk-u-text-bold'}}">
+        <div>
           {{moment-format @publicationFlow.publicationSubcase.dueDate}}
         </div>
       {{else}}

--- a/app/controllers/publications/overview/late.js
+++ b/app/controllers/publications/overview/late.js
@@ -2,5 +2,5 @@ import PublicationsOverviewBaseController from './_base';
 import { tracked } from '@glimmer/tracking';
 
 export default class PublicationsOverviewLateController extends PublicationsOverviewBaseController {
-  @tracked sort = 'publication-subcase.due-date';
+  @tracked sort = 'publication-subcase.target-end-date';
 }

--- a/app/routes/publications/overview/late.js
+++ b/app/routes/publications/overview/late.js
@@ -18,13 +18,13 @@ export default class PublicationsOverviewLateRoute extends PublicationsOverviewB
         ':id:': pendingStatuses.mapBy('id').join(','),
       },
       'publication-subcase': {
-        // notice: due-date is datetime but appears as a date to the user
+        // notice: target-end-date is datetime but appears as a date to the user
         // If a user enters '2022-02-07', it is saved as '2022-02-06 23:00 UTC'
         // This is interpreted as < 2022-02-08 00:00 Flemish time. => due-datetime + 1 day
-        // We do a (due-date < startOfDay) check. This allows decisions published
+        // We do a (target-end-date < startOfDay) check. This allows decisions published
         // in the course of the day not to be marked as overdue.
         // @see also: `get isOverdue` in publication-subcase
-        ':lt:due-date': getStartOfToday().toISOString(),
+        ':lt:target-end-date': getStartOfToday().toISOString(),
       },
     };
   }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3501

- sort on `target-end-date` instead of `due-date` :heavy_check_mark: 
- keep filtering on "not final", was already the case :white_check_mark: 
- oldest first, was already the case :white_check_mark: 

![image](https://user-images.githubusercontent.com/22245223/175330472-b8d3e5eb-6845-4966-86ea-c9033dce3a1f.png)

