### PR TITLE
KAS-3502 add label for clarifying received date

### DIFF
--- a/app/components/publications/documents/document-card-step.hbs
+++ b/app/components/publications/documents/document-card-step.hbs
@@ -15,6 +15,7 @@
             </h6>
             {{#if @piece.receivedDate}}
               <p class="auk-u-text-muted">
+                {{t "received-at"}}
                 {{moment-format @piece.receivedDate}}
               </p>
             {{/if}}


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3502

ticket suggested "Datum van ontvangst".
To be more inline with similar date labels, opted for existing translation "Ontvangen op".

Will update if suggested change is not ok
