### PR TITLE
KAS-3624 fix bug where invalid date is being used

### DIFF
--- a/app/components/meeting/edit-meeting-modal.hbs
+++ b/app/components/meeting/edit-meeting-modal.hbs
@@ -44,26 +44,26 @@
           />
         </div>
       </div>
-      {{!Publicatiedatum}}
-      <div class="auk-u-mb-2">
-        <div data-test-edit-meeting-document-publication-date class="auk-form-group">
-          <Auk::Label>
-            {{t "date-publication-documents"}}
-          </Auk::Label>
-          <Auk::Datepicker
-            @enableTime={{true}}
-            @date={{this.plannedDocumentPublicationDate}}
-            @onChange={{set this "plannedDocumentPublicationDate"}}
-            @disabled={{this.isDisabledPlannedDocumentPublicationDate}}
-          />
-          <Auk::FormHelpText
-            class="auk-u-mt"
-            @icon="circle-info"
-            @text={{t "agenda-publication--publication-date--help"}}
-          />
-        </div>
-      </div>
     {{/if}}
+    {{!Publicatiedatum}}
+    <div class="auk-u-mb-2">
+      <div data-test-edit-meeting-document-publication-date class="auk-form-group">
+        <Auk::Label>
+          {{t "date-publication-documents"}}
+        </Auk::Label>
+        <Auk::Datepicker
+          @enableTime={{true}}
+          @date={{this.plannedDocumentPublicationDate}}
+          @onChange={{set this "plannedDocumentPublicationDate"}}
+          @disabled={{this.isDisabledPlannedDocumentPublicationDate}}
+        />
+        <Auk::FormHelpText
+          class="auk-u-mt"
+          @icon="circle-info"
+          @text={{t "agenda-publication--publication-date--help"}}
+        />
+      </div>
+    </div>
     <div class="auk-u-mb-2">
       <div class="auk-form-group">
         <Auk::Label>

--- a/app/components/meeting/edit-meeting-modal.js
+++ b/app/components/meeting/edit-meeting-modal.js
@@ -203,7 +203,7 @@ export default class MeetingEditMeetingComponent extends Component {
     this.numberRepresentation = `${mainMeeting.numberRepresentation}-${this.meetingKindPostfix}`;
     this.startDate = mainMeeting.plannedStart;
     if (!this.isDisabledPlannedDocumentPublicationDate) {
-      const nextBusinessDay = setMinutes(setHours(addBusinessDays(mainMeeting.startDate, 1), 14), 0);
+      const nextBusinessDay = setMinutes(setHours(addBusinessDays(this.startDate, 1), 14), 0);
       this.plannedDocumentPublicationDate = nextBusinessDay;
     }
     this.extraInfo = mainMeeting.extraInfo;


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3624

Bugfix: The date for "plannedStart" for themis-publication and internal-document activities are not filled in for annex meetings.
The bug was caused by using an non-existing property on a model instead of a locally declared date.

Also made the date input field available for editing.

