### PR TITLE
KAS-3598: Editor grows too large

### DIFF
--- a/app/styles/addon-overrides/_ember-rdfa-editor.scss
+++ b/app/styles/addon-overrides/_ember-rdfa-editor.scss
@@ -105,3 +105,7 @@ $say-editor-padding: 1rem;
     padding-top: 3rem;
   }
 }
+
+.say-editor__inner {
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
When a line is too long and a user is typing in the middle of the
sentence, the editor doesn't always wrap long words at the end of the
line. To remedy this we apply overflow-wrap: anywhere to the editor,
which makes it break up words over multiple lines if they're too long.