### PR TITLE
KAS-3579: Minimal `include`s

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,6 +1,7 @@
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import { inject as service } from '@ember/service';
 import { later } from '@ember/runloop';
+import minimalInclude from 'frontend-kaleidos/utils/minimal-include';
 
 export default class ApplicationAdapter extends JSONAPIAdapter {
   @service intl;
@@ -19,6 +20,22 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
       this.toaster.error(this.intl.t('couldnt-answer-net-req'));
       throw error;
     }
+  }
+
+  buildQuery(snapshot) {
+    const query = super.buildQuery(snapshot);
+    if (query?.include) {
+      query.include = minimalInclude(query.include.split(','));
+    }
+    return query;
+  }
+
+  buildURL(modelName, id, snapshot, requestType, query) {
+    if (query?.include) {
+      query.include = minimalInclude(query.include.split(','));
+    }
+    const url = super.buildURL(modelName, id, snapshot, requestType, query);
+    return url;
   }
 
   // from https://github.com/lblod/frontend-gelinkt-notuleren/blob/5d3c17e9c084e13ea8354c81bf378a27043d7e59/app/adapters/application.js

--- a/app/routes/agenda/agendaitems.js
+++ b/app/routes/agenda/agendaitems.js
@@ -31,6 +31,7 @@ export default class AgendaAgendaitemsRoute extends Route {
     } = this.modelFor('agenda');
 
     // Could be optimized not to make below query again when only query params changed
+    // *NOTE* Do not change this query, this call is pre-cached by cache-warmup-service
     let agendaitems = await this.store.query('agendaitem', {
       'filter[agenda][:id:]': agenda.id,
       'page[size]': PAGE_SIZE.AGENDAITEMS,

--- a/app/utils/minimal-include.js
+++ b/app/utils/minimal-include.js
@@ -1,0 +1,27 @@
+/**
+ * Returns the a comma-separated string containing the minimal necessary include
+ * paths. When a path is a complete prefix of another path, the shorter path
+ * doesn't need to be part of the include parameter, so it gets removed by this
+ * function.
+ *
+ * @param {Array<string>} paths list of mu-cl-resources paths
+ * @returns {string} String comma-separated string with the minimal paths
+ */
+export default function minimalInclude(paths) {
+  return paths
+    .reduce((acc, path, i, arr) => {
+      let isPrefix = false;
+      arr.slice(i + 1).forEach((otherPath, j) => {
+        if (path.includes(`${otherPath}.`)) {
+          arr.splice(i + j + 1, 1);
+          i--;
+        }
+        if (!isPrefix) {
+          isPrefix = otherPath.includes(`${path}.`)
+        }
+      });
+      if (isPrefix) return acc;
+      return [...acc, path];
+    }, [])
+    .join(',');
+}

--- a/app/utils/minimal-include.js
+++ b/app/utils/minimal-include.js
@@ -4,6 +4,15 @@
  * doesn't need to be part of the include parameter, so it gets removed by this
  * function.
  *
+ * The function works by iterating over each path and storing only paths that
+ * aren't a prefix of other paths. For each path, we iterate over all other
+ * paths and make sure that (1) the current path is not a prefix of another path
+ * and (2) that other paths are not full prefix of the current path. If (1), we
+ * discard the current path, if (2) we discord the other path.
+ *
+ * Not the most efficient, but given the small input it will handle it should be
+ * okay.
+ *
  * @param {Array<string>} paths list of mu-cl-resources paths
  * @returns {string} String comma-separated string with the minimal paths
  */
@@ -14,6 +23,8 @@ export default function minimalInclude(paths) {
       arr.slice(i + 1).forEach((otherPath, j) => {
         if (path.includes(`${otherPath}.`)) {
           arr.splice(i + j + 1, 1);
+          // We deleted an element further down the array, decrease the index so
+          // it still points to the right element
           i--;
         }
         if (!isPrefix) {

--- a/app/utils/minimal-include.js
+++ b/app/utils/minimal-include.js
@@ -21,14 +21,14 @@ export default function minimalInclude(paths) {
     .reduce((acc, path, i, arr) => {
       let isPrefix = false;
       arr.slice(i + 1).forEach((otherPath, j) => {
-        if (path.includes(`${otherPath}.`)) {
+        if (path.startsWith(`${otherPath}.`)) {
           arr.splice(i + j + 1, 1);
           // We deleted an element further down the array, decrease the index so
           // it still points to the right element
           i--;
         }
         if (!isPrefix) {
-          isPrefix = otherPath.includes(`${path}.`)
+          isPrefix = otherPath.startsWith(`${path}.`)
         }
       });
       if (isPrefix) return acc;

--- a/app/utils/minimal-include.js
+++ b/app/utils/minimal-include.js
@@ -4,35 +4,29 @@
  * doesn't need to be part of the include parameter, so it gets removed by this
  * function.
  *
- * The function works by iterating over each path and storing only paths that
- * aren't a prefix of other paths. For each path, we iterate over all other
- * paths and make sure that (1) the current path is not a prefix of another path
- * and (2) that other paths are not full prefix of the current path. If (1), we
- * discard the current path, if (2) we discord the other path.
- *
- * Not the most efficient, but given the small input it will handle it should be
- * okay.
+ * The function works by sorting the paths first, then doing a single pass over
+ * the paths and discarding any path that is a prefix of its neighbour.
  *
  * @param {Array<string>} paths list of mu-cl-resources paths
  * @returns {string} String comma-separated string with the minimal paths
  */
 export default function minimalInclude(paths) {
   return paths
+    .sort((a, b) => {
+      const splitA = a.split('.')
+      const splitB = b.split('.')
+      for (let i = 0; i < splitA.length; i++) {
+        if (splitA[i] < splitB[i]) {
+          return -1;
+        } else if (splitA[i] > splitB[i]) {
+          return 1;
+        }
+      }
+      return 0;
+    })
     .reduce((acc, path, i, arr) => {
-      let isPrefix = false;
-      arr.slice(i + 1).forEach((otherPath, j) => {
-        if (path.startsWith(`${otherPath}.`)) {
-          arr.splice(i + j + 1, 1);
-          // We deleted an element further down the array, decrease the index so
-          // it still points to the right element
-          i--;
-        }
-        if (!isPrefix) {
-          isPrefix = otherPath.startsWith(`${path}.`)
-        }
-      });
-      if (isPrefix) return acc;
-      return [...acc, path];
+      const nextPath = arr[i + 1] ?? '';
+      return (nextPath.startsWith(path) ? acc : [...acc, path]);
     }, [])
     .join(',');
 }


### PR DESCRIPTION
Not the most efficient function, but it should suffice. To apply the minimal includes to all outgoing queries, the `application` adapter has two overriden methods, `buildQuery` and `buildURL`. It's not entirely clear to me based on the docs which method is applied to which store calls, but while testing it seems that `buildURL` is only used for certain methods, e.g. `findRecord`, while `buildQuery` is only used for others, e.g. `query`. So here both methods are overriden just to be sure.