### PR TITLE
KAS-3448 publication overview performance

### DIFF
--- a/app/routes/publications/overview/_base.js
+++ b/app/routes/publications/overview/_base.js
@@ -17,8 +17,7 @@ export default class PublicationsOverviewBaseRoute extends Route {
   tableConfigStorageKey;
 
   tableConfig;
-  includes;
-  filter;
+  filter; // set in subclasses
 
   queryParams = {
     page: {
@@ -41,22 +40,6 @@ export default class PublicationsOverviewBaseRoute extends Route {
     if (!this.tableConfig.visibleColumns.length) {
       this.tableConfig.loadDefault();
     }
-
-    // determine which included data the visible columns require
-    let requiredFieldPaths = [];
-    for (const column of Object.values(this.tableConfig.visibleColumns)) {
-      requiredFieldPaths = requiredFieldPaths.concat(column.apiFieldPaths);
-    }
-    // Filter for field-paths that are more than 1 hop away, thus requiring an include
-    const pathsRequiringInclude = requiredFieldPaths.filter((path) => {
-      return path.includes('.');
-    }).map((path) => {
-      return path.split('.').slice(0, -1).join('.');
-    });
-
-    const uniqueIncludes = [...new Set(pathsRequiringInclude)];
-    // Sort includes to increase cache-hit chances
-    this.includes = uniqueIncludes.sort();
   }
 
   model(params) {
@@ -68,9 +51,6 @@ export default class PublicationsOverviewBaseRoute extends Route {
         size: params.size,
       },
     };
-    if (this.includes.length) {
-      queryParams.include = this.includes.join(',');
-    }
     return this.store.query('publication-flow', queryParams);
   }
 

--- a/app/routes/publications/overview/late.js
+++ b/app/routes/publications/overview/late.js
@@ -14,7 +14,7 @@ export default class PublicationsOverviewLateRoute extends PublicationsOverviewB
   tableConfigStorageKey = "publication-table.all";
 
   beforeModel() {
-    super.beforeModel(...arguments)
+    super.beforeModel(...arguments);
     const pendingStatuses = this.store.peekAll('publication-status').rejectBy('isFinal');
     this.filter = {
       status: {

--- a/app/routes/publications/overview/proof.js
+++ b/app/routes/publications/overview/proof.js
@@ -22,7 +22,7 @@ export default class PublicationsOverviewProofRoute extends PublicationsOverview
   tableConfigStorageKey = "publication-table.proof";
 
   beforeModel() {
-    super.beforeModel(...arguments)
+    super.beforeModel(...arguments);
     const proofStatuses = this.store.peekAll('publication-status').filter((it) => {
       return PROOF_STATUSES_URIS.includes(it.uri);
     });

--- a/app/routes/publications/overview/proofread.js
+++ b/app/routes/publications/overview/proofread.js
@@ -23,7 +23,7 @@ export default class PublicationsOverviewProofreadRoute extends PublicationsOver
   tableConfigStorageKey = "publication-table.proofread";
 
   beforeModel() {
-    super.beforeModel(...arguments)
+    super.beforeModel(...arguments);
     const proofreadStatuses = this.store.peekAll('publication-status').filter((it) => {
       return PROOFREAD_STATUSES_URIS.includes(it.uri);
     });

--- a/app/routes/publications/overview/reports.js
+++ b/app/routes/publications/overview/reports.js
@@ -20,14 +20,14 @@ export default class PublicationsOverviewReportsRoute extends Route {
     reportTypes = reportTypes.toArray();
 
     if (reportTypes.length !== REPORT_TYPES_CONFIG.length) {
-      console.error('incorrect number of report types configured')
+      console.error('incorrect number of report types configured');
     }
 
     // configuration order determines order in UI
     const reportTypeEntries = REPORT_TYPES_CONFIG.map(async (reportTypeConfig) => {
       const reportType = reportTypes.findBy('uri', reportTypeConfig.uri);
       if (!reportType) {
-        console.error('report type config uri does not exist')
+        console.error('report type config uri does not exist');
       }
 
       const lastJob = await this.store.queryOne(

--- a/app/routes/publications/overview/translation.js
+++ b/app/routes/publications/overview/translation.js
@@ -14,7 +14,7 @@ export default class PublicationsOverviewTranslationRoute extends PublicationsOv
   tableConfigStorageKey = "publication-table.translation";
 
   beforeModel() {
-    super.beforeModel(...arguments)
+    super.beforeModel(...arguments);
     this.filter = {
       status: {
         ':uri:': CONSTANTS.PUBLICATION_STATUSES.TRANSLATION_REQUESTED,


### PR DESCRIPTION
Remove include from request to get list of publication-flows to improve performance. Related data will be sideloaded through separate requests. 

With this approach requests will hit the cache more often since the application sends the same requests for each user, independently of their visible columns configuration.

First render of the data table now happens within 2s-3s with a cold cache.

Also tested an additional filter on `opening-date` (publications of last 30, 60, 120 days only) to limit the total number of results, but duration remains in the same order of magnitude.