### PR TITLE
implement small delay right after test login to ensure data is loaded

### DIFF
--- a/cypress/integration/unit/search-other-spec-data.spec.js
+++ b/cypress/integration/unit/search-other-spec-data.spec.js
@@ -15,6 +15,7 @@ context('Search tests', () => {
 
   it('Search for title in kort-bestek and open the detail view by clicking icon', () => {
     cy.visit('/zoeken/kort-bestek');
+    cy.wait(1500); // TODO-bug flakyness on this page, maybe cypress is too fast??
     // ! depends on mandatee-assigning.spec and could fail
     const searchTerm = 'assign mandatee';
     cy.get(route.search.input).clear();

--- a/cypress/support/commands/authorizationAuthentication.commands.js
+++ b/cypress/support/commands/authorizationAuthentication.commands.js
@@ -39,6 +39,8 @@ function login(name, retries = 0) {
   });
   cy.intercept('GET', '/accounts/*').as('getAccount');
   cy.intercept('GET', '/accounts/*/user').as('getAccountUser');
+  cy.intercept('GET', '/concepts?filter**').as('loadConcepts');
+  cy.intercept('GET', '/agendas?filter**').as('loadAgendasRoute');
   cy.visit('/overzicht?size=2').wait('@getCurrentSession')
     .then((responseBody) => {
       console.log(responseBody);
@@ -52,6 +54,7 @@ function login(name, retries = 0) {
       }
     });
   cy.wait('@getAccount').wait('@getAccountUser');
+  cy.wait('@loadConcepts').wait('@loadAgendasRoute');
   cy.log('/login');
 }
 

--- a/cypress/support/commands/authorizationAuthentication.commands.js
+++ b/cypress/support/commands/authorizationAuthentication.commands.js
@@ -40,7 +40,6 @@ function login(name, retries = 0) {
   cy.intercept('GET', '/accounts/*').as('getAccount');
   cy.intercept('GET', '/accounts/*/user').as('getAccountUser');
   cy.intercept('GET', '/concepts?filter**').as('loadConcepts');
-  cy.intercept('GET', '/agendas?filter**').as('loadAgendasRoute');
   cy.visit('/overzicht?size=2').wait('@getCurrentSession')
     .then((responseBody) => {
       console.log(responseBody);
@@ -54,7 +53,7 @@ function login(name, retries = 0) {
       }
     });
   cy.wait('@getAccount').wait('@getAccountUser');
-  cy.wait('@loadConcepts').wait('@loadAgendasRoute');
+  cy.wait('@loadConcepts');
   cy.log('/login');
 }
 


### PR DESCRIPTION
active bug where fast switches means entering a route with wrong queryparams is giving test flakyness.
Overall it shouldn't take that much extra time to wait for that data to load