### PR TITLE
used the get('uri') to check the current document release status instead of the whole concept object

### DIFF
--- a/app/components/agenda/agenda-overview/agenda-overview-item.js
+++ b/app/components/agenda/agenda-overview/agenda-overview-item.js
@@ -76,7 +76,7 @@ export default class AgendaOverviewItem extends AgendaSidebarItem {
     if (this.currentSession.isOverheid) {
       const documentPublicationActivity = yield this.args.meeting.internalDocumentPublicationActivity;
       const documentPublicationStatus = yield documentPublicationActivity.status;
-      this.documentsAreVisible = documentPublicationStatus == CONSTANTS.RELEASE_STATUSES.RELEASED;
+      this.documentsAreVisible = documentPublicationStatus.get('uri') == CONSTANTS.RELEASE_STATUSES.RELEASED;
     } else {
       this.documentsAreVisible = true;
     }

--- a/app/routes/agenda/agendaitems/agendaitem/documents.js
+++ b/app/routes/agenda/agendaitems/agendaitem/documents.js
@@ -58,7 +58,7 @@ export default class DocumentsAgendaitemAgendaitemsAgendaRoute extends Route {
     if (this.currentSession.isOverheid) {
       const documentPublicationActivity = await this.meeting.internalDocumentPublicationActivity;
       const documentPublicationStatus = await documentPublicationActivity.status;
-      this.documentsAreVisible = documentPublicationStatus == CONSTANTS.RELEASE_STATUSES.RELEASED;
+      this.documentsAreVisible = documentPublicationStatus.get('uri') == CONSTANTS.RELEASE_STATUSES.RELEASED;
     } else {
       this.documentsAreVisible = true;
     }

--- a/app/routes/cases/case/subcases/subcase/documents.js
+++ b/app/routes/cases/case/subcases/subcase/documents.js
@@ -56,7 +56,7 @@ export default class DocumentsSubcaseSubcasesRoute extends Route {
     if (this.currentSession.isOverheid) {
       const documentPublicationActivity = await this.meeting.internalDocumentPublicationActivity;
       const documentPublicationStatus = await documentPublicationActivity.status;
-      this.documentsAreVisible = documentPublicationStatus == CONSTANTS.RELEASE_STATUSES.RELEASED;
+      this.documentsAreVisible = documentPublicationStatus.get('uri') == CONSTANTS.RELEASE_STATUSES.RELEASED;
     } else {
       this.documentsAreVisible = true;
     }


### PR DESCRIPTION
This caused the document list to be empty when it wasn't supposed to be. Simple fix, the whole object was compared to a URI constant instead of the uri property.