### PR TITLE
Hotfix KAS-3545 download not working in document preview

### DIFF
--- a/app/components/documents/document-preview/document-preview-modal.hbs
+++ b/app/components/documents/document-preview/document-preview-modal.hbs
@@ -14,7 +14,7 @@
           @iconAlignment="left"
           href={{this.selectedVersion.file.namedDownloadLink}}
           download
-        >Downloaden</AuLinkExternal>
+        >{{t "download-2"}}</AuLinkExternal>
       {{/if}}
     </span>
   </:title>

--- a/app/components/documents/document-preview/document-preview-modal.hbs
+++ b/app/components/documents/document-preview/document-preview-modal.hbs
@@ -8,7 +8,13 @@
     <span class="au-u-flex au-u-flex--vertical-center au-u-flex--spaced-small">
       {{this.selectedVersion.name}}
       {{#if this.selectedVersion.file}}
-        <AuLink href={{this.selectedVersion.file.namedDownloadLink}} @skin="button-naked" @icon="download" @iconAlignment="left" download>Downloaden</AuLink>
+        <AuLinkExternal
+          {{! TODO: AuExternalLink doesn't support @style="button-naked" yet}}
+          @icon="download"
+          @iconAlignment="left"
+          href={{this.selectedVersion.file.namedDownloadLink}}
+          download
+        >Downloaden</AuLinkExternal>
       {{/if}}
     </span>
   </:title>

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -144,6 +144,7 @@
   "documents-attached-to": "Bijbehorende documenten",
   "documents-sub case": "Documenten van de procedurestap",
   "download": "Download",
+  "download-2": "Downloaden",
   "download-documents": "Download alle documenten",
   "download-all-documents": "Download alle documenten",
   "drop-text": "Laat los om het bestand op te laden.",


### PR DESCRIPTION
Use `AuLinkExternal` instead of `AuLink` (the latter uses a `LinkTo` internally and doesn't work well with passing an `href`.

Missing styling: we used `@style="button-naked"` before but that is not available for `AuLinkExternal`.

Jenkins:
- http://kal-kastaar.s.redpencil.io:8080/job/kaleidos/job/custom_frontend_backend_combination_2/35/