### PR TITLE
KAS-3433: Hotfix for pill colours and when to show them

### DIFF
--- a/app/components/agenda/agenda-header/publication-pills.hbs
+++ b/app/components/agenda/agenda-header/publication-pills.hbs
@@ -3,36 +3,31 @@
     {{#if this.mayManageDecisionPublications}}
       {{#if @meeting.internalDecisionPublicationActivity.startDate}}
         <AuPill @skin="success" @icon="check" class="auk-u-mr-2 auk-u-mt-2">
-          Beslissingen zijn vrijgegeven op
-          {{moment-format @meeting.internalDecisionPublicationActivity.startDate "DD-MM-YYYY"}}
-          om
-          {{moment-format @meeting.internalDecisionPublicationActivity.startDate "HH:mm"}}
-        </AuPill>
-      {{else}}
-        <AuPill @skin="default" @icon="circle-info" class="auk-u-mr-2 auk-u-mt-2">
-          Beslissingen zijn nog niet vrijgegeven
+          {{t
+            "decisions-were-released-at"
+            date=(moment-format @meeting.internalDecisionPublicationActivity.startDate "DD-MM-YYYY")
+            time=(moment-format @meeting.internalDecisionPublicationActivity.startDate "HH:mm")
+          }}
         </AuPill>
       {{/if}}
     {{/if}}
     {{#if this.mayManageDocumentPublications}}
       {{#if @meeting.internalDocumentPublicationActivity.startDate}}
         <AuPill @skin="success" @icon="check" class="auk-u-mr-2 auk-u-mt-2">
-          Documenten zijn vrijgegeven op
-          {{moment-format @meeting.internalDocumentPublicationActivity.plannedDate "DD-MM-YYYY"}}
-          om
-          {{moment-format @meeting.internalDocumentPublicationActivity.plannedDate "HH:mm"}}
+          {{t
+            "documents-were-released-at"
+            date=(moment-format @meeting.internalDocumentPublicationActivity.plannedDate "DD-MM-YYYY")
+            time=(moment-format @meeting.internalDocumentPublicationActivity.plannedDate "HH:mm")
+          }}
         </AuPill>
       {{else}}
         {{#if this.isConfirmedDocumentPublicationPlanning}}
-          <AuPill @skin="warning" @icon="clock" class="auk-u-mr-2 auk-u-mt-2">
-            Vrijgave documenten gepland op
-            {{moment-format @meeting.internalDocumentPublicationActivity.plannedDate "DD-MM-YYYY"}}
-            om
-            {{moment-format @meeting.internalDocumentPublicationActivity.plannedDate "HH:mm"}}
-          </AuPill>
-        {{else}}
-          <AuPill @skin="default" @icon="circle-info" class="auk-u-mr-2 auk-u-mt-2">
-            Documenten zijn nog niet vrijgegeven
+          <AuPill @skin="default" @icon="clock" class="auk-u-mr-2 auk-u-mt-2">
+            {{t
+              "documents-are-planned-to-release-at"
+               date=(moment-format @meeting.internalDocumentPublicationActivity.plannedDate "DD-MM-YYYY")
+               time=(moment-format @meeting.internalDocumentPublicationActivity.plannedDate "HH:mm")
+            }}
           </AuPill>
         {{/if}}
       {{/if}}
@@ -40,22 +35,19 @@
     {{#if this.mayManageThemisPublications}}
       {{#if (and this.isReleasedThemisPublicationActivity this.themisPublicationIncludesDocuments)}}
         <AuPill @skin="success" @icon="check" class="auk-u-mr-2 auk-u-mt-2">
-          Documenten zijn gepubliceerd op
-          {{moment-format this.latestThemisPublicationActivity.plannedDate "DD-MM-YYYY"}}
-          om
-          {{moment-format this.latestThemisPublicationActivity.plannedDate "HH:mm"}}
+          {{t
+            "documents-were-published-at"
+            date=(moment-format this.latestThemisPublicationActivity.plannedDate "DD-MM-YYYY")
+            time=(moment-format this.latestThemisPublicationActivity.plannedDate "HH:mm")
+          }}
         </AuPill>
       {{else if this.isConfirmedThemisPublicationActivity}}
-        <AuPill @skin="warning" @icon="clock" class="auk-u-mr-2 auk-u-mt-2">
-          Publicatie documenten gepland op
-          {{moment-format this.latestThemisPublicationActivity.plannedDate "DD-MM-YYYY"}}
-          om
-          {{moment-format this.latestThemisPublicationActivity.plannedDate "HH:mm"}}
-        </AuPill>
-      {{else}}
-        {{! It's either the first publication that still needs to be confirmed or the latest publication is a retraction of documents}}
-        <AuPill @skin="default" @icon="circle-info" class="auk-u-mr-2 auk-u-mt-2">
-          Documenten zijn nog niet gepubliceerd
+        <AuPill @skin="default" @icon="clock" class="auk-u-mr-2 auk-u-mt-2">
+          {{t
+            "documents-are-planned-to-release-at"
+            date=(moment-format this.latestThemisPublicationActivity.plannedDate "DD-MM-YYYY")
+            time=(moment-format this.latestThemisPublicationActivity.plannedDate "HH:mm")
+          }}
         </AuPill>
       {{/if}}
     {{/if}}

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1053,5 +1053,10 @@
   "open-search-for-mandatee": "Vrij zoeken",
   "open-search-for-mandatee-tooltip": "Opgelet. Activeer deze optie enkel indien strikt noodzakelijk. In tegenstelling tot bij standaard zoeken, kunnen de aangeboden resultaten bij vrij zoeken ook ministers bevatten die niet actief zijn/waren gedurende de referentieperiode waarvoor u zoekt. Deze functionaliteit kan bv. gebruikt worden om net-niet-meer actieve ministers (rond een ministerwissel) toe te wijzen. ",
   "fullscreen": "Volledig scherm",
-  "close-fullscreen": "Sluit volledig scherm"
+  "close-fullscreen": "Sluit volledig scherm",
+  "decisions-were-released-at": "Beslissingen zijn vrijgegeven op {date} om {time}",
+  "documents-were-released-at": "Documenten zijn vrijgegeven op {date} om {time}",
+  "documents-are-planned-to-release-at": "Vrijgave van documenten gepland op {date} om {time}",
+  "documents-were-published-at": "Documenten zijn gepubliceerd op {date} om {time}",
+  "documents-are-planned-to-release-at": "Publicatie documenten gepland op {date} om {time}"
 }


### PR DESCRIPTION
- Don't display pills for "not happened yet" cases (e.g. "Beslissingen zijn nog niet vrijgegeven" -> don't show a pill instead of showing a white pill)
- Planned at pills are white instead of yellow

The rest of the behaviour was okay and remains unchanged.

Commit should also be mergeable to development