### PR TITLE
KAS-2836: Re-work ThemesSelector to no longer have a mutable getter

### DIFF
--- a/app/components/utils/themes-selector.hbs
+++ b/app/components/utils/themes-selector.hbs
@@ -1,15 +1,17 @@
 {{#if this.findAll.isRunning}}
-  <WebComponents::VlLoader @text={{t "themes-loading-text"}} />
+  <Auk::Loader @message={{t "themes-loading-text"}} />
 {{else}}
   <div class="auk-o-grid">
-    {{#each this.selectedThemesReload as |theme|}}
+    {{#each this.themes as |theme|}}
       <div class="auk-o-grid-col-4">
         <div class="auk-u-mb">
-          <Auk::Checkbox
-            @checked={{theme.selected}}
-            @label={{theme.label}}
-            {{on "input" (fn this.selectModel theme)}}
-          />
+          {{#let (includes theme @selectedThemes) as |checked|}}
+            <Auk::Checkbox
+              @checked={{checked}}
+              @label={{theme.label}}
+              {{on "input" (fn this.toggleTheme theme checked)}}
+            />
+          {{/let}}
         </div>
       </div>
     {{/each}}

--- a/app/components/utils/themes-selector.js
+++ b/app/components/utils/themes-selector.js
@@ -2,60 +2,32 @@ import Component from '@glimmer/component';
 import { task } from 'ember-concurrency';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
 
+/**
+ * @param {Array<Theme>} selectedThemes The themes that are already selected
+ */
 export default class ThemesSelector extends Component {
   @service store;
-  @tracked themeLabels; // A key value pair with keys label and selected.
-  @tracked selectedThemes = this.args.selectedThemes || []; // The themes from newsletterinfo. This can be undefined or null so we default to an empty list
 
   constructor() {
     super(...arguments);
     this.findAll.perform();
   }
 
-  // This will load all the themes from the API once invoked
   @task
   *findAll() {
-    const themes = yield this.store.query('theme', {}); // Query to make sure you get all themes from the API instead
-    this.themes = themes.sortBy('label').filter((theme) => !theme.deprecated);
-    this.themeLabels = this.themes.map((theme) => ({
-      label: theme.label,
-      selected: false,
-    }));
+    this.themes = yield this.store.query('theme', {
+      filter: { deprecated: false },
+      sort: 'label',
+    });
   }
-
-  checkSelectedLabels() {
-    if (this.selectedThemes && this.selectedThemes.length > 0) {
-      this.selectedThemes.forEach((selectedTheme) => {
-        const foundTheme = this.themeLabels.find((theme) => theme.label === selectedTheme.get('label'));
-        if (foundTheme) {
-          foundTheme.selected = true;
-        }
-      });
-    }
-  }
-
-  /* eslint-disable ember/no-side-effects */
-  get selectedThemesReload() {
-    if (this.args.selectedThemes && this.args.selectedThemes.length > 0) {
-      this.selectedThemes = this.args.selectedThemes;
-      this.themeLabels = this.themes.map((theme) => ({
-        label: theme.label,
-        selected: false,
-      }));
-      this.checkSelectedLabels();
-    }
-    return this.themeLabels;
-  }
-  /* eslint-enable ember/no-side-effects */
 
   @action
-  selectModel(themeLabel) {
-    if (!themeLabel.selected) {
-      this.selectedThemes.addObject(this.themes.find((theme) => theme.label === themeLabel.label));
+  toggleTheme(theme, wasChecked) {
+    if (wasChecked) {
+      this.args.selectedThemes.removeObject(theme);
     } else {
-      this.selectedThemes.removeObject(this.themes.find((theme) => theme.label === themeLabel.label));
+      this.args.selectedThemes.addObject(theme);
     }
   }
 }

--- a/app/components/utils/themes-selector.js
+++ b/app/components/utils/themes-selector.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { task } from 'ember-concurrency';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 
 /**
  * @param {Array<Theme>} selectedThemes The themes that are already selected
@@ -19,6 +20,7 @@ export default class ThemesSelector extends Component {
     this.themes = yield this.store.query('theme', {
       filter: { deprecated: false },
       sort: 'label',
+      size: PAGE_SIZE.CODE_LISTS,
     });
   }
 

--- a/cypress/integration/all-flaky-tests/subcase.spec.js
+++ b/cypress/integration/all-flaky-tests/subcase.spec.js
@@ -231,13 +231,13 @@ context('Subcase tests', () => {
 
     // Are there Themes in this agenda? Should be none
     cy.openAgendaitemKortBestekTab(subcaseTitleShort);
-    cy.intercept('GET', '**/themes').as('getAgendaitemThemes');
+    cy.intercept('GET', '/themes**').as('getAgendaitemThemes');
     cy.get(newsletter.newsItem.create).click();
     cy.wait('@getAgendaitemThemes');
     cy.get(newsletter.editItem.cancel).click();
 
     // open themes ediging pane.
-    cy.intercept('GET', '**/themes').as('getAgendaitemThemes');
+    cy.intercept('GET', '/themes**').as('getAgendaitemThemes');
     cy.get(newsletter.newsItem.create).click();
     cy.wait('@getAgendaitemThemes');
 

--- a/cypress/integration/all-flaky-tests/subcase.spec.js
+++ b/cypress/integration/all-flaky-tests/subcase.spec.js
@@ -282,7 +282,7 @@ context('Subcase tests', () => {
     cy.wait('@getAgendaitems');
 
     // open the themes editor.
-    cy.intercept('GET', '**/themes').as('getKortBestekThemes');
+    cy.intercept('GET', '/themes**').as('getKortBestekThemes');
     cy.get(newsletter.tableRow.newsletterRow).eq(0)
       .find(newsletter.buttonToolbar.edit)
       .click();

--- a/cypress/integration/unit/newsletter-info.spec.js
+++ b/cypress/integration/unit/newsletter-info.spec.js
@@ -127,7 +127,7 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
     // check default nota has no KB
     cy.get(newsletter.newsItem.alert).contains('Nog geen kort bestek voor dit agendapunt.');
     // create new KB
-    cy.intercept('GET', '/themes').as('getThemes');
+    cy.intercept('GET', '/themes**').as('getThemes');
     cy.get(newsletter.newsItem.create).click();
     cy.wait('@getThemes');
     // check default values
@@ -176,7 +176,7 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
     cy.openAgendaitemKortBestekTab(subcaseTitleShort);
     cy.get(newsletter.newsItem.alert).contains('Nog geen kort bestek voor dit agendapunt.');
     // create new KB
-    cy.intercept('GET', '/themes').as('getThemes');
+    cy.intercept('GET', '/themes**').as('getThemes');
     cy.get(newsletter.newsItem.create).click();
     cy.wait('@getThemes');
     // check default values
@@ -257,7 +257,7 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
     // TODO KAS-3367 extract, selector around the alert?
     cy.get(newsletter.newsItem.alert).contains('Nog geen kort bestek voor dit agendapunt.');
     // create new KB
-    cy.intercept('GET', '/themes').as('getThemes');
+    cy.intercept('GET', '/themes**').as('getThemes');
     cy.get(newsletter.newsItem.create).click();
     cy.wait('@getThemes');
     // check default values
@@ -327,7 +327,7 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
     // check if KB empty
     cy.get(newsletter.newsItem.alert).contains('Nog geen kort bestek voor dit agendapunt.');
     // create new KB
-    cy.intercept('GET', '/themes').as('getThemes');
+    cy.intercept('GET', '/themes**').as('getThemes');
     cy.get(newsletter.newsItem.create).click();
     cy.wait('@getThemes');
     // check default values
@@ -358,7 +358,7 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
     const files = [file];
 
     cy.visitAgendaWithLink(agendaitemKBLink);
-    cy.intercept('GET', '/themes').as('getThemes');
+    cy.intercept('GET', '/themes**').as('getThemes');
     cy.get(newsletter.newsItem.create).click();
     cy.wait('@getThemes');
 
@@ -375,7 +375,7 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
       .click();
     // check cancel
     cy.get(newsletter.editItem.cancel).click();
-    cy.intercept('GET', '/themes').as('getThemes2');
+    cy.intercept('GET', '/themes**').as('getThemes2');
     cy.get(newsletter.newsItem.create).click();
     cy.wait('@getThemes2');
     cy.get(dependency.rdfa.editorInner).should('be.empty');
@@ -392,7 +392,7 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
     cy.reload();
 
     cy.visitAgendaWithLink(agendaitemKBLink);
-    cy.intercept('GET', '/themes').as('getThemes3');
+    cy.intercept('GET', '/themes**').as('getThemes3');
     cy.get(newsletter.newsItem.create).click();
     cy.wait('@getThemes3');
     cy.get(newsletter.editItem.mandateeProposal).contains(proposalText);
@@ -434,7 +434,7 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
     cy.addDocumentsToAgendaitem(subcaseTitleNota, files);
     cy.visit(newsletterLink);
     // check newsitem save
-    cy.intercept('GET', '/themes').as('getThemes');
+    cy.intercept('GET', '/themes**').as('getThemes');
     cy.get(newsletter.buttonToolbar.edit).click();
     cy.wait('@getThemes');
     cy.get(newsletter.editItem.toggleFinished).click();
@@ -534,7 +534,7 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
     cy.visitAgendaWithLink(agendaLinkMed);
     cy.addAgendaitemMandatee(2); // Hilde Crevits
     cy.openAgendaitemKortBestekTab(subcaseTitleMededeling);
-    cy.intercept('GET', '/themes').as('getThemes_1');
+    cy.intercept('GET', '/themes**').as('getThemes_1');
     cy.get(newsletter.newsItem.edit).click();
     cy.wait('@getThemes_1');
     cy.get(newsletter.editItem.rdfaEditor).type(richtextMededeling);
@@ -596,7 +596,7 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
     cy.visitAgendaWithLink(agendaLinkNota);
     cy.addAgendaitemMandatee(0);
     cy.openAgendaitemKortBestekTab(subcaseTitleNota);
-    cy.intercept('GET', '/themes').as('getThemes_2');
+    cy.intercept('GET', '/themes**').as('getThemes_2');
     cy.get(newsletter.newsItem.edit).click();
     cy.wait('@getThemes_2');
     cy.get(newsletter.editItem.themesSelector).contains(theme2)
@@ -617,7 +617,7 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
   // RDFA tests can be flaky locally when having dev tools open or when running in background (not in focus)
   it('should test the rdfa editor', () => {
     cy.visit('/vergadering/5EBA94D7751CF70008000001/kort-bestek');
-    cy.intercept('GET', '/themes').as('getThemes');
+    cy.intercept('GET', '/themes**').as('getThemes');
     cy.get(newsletter.buttonToolbar.edit).eq(0)
       .click();
     cy.wait('@getThemes');


### PR DESCRIPTION
The component still mutates the passed in `selectedThemes` argument, but I don't think it's too much of an issue here given that it's only used in one place and that we depend on the mutation to happen in the parent comment (we check if no themes were selected before saving).

Of note (at least to me): `.{add,remove}Object()` work even when we pass in a plain JS array ([here](https://github.com/kanselarij-vlaanderen/frontend-kaleidos/blob/development/app/components/newsletter-item/edit-panel.js#L42) we assing a plain JS array to `selectedThemes` property, which we pass to this component). I guess Ember wraps component arguments in some internal class, even when it's just a regular object?