### PR TITLE
KAS-3482: Search on agendaitem pieces

### DIFF
--- a/app/routes/agenda/agendaitems.js
+++ b/app/routes/agenda/agendaitems.js
@@ -69,7 +69,7 @@ export default class AgendaAgendaitemsRoute extends Route {
 
     if (params.filter) {
       const filter = {
-        ':phrase_prefix:title,shortTitle': `${params.filter}`,
+        ':phrase_prefix:title,shortTitle,pieceNames': `${params.filter}`,
         meetingId: meeting.id,
         agendaId: agenda.id,
       };


### PR DESCRIPTION
https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/304

Users can now filter on the agendaitem title, subtitle, and its pieces' name.

Jenkins run: http://kal-kastaar.s.redpencil.io:8080/job/kaleidos/job/custom_frontend_backend_combination/266/