### PR TITLE
KAS-3478: Weergave van (un)numbered lists binnen auk-content

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@ember/test-helpers": "^2.6.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
-    "@kanselarij-vlaanderen/au-kaleidos-css": "2.5.14",
+    "@kanselarij-vlaanderen/au-kaleidos-css": "2.5.15",
     "@kanselarij-vlaanderen/au-kaleidos-icons": "3.0.1",
     "@lblod/ember-acmidm-login": "~1.3.0",
     "@lblod/ember-mock-login": "^0.5.0-beta",


### PR DESCRIPTION
**Ticket binnen Jira:** https://kanselarij.atlassian.net/browse/KAS-3478

Aanpassingen zijn vooral gebeurd binnen `au-kaleidos-css`: https://github.com/kanselarij-vlaanderen/au-kaleidos-css/commit/79cd483e2f4c10efb9014ebc09eba18e90517af5.

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.