### PR TITLE
Cypress flakyness

### DIFF
--- a/app/components/agenda/agenda-overview/agenda-overview-item.js
+++ b/app/components/agenda/agenda-overview/agenda-overview-item.js
@@ -75,8 +75,10 @@ export default class AgendaOverviewItem extends AgendaSidebarItem {
     // should not be visible yet for a specific profile.
     if (this.currentSession.isOverheid) {
       const documentPublicationActivity = yield this.args.meeting.internalDocumentPublicationActivity;
-      const documentPublicationStatus = yield documentPublicationActivity.status;
-      this.documentsAreVisible = documentPublicationStatus.uri === CONSTANTS.RELEASE_STATUSES.RELEASED;
+      if (documentPublicationActivity) {
+        const documentPublicationStatus = yield documentPublicationActivity?.status;
+        this.documentsAreVisible = documentPublicationStatus.uri === CONSTANTS.RELEASE_STATUSES.RELEASED;
+      }
     } else {
       this.documentsAreVisible = true;
     }

--- a/app/routes/agenda/agendaitems/agendaitem/documents.js
+++ b/app/routes/agenda/agendaitems/agendaitem/documents.js
@@ -57,8 +57,10 @@ export default class DocumentsAgendaitemAgendaitemsAgendaRoute extends Route {
     // should not be visible yet for a specific profile.
     if (this.currentSession.isOverheid) {
       const documentPublicationActivity = await this.meeting.internalDocumentPublicationActivity;
-      const documentPublicationStatus = await documentPublicationActivity.status;
-      this.documentsAreVisible = documentPublicationStatus.uri === CONSTANTS.RELEASE_STATUSES.RELEASED;
+      if (documentPublicationActivity) {
+        const documentPublicationStatus = await documentPublicationActivity.status;
+        this.documentsAreVisible = documentPublicationStatus.uri === CONSTANTS.RELEASE_STATUSES.RELEASED;
+      }
     } else {
       this.documentsAreVisible = true;
     }

--- a/app/routes/cases/case/subcases/subcase/documents.js
+++ b/app/routes/cases/case/subcases/subcase/documents.js
@@ -55,8 +55,10 @@ export default class DocumentsSubcaseSubcasesRoute extends Route {
     // should not be visible yet for a specific profile.
     if (this.currentSession.isOverheid) {
       const documentPublicationActivity = await this.meeting.internalDocumentPublicationActivity;
-      const documentPublicationStatus = await documentPublicationActivity.status;
-      this.documentsAreVisible = documentPublicationStatus.uri === CONSTANTS.RELEASE_STATUSES.RELEASED;
+      if (documentPublicationActivity) {
+        const documentPublicationStatus = await documentPublicationActivity.status;
+        this.documentsAreVisible = documentPublicationStatus.uri === CONSTANTS.RELEASE_STATUSES.RELEASED;
+      }
     } else {
       this.documentsAreVisible = true;
     }

--- a/cypress/integration/e2e/propagatie-overheid.spec.js
+++ b/cypress/integration/e2e/propagatie-overheid.spec.js
@@ -80,7 +80,7 @@ context('Propagation to other graphs', () => {
     });
 
     cy.releaseDecisions();
-    cy.wait(60000);
+    cy.wait(80000);
     // check status pills (use within because find doesn't work, probably can't chain of appuniversum wormhole)
     cy.get(agenda.publicationPills.container).within(() => {
       cy.get(appuniversum.pill).contains(`Beslissingen zijn vrijgegeven op ${todayFormatted}`);

--- a/cypress/integration/unit/case.spec.js
+++ b/cypress/integration/unit/case.spec.js
@@ -67,9 +67,11 @@ context('Create case as Admin user', () => {
     // ensure type is the same after copy to new subcase
     // ensure confidentiality is the same after copy to new subcase
     cy.intercept('POST', '/subcases').as('createNewSubcase');
+    cy.intercept('POST', '/submission-activities').as('createSubmission');
     cy.get(cases.subcaseOverviewHeader.createSubcase).click();
     cy.get(cases.newSubcase.clonePreviousSubcase).click();
     cy.wait('@createNewSubcase');
+    cy.wait('@createSubmission');
     cy.openSubcase(0);
     cy.get(cases.subcaseTitlesView.type).contains('Mededeling');
     cy.get(route.subcaseOverview.confidentialityCheckBox).should('be.checked');

--- a/cypress/integration/unit/propagation-confidentiality.spec.js
+++ b/cypress/integration/unit/propagation-confidentiality.spec.js
@@ -95,7 +95,7 @@ context('Propagation of confidentiality setup', () => {
     checkAccess(docNameLocked5);
     cy.releaseDocuments();
     // wait for yggie a bit, the next 2 profiles will succeed, enough time should have passed for overheid profile
-    cy.wait(20000);
+    cy.wait(60000);
   });
 
   it('login as minister and check access', () => {

--- a/cypress/support/commands/agenda-commands.js
+++ b/cypress/support/commands/agenda-commands.js
@@ -346,6 +346,7 @@ function approveDesignAgenda(shouldConfirm = true) {
 function approveAndCloseDesignAgenda(shouldConfirm = true) {
   cy.log('approveAndCloseDesignAgenda');
 
+  cy.intercept('POST', '/agendas/*/close').as('closeAgenda');
   cy.get(agenda.agendaActions.showOptions).click();
   cy.get(agenda.agendaActions.actions.approveAndCloseAgenda).click();
   cy.get(auk.loader).should('not.exist'); // new loader when refreshing data
@@ -357,6 +358,8 @@ function approveAndCloseDesignAgenda(shouldConfirm = true) {
       timeout: 60000,
     }).should('not.exist');
   }
+  cy.wait('@closeAgenda');
+  cy.get(auk.loader).should('not.exist'); // loader when refreshing data
   cy.log('/approveAndCloseDesignAgenda');
 }
 

--- a/cypress/support/commands/agenda-commands.js
+++ b/cypress/support/commands/agenda-commands.js
@@ -346,7 +346,6 @@ function approveDesignAgenda(shouldConfirm = true) {
 function approveAndCloseDesignAgenda(shouldConfirm = true) {
   cy.log('approveAndCloseDesignAgenda');
 
-  cy.intercept('POST', '/agendas/*/close').as('closeAgenda');
   cy.get(agenda.agendaActions.showOptions).click();
   cy.get(agenda.agendaActions.actions.approveAndCloseAgenda).click();
   cy.get(auk.loader).should('not.exist'); // new loader when refreshing data
@@ -358,7 +357,6 @@ function approveAndCloseDesignAgenda(shouldConfirm = true) {
       timeout: 60000,
     }).should('not.exist');
   }
-  cy.wait('@closeAgenda');
   cy.get(auk.loader).should('not.exist'); // loader when refreshing data
   cy.log('/approveAndCloseDesignAgenda');
 }


### PR DESCRIPTION
The error throwing is somewhat difficult to produce. (document tab in agenda, often fail on jenkins for profile "overheid")
It might be caused by documents being viewed by "overheid" when yggdrasil is still working or not yet finished.
But the error can occur when there is no "internalDocuments..." yet.

There is also another error I have not reproduced where something is 'undefined'. Guessing it's a `currentRoute` or `transition` because the error comes from the `RouterService` and is trying to get `name` from `undefined`.

Flakyness not fixed (yet):
Search on "assign-mandatee.spec" agendaitems fails often, not sure why.