### PR TITLE
KAS-2257 use seperate sorting for legacy documents and implement

### DIFF
--- a/app/components/agenda/agenda-overview/agenda-overview-item.js
+++ b/app/components/agenda/agenda-overview/agenda-overview-item.js
@@ -11,6 +11,8 @@ import { sortPieces } from 'frontend-kaleidos/utils/documents';
 import CONFIG from 'frontend-kaleidos/utils/config';
 import VrNotulenName,
 { compareFunction as compareNotulen } from 'frontend-kaleidos/utils/vr-notulen-name';
+import VrLegacyDocumentsName,
+{ compareFunction as compareLegacyDocuments } from 'frontend-kaleidos/utils/vr-legacy-document-name';
 
 export default class AgendaOverviewItem extends AgendaSidebarItem {
   /**
@@ -75,6 +77,8 @@ export default class AgendaOverviewItem extends AgendaSidebarItem {
     let sortedPieces;
     if (this.args.agendaitem.isApproval) {
       sortedPieces = sortPieces(pieces, VrNotulenName, compareNotulen);
+    } else if (this.args.meeting.isPreKaleidos) {
+      sortedPieces = sortPieces(pieces, VrLegacyDocumentsName, compareLegacyDocuments);
     } else {
       sortedPieces = sortPieces(pieces);
     }

--- a/app/components/agenda/agenda-overview/agenda-overview-item.js
+++ b/app/components/agenda/agenda-overview/agenda-overview-item.js
@@ -11,7 +11,7 @@ import { sortPieces } from 'frontend-kaleidos/utils/documents';
 import CONFIG from 'frontend-kaleidos/utils/config';
 import VrNotulenName,
 { compareFunction as compareNotulen } from 'frontend-kaleidos/utils/vr-notulen-name';
-import VrLegacyDocumentsName,
+import VrLegacyDocumentName,
 { compareFunction as compareLegacyDocuments } from 'frontend-kaleidos/utils/vr-legacy-document-name';
 
 export default class AgendaOverviewItem extends AgendaSidebarItem {
@@ -78,7 +78,7 @@ export default class AgendaOverviewItem extends AgendaSidebarItem {
     if (this.args.agendaitem.isApproval) {
       sortedPieces = sortPieces(pieces, VrNotulenName, compareNotulen);
     } else if (this.args.meeting.isPreKaleidos) {
-      sortedPieces = sortPieces(pieces, VrLegacyDocumentsName, compareLegacyDocuments);
+      sortedPieces = sortPieces(pieces, VrLegacyDocumentName, compareLegacyDocuments);
     } else {
       sortedPieces = sortPieces(pieces);
     }

--- a/app/components/subcases/subcase-item.js
+++ b/app/components/subcases/subcase-item.js
@@ -6,6 +6,8 @@ import { task } from 'ember-concurrency';
 import { sortPieces } from 'frontend-kaleidos/utils/documents';
 import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
+import VrLegacyDocumentsName,
+{ compareFunction as compareLegacyDocuments } from 'frontend-kaleidos/utils/vr-legacy-document-name';
 
 export default class SubcaseItemSubcasesComponent extends Component {
   /**
@@ -94,7 +96,11 @@ export default class SubcaseItemSubcasesComponent extends Component {
       pieces.push(...submissionPieces);
     }
 
-    this.subcaseDocuments = sortPieces(pieces);
+    if (this.args.subcase?.requestedForMeeting.get('isPreKaleidos')) {
+      this.subcaseDocuments = sortPieces(pieces, VrLegacyDocumentsName, compareLegacyDocuments);
+    } else {
+      this.subcaseDocuments = sortPieces(pieces);
+    }
   }
 
   @task

--- a/app/components/subcases/subcase-item.js
+++ b/app/components/subcases/subcase-item.js
@@ -96,7 +96,8 @@ export default class SubcaseItemSubcasesComponent extends Component {
       pieces.push(...submissionPieces);
     }
 
-    if (this.args.subcase?.requestedForMeeting.get('isPreKaleidos')) {
+    const meeting = yield this.args.subcase?.requestedForMeeting;
+    if (meeting?.isPreKaleidos) {
       this.subcaseDocuments = sortPieces(pieces, VrLegacyDocumentName, compareLegacyDocuments);
     } else {
       this.subcaseDocuments = sortPieces(pieces);

--- a/app/components/subcases/subcase-item.js
+++ b/app/components/subcases/subcase-item.js
@@ -6,7 +6,7 @@ import { task } from 'ember-concurrency';
 import { sortPieces } from 'frontend-kaleidos/utils/documents';
 import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
-import VrLegacyDocumentsName,
+import VrLegacyDocumentName,
 { compareFunction as compareLegacyDocuments } from 'frontend-kaleidos/utils/vr-legacy-document-name';
 
 export default class SubcaseItemSubcasesComponent extends Component {
@@ -97,7 +97,7 @@ export default class SubcaseItemSubcasesComponent extends Component {
     }
 
     if (this.args.subcase?.requestedForMeeting.get('isPreKaleidos')) {
-      this.subcaseDocuments = sortPieces(pieces, VrLegacyDocumentsName, compareLegacyDocuments);
+      this.subcaseDocuments = sortPieces(pieces, VrLegacyDocumentName, compareLegacyDocuments);
     } else {
       this.subcaseDocuments = sortPieces(pieces);
     }

--- a/app/routes/agenda/agendaitems/agendaitem/documents.js
+++ b/app/routes/agenda/agendaitems/agendaitem/documents.js
@@ -7,7 +7,7 @@ import { sortPieces } from 'frontend-kaleidos/utils/documents';
 import VrNotulenName, {
   compareFunction as compareNotulen,
 } from 'frontend-kaleidos/utils/vr-notulen-name';
-import VrLegacyDocumentsName,
+import VrLegacyDocumentName,
 { compareFunction as compareLegacyDocuments } from 'frontend-kaleidos/utils/vr-legacy-document-name';
 
 export default class DocumentsAgendaitemAgendaitemsAgendaRoute extends Route {
@@ -27,7 +27,7 @@ export default class DocumentsAgendaitemAgendaitemsAgendaRoute extends Route {
     if (agendaitem.isApproval) {
       sortedPieces = sortPieces(pieces, VrNotulenName, compareNotulen);
     } else if (meeting.isPreKaleidos) {
-      sortedPieces = sortPieces(pieces, VrLegacyDocumentsName, compareLegacyDocuments);
+      sortedPieces = sortPieces(pieces, VrLegacyDocumentName, compareLegacyDocuments);
     } else {
       sortedPieces = sortPieces(pieces);
     }

--- a/app/routes/agenda/agendaitems/agendaitem/documents.js
+++ b/app/routes/agenda/agendaitems/agendaitem/documents.js
@@ -7,6 +7,8 @@ import { sortPieces } from 'frontend-kaleidos/utils/documents';
 import VrNotulenName, {
   compareFunction as compareNotulen,
 } from 'frontend-kaleidos/utils/vr-notulen-name';
+import VrLegacyDocumentsName,
+{ compareFunction as compareLegacyDocuments } from 'frontend-kaleidos/utils/vr-legacy-document-name';
 
 export default class DocumentsAgendaitemAgendaitemsAgendaRoute extends Route {
   @service store;
@@ -21,8 +23,11 @@ export default class DocumentsAgendaitemAgendaitemsAgendaRoute extends Route {
     });
     pieces = pieces.toArray();
     let sortedPieces;
+    const meeting = this.modelFor('agenda').meeting;
     if (agendaitem.isApproval) {
       sortedPieces = sortPieces(pieces, VrNotulenName, compareNotulen);
+    } else if (meeting.isPreKaleidos) {
+      sortedPieces = sortPieces(pieces, VrLegacyDocumentsName, compareLegacyDocuments);
     } else {
       sortedPieces = sortPieces(pieces);
     }

--- a/app/routes/cases/case/subcases/subcase/documents.js
+++ b/app/routes/cases/case/subcases/subcase/documents.js
@@ -4,6 +4,8 @@ import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { sortPieces } from 'frontend-kaleidos/utils/documents';
+import VrLegacyDocumentsName,
+{ compareFunction as compareLegacyDocuments } from 'frontend-kaleidos/utils/vr-legacy-document-name';
 
 export default class DocumentsSubcaseSubcasesRoute extends Route {
   @service store;
@@ -25,7 +27,14 @@ export default class DocumentsSubcaseSubcasesRoute extends Route {
       pieces.push(...submissionPieces);
     }
 
-    const sortedPieces = sortPieces(pieces);
+    let sortedPieces;
+    const meeting = await subcase.requestedForMeeting;
+    if (meeting?.isPreKaleidos) {
+      sortedPieces = sortPieces(pieces, VrLegacyDocumentsName, compareLegacyDocuments);
+    } else {
+      sortedPieces = sortPieces(pieces);
+    }
+
     return {
       pieces: sortedPieces,
       // linkedPieces: this.modelFor('cases.case.subcases.subcase').get('linkedPieces')

--- a/app/routes/cases/case/subcases/subcase/documents.js
+++ b/app/routes/cases/case/subcases/subcase/documents.js
@@ -4,7 +4,7 @@ import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { sortPieces } from 'frontend-kaleidos/utils/documents';
-import VrLegacyDocumentsName,
+import VrLegacyDocumentName,
 { compareFunction as compareLegacyDocuments } from 'frontend-kaleidos/utils/vr-legacy-document-name';
 
 export default class DocumentsSubcaseSubcasesRoute extends Route {
@@ -30,7 +30,7 @@ export default class DocumentsSubcaseSubcasesRoute extends Route {
     let sortedPieces;
     const meeting = await subcase.requestedForMeeting;
     if (meeting?.isPreKaleidos) {
-      sortedPieces = sortPieces(pieces, VrLegacyDocumentsName, compareLegacyDocuments);
+      sortedPieces = sortPieces(pieces, VrLegacyDocumentName, compareLegacyDocuments);
     } else {
       sortedPieces = sortPieces(pieces);
     }

--- a/app/utils/vr-legacy-document-name.js
+++ b/app/utils/vr-legacy-document-name.js
@@ -1,0 +1,111 @@
+import CONFIG from 'frontend-kaleidos/utils/config';
+import moment from 'moment';
+
+export default class VRDocumentName {
+  static get regexGroups() {
+    return Object.freeze({
+      date: '(?<date>[12][90][0-9]{2} [0-3][0-9][01][0-9])',
+      casePrefix: '(?<casePrefix>( VV)|())',  // VV = Vlaamse Veerkracht
+      docType: '(?<docType>(DOC)|(DEC)|(MED))',
+      caseNr: '(?<caseNr>\\d{4})',
+      index: '(?<index>\\d{1,3})',
+      versionSuffix: `(?<versionSuffix>(${Object.values(CONFIG.latinAdverbialNumberals).map((suffix) => suffix.toUpperCase())
+        .join(')|(')}))`.replace('()|', ''), // Hack to get out the value for piece '0'
+    });
+  }
+
+  static get looseRegex() {
+    const regexGroup = VRDocumentName.regexGroups;
+    return new RegExp(`VR ${regexGroup.date}${regexGroup.casePrefix} ${regexGroup.docType}\\.${regexGroup.caseNr}([/-]${regexGroup.index})?(.*?)${regexGroup.versionSuffix}?$`);
+  }
+
+  static get strictRegex() {
+    const regexGroup = VRDocumentName.regexGroups;
+    return new RegExp(`^VR ${regexGroup.date}${regexGroup.casePrefix} ${regexGroup.docType}\\.${regexGroup.caseNr}(/${regexGroup.index})?${regexGroup.versionSuffix}?$`);
+  }
+
+  constructor(name, options) {
+    this.name = name;
+    this.strict = !!options && !!options.strict;
+    if (this.strict && !this.isValid) {
+      throw new Error(`Invalid VR Document Name "${this.name}" (strict mode)`);
+    }
+  }
+
+  toString() {
+    return this.name;
+  }
+
+  get regex() {
+    return this.strict ? VRDocumentName.strictRegex : VRDocumentName.looseRegex;
+  }
+
+  parseMeta() {
+    const match = this.regex.exec(this.name);
+    if (!match) {
+      throw new Error(`Couldn't parse VR Document Name "${this.name}" (${this.strict ? 'strict' : 'loose'} parsing mode)`);
+    }
+    const versionSuffix = match.groups.versionSuffix;
+    let versionNumber = 1;
+    if (versionSuffix) {
+      versionNumber = CONFIG.numbersBylatinAdverbialNumberals[versionSuffix.toLowerCase()];
+    }
+    const meta = {
+      date: moment(match.groups.date, 'YYYY DDMM').toDate(), // TODO set moment "strict" parsing to true + throw error when "Invalid date"
+      casePrefix: match.groups.casePrefix,
+      docType: match.groups.docType,
+      caseNr: parseInt(match.groups.caseNr, 10),
+      index: parseInt(match.groups.index || 1, 10),
+      versionSuffix,
+      versionNumber,
+    };
+    return meta;
+  }
+
+  // TODO: Mag misschien weg?
+  // Will only be needed by backend renaming service
+  // static fromMeta (meta) {
+  //   const date = meta.date || Date();
+  //   const docType = meta.docType || 'DOC';
+  //   const caseNr = meta.caseNr.padStart(4, '0');
+  //   const index = meta.index.toString();
+  //   const pieceNr = meta.pieceNr || 1;
+  //   const formattedDate = moment(date).format('YYYY DDMM');
+  //
+  //   return VRDocumentName(`VR ${formattedDate} ${docType}.${caseNr}/${index}${this.pieceSuffixes[pieceNr]}`);
+  // }
+
+  get isValid() {
+    return VRDocumentName.strictRegex.test(this.name);
+  }
+
+  get withoutVersionSuffix() {
+    return this.name.replace(new RegExp(`${VRDocumentName.regexGroups.versionSuffix}$`, 'ui'), '');
+  }
+
+  withOtherVersionSuffix(pieceNr) {
+    return `${this.withoutVersionSuffix}${CONFIG.latinAdverbialNumberals[pieceNr].toUpperCase()}`;
+  }
+}
+
+export const compareFunction = function(parameterA, parameterB) {
+  try {
+    const metaA = parameterA.parseMeta();
+    try { // Both names parse
+      const metaB = parameterB.parseMeta();
+      return (metaB.caseNr - metaA.caseNr) // Case number descending (newest first)
+        || (metaA.index - metaB.index) // Index ascending
+        || (metaB.date - metaA.date) // Date descending (newest first)
+        || (metaA.versionNumber - metaB.versionNumber); // versionNumber ascending (newest last)
+    } catch { // Only a parses
+      return -1;
+    }
+  } catch {
+    try { // Only b parses
+      parameterB.parseMeta();
+      return 1;
+    } catch { // Both don't parse
+      return parameterA.name.localeCompare(parameterB.name);
+    }
+  }
+};


### PR DESCRIPTION
Ticket https://kanselarij.atlassian.net/browse/KAS-2257

In commentaar staat:

>Het ticket gaat nu nog enkel om volgende : aanpassen van de sortering van documenten 
Van:
VR 2005 2207 DOC.0695/2
VR 2005 2207 DOC.0695
VR 2005 2207 DOC.0695/1
Naar:
VR 2005 2207 DOC.0695
VR 2005 2207 DOC.0695/1
VR 2005 2207 DOC.0695/2
De sortering op de legacy data (voor 9/10/2019) mag die van daarna niet affecteren. 

Ik had deze commentaar pas gelezen na dat ik aanpassingen had gemaakt en getest.
Maar ik heb dit probleem + een deel van het BIS/TER sortering probleem aangepakt wat eigenlijk niet moest.

Het sorteren op nummer zonder de `/0` opgelost door de `index` van de `meta` 0 te maken ipv `NaN`
Het sorteren op nummer en nummerBIS, opgelost door de `version` parsing van de `meta` om te draaien, maar niet in document-Card (de lijst geschiedenis met een echte BIS zou anders verkeerd zijn).

Toegepast in views:
Agendapunt overzicht
Agendapunt detail documenten view
Procedurestap documenten view
Procedurestap overzicht "toon documenten" view.

Niet toegepast op document-card/ document-list omdat de sortering van de document kaartjes op de route zit. De sortering in  `documents::documentslist` is voor stukken van 1 container te sorteren. (was gevraagd in ticket, maar niet correct)

Enkel toegepast op agendapunten/procedurestappen van vergadering vóór start kaleidos (met waarde uit de config)

### voorbeeld van sortering op legacy met nieuwe code (zittingen voor 01/10/2019):
Agendapunt overzicht:
![image](https://user-images.githubusercontent.com/22245223/178005596-de7a0651-328b-478a-bc01-fb7682a97118.png)
Agendapunt detail documenten
![image](https://user-images.githubusercontent.com/22245223/178005873-e6724d8b-498f-4a40-8c1e-a59674081d39.png)
Procedurestap
![image](https://user-images.githubusercontent.com/22245223/178005989-ec568e54-9188-4731-89b8-f5a909123f4a.png)
Procedurestap overzicht
![image](https://user-images.githubusercontent.com/22245223/178006069-948b2bef-c7f5-439b-9378-c7141d84ab24.png)


### ter referentie: Zelfde documenten maar met de huidige sortering (legacy niet toegepast)
![image](https://user-images.githubusercontent.com/22245223/178006958-387b14fa-8a40-4df9-9e7c-c2231523a6a4.png)
![image](https://user-images.githubusercontent.com/22245223/178007039-4e94c0ff-d7f2-4eb8-9b50-f314e29f53a2.png)
![image](https://user-images.githubusercontent.com/22245223/178007155-b206a11f-9bd0-40a1-9aa8-40d5af310a3b.png)
![image](https://user-images.githubusercontent.com/22245223/178007099-b557c983-622f-43da-97bd-778681f31e3c.png)


Schermen dat niet aangegeven zijn in ticket:
bulk wijzigen op agendapunten
Dit zit goed zonder extra aanpassingen omdat de sortering meekomt van de route.
![image](https://user-images.githubusercontent.com/22245223/178007607-d90feaa6-2f28-4780-aad6-494984d609d3.png)

bulk wijzigen procedurestap
Deze zit niet goed, maar is ook niet gevraagd.
Komt door gebruik van `<Documents::BatchDocumentEdit>` ipv `<Documents::BatchDetails::BatchDocumentsDetailsModal>`
Die eerste gebruikt een andere manier van sorteren (`sortDocumentContainers` ipv `sortPieces`).
Mogelijk makkelijker om gewoon de andere component te gebruiken ipv hier ook een 99% copy van te maken puur voor legacy?
![image](https://user-images.githubusercontent.com/22245223/178008133-3f6d78b7-ad66-40f8-9310-9d82f3fc1064.png)






