### PR TITLE
KAS-3524 change setting mailcampaign inverse on meeting

### DIFF
--- a/app/components/newsletter/newsletter-header-overview.js
+++ b/app/components/newsletter/newsletter-header-overview.js
@@ -224,19 +224,12 @@ export default class NewsletterHeaderOverviewComponent extends Component {
 
   @task
   *deleteCampaign() {
-    const meeting = this.args.meeting;
-
     if (this.mailCampaign?.campaignId) {
       yield this.newsletterService.deleteCampaign(this.mailCampaign.campaignId);
       this.toaster.success(this.intl.t('success-delete-newsletter'));
     }
     this.mailCampaign.destroyRecord();
-    const reloadedMeeting = yield this.store.findRecord('meeting', meeting.id, {
-      reload: true,
-    });
-    reloadedMeeting.mailCampaign = null;
-
-    yield reloadedMeeting.save();
+    yield this.args.meeting.belongsTo('mailCampaign').reload();
     yield this.loadMailCampaign.perform();
   }
 

--- a/app/models/meeting.js
+++ b/app/models/meeting.js
@@ -27,7 +27,10 @@ export default class Meeting extends Model {
   @belongsTo('meeting', {
     inverse: null,
   }) mainMeeting;
-  @belongsTo('mail-campaign') mailCampaign;
+  // mailcampaign is read-only to prevent concurrency issues
+  @belongsTo('mail-campaign', {
+    serialize: false,
+  }) mailCampaign;
   @belongsTo('agenda', {
     inverse: null,
   }) agenda;

--- a/app/services/newsletter-service.js
+++ b/app/services/newsletter-service.js
@@ -41,14 +41,10 @@ export default class NewsletterService extends Service {
       campaignId: result.data.id,
       campaignWebId: result.data.attributes.webId,
       archiveUrl: result.data.attributes.archiveUrl,
+      meeting: meeting,
     });
 
     await mailCampaign.save();
-    const reloadedMeeting = await this.store.findRecord('meeting', meeting.id, {
-      reload: true,
-    });
-    reloadedMeeting.mailCampaign = mailCampaign;
-    await reloadedMeeting.save();
     return mailCampaign;
   }
 


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3524

bug cause:
Saving of meeting by "kanselarij" and "kort-bestek" users around similar times (release decisions internally, release newsitems to valvas) could cause the `meeting.mailcampaign` to be deleted (because of how ember patches are processed in the backend)

The solution to this is to make the relation read-only, and set the relation inversely via the mailcampaign.
Note that the concurrency issue could also effect other situations, like `meeting.internalDecisionPublicationActivity` being deleted when "kort-bestek" saves the mailcampaign. (not tested, but the way to do it would be to open the agenda pre-decision release, go to KB views, then start mailcampaign after decisions are released in a different browser tab but without refreshing the KB browser tab.)

That case (if it would happen) should now also be removed because we no longer perform a save of the `meeting` model with possible stale inverse relations.
Ideally, `internalDecisionPublicationActivity` (and others) on `meeting` could also be read-only to prevent future `meeting` saves with stale data