### PR TITLE
KAS-3584 change file to replace with word file replacement

### DIFF
--- a/app/components/documents/document-card.hbs
+++ b/app/components/documents/document-card.hbs
@@ -48,7 +48,7 @@
                     href={{this.piece.file.primarySource.namedDownloadLink}}
                     download
                   >
-                    {{t (if (eq this.piece.file.primarySouce.extension "docx") "word-document" "source-file-lowercase")}}
+                    {{t (if (eq this.piece.file.primarySource.extension "docx") "word-document" "source-file-lowercase")}}
                   </AuLinkExternal>
                 </p>
               {{/if}}

--- a/app/components/documents/document-details-panel.hbs
+++ b/app/components/documents/document-details-panel.hbs
@@ -47,7 +47,7 @@
         />
       </Auk::KeyValue>
       <Auk::KeyValue
-        @key={{t "word-document"}}
+        @key={{t "source-document"}}
       >
         <div class="au-u-flex au-u-flex--between">
           {{#if @piece.file.primarySource}}

--- a/app/components/documents/document-details-panel.hbs
+++ b/app/components/documents/document-details-panel.hbs
@@ -47,27 +47,28 @@
         />
       </Auk::KeyValue>
       <Auk::KeyValue
-        data-test-details-tab-access-level
-        @key={{t "source-file"}}
+        @key={{t "word-document"}}
       >
         <div class="au-u-flex au-u-flex--between">
-          <p>
-            {{! Note that showing this composed name as "source file name" might be confusing.
-            Better show original source file (not document) name?}}
-            {{@piece.name}}.{{@piece.file.extension}}
-          </p>
+          {{#if @piece.file.primarySource}}
+            <p>
+              {{! Note that showing this composed name as "source file name" might be confusing.
+              Better show original source file (not document) name?}}
+              {{@piece.name}}.{{@piece.file.primarySource.extension}}
+            </p>
+          {{/if}}
           <AuButton
             @icon="upload"
             @iconAlignment="left"
             @skin="secondary"
-            {{on "click" (toggle "isUploadingReplacementFile" this)}}
+            {{on "click" (toggle "isUploadingReplacementSourceFile" this)}}
           >
-            {{t "replace"}}
+            {{t (if @piece.file.primarySource "replace" "upload")}}
           </AuButton>
         </div>
       </Auk::KeyValue>
-      {{#if this.isUploadingReplacementFile}}
-        <Auk::FileUploader @onUpload={{set this "replacementFile"}} />
+      {{#if this.isUploadingReplacementSourceFile}}
+        <Auk::FileUploader @onUpload={{set this "replacementSourceFile"}} />
       {{/if}}
     </Auk::Panel::Body>
     <Auk::Panel::Footer>
@@ -157,10 +158,17 @@
         />
       </Auk::KeyValue>
       <Auk::KeyValue
-        data-test-details-tab-access-level
-        @key={{t "source-file"}}
+        @key={{t (if (eq @piece.file.primarySource.extension "docx") "word-document" "source-file")}}
       >
-        {{#if @piece.file}}
+        {{#if @piece.file.primarySource}}
+          <AuLink
+            href={{@piece.file.primarySource.namedDownloadLink}}
+            @skin="primary"
+            @icon="download"
+            @iconAlignment="left"
+            download
+          >{{@piece.name}}.{{@piece.file.primarySource.extension}}</AuLink>
+        {{else if @piece.file}}
           <AuLink
             href={{@piece.file.namedDownloadLink}}
             @skin="primary"
@@ -168,7 +176,7 @@
             @iconAlignment="left"
             download
           >{{@piece.name}}.{{@piece.file.extension}}</AuLink>
-        {{else}}
+          {{else}}
           {{@piece.name}}
         {{/if}}
       </Auk::KeyValue>

--- a/app/components/documents/document-details-panel.hbs
+++ b/app/components/documents/document-details-panel.hbs
@@ -47,7 +47,7 @@
         />
       </Auk::KeyValue>
       <Auk::KeyValue
-        @key={{t "source-document"}}
+        @key={{t "source-file"}}
       >
         <div class="au-u-flex au-u-flex--between">
           {{#if @piece.file.primarySource}}

--- a/app/components/documents/document-details-panel.js
+++ b/app/components/documents/document-details-panel.js
@@ -66,13 +66,6 @@ export default class DocumentsDocumentDetailsPanel extends Component {
     this.isUploadingReplacementSourceFile = !this.isUploadingReplacementSourceFile;
   }
 
-  // @action
-  // async toggleUploadReplacementFile() {
-  //   await this.replacementSourceFile?.destroyRecord();
-  //   this.replacementSourceFile = null;
-  //   this.isUploadingReplacementSourceFile = !this.isUploadingReplacementSourceFile;
-  // }
-
   @action
   openEditDetails() {
     this.isEditingDetails = true;

--- a/app/components/documents/document-details-panel.js
+++ b/app/components/documents/document-details-panel.js
@@ -13,8 +13,8 @@ export default class DocumentsDocumentDetailsPanel extends Component {
   @service pieceAccessLevelService;
   @tracked isEditingDetails = false;
   @tracked isOpenVerifyDeleteModal = false;
-  @tracked isUploadingReplacementFile = false;
-  @tracked replacementFile;
+  @tracked isUploadingReplacementSourceFile = false;
+  @tracked replacementSourceFile;
   @tracked documentType;
   @tracked accessLevel;
   @tracked isLastVersionOfPiece;
@@ -39,18 +39,20 @@ export default class DocumentsDocumentDetailsPanel extends Component {
   *cancelEditDetails() {
     this.args.piece.rollbackAttributes(); // in case of piece name change
     yield this.loadDetailsData.perform();
-    yield this.replacementFile?.destroyRecord();
-    this.isUploadingReplacementFile = false;
-    this.replacementFile = null;
+    yield this.replacementSourceFile?.destroyRecord();
+    this.isUploadingReplacementSourceFile = false;
+    this.replacementSourceFile = null;
     this.isEditingDetails = false;
   }
 
   @task
   *saveDetails() {
-    if (this.replacementFile) {
-      const oldFile = yield this.args.piece.file;
-      yield oldFile.destroyRecord();
-      this.args.piece.file = this.replacementFile;
+    if (this.replacementSourceFile) {
+      const file = yield this.args.piece.file;
+      const oldSourceFile = yield file.primarySource;
+      yield oldSourceFile?.destroyRecord();
+      file.primarySource = this.replacementSourceFile;
+      yield file.save();
     }
     this.args.piece.accessLevel = this.accessLevel;
     yield this.args.piece.save();
@@ -60,16 +62,16 @@ export default class DocumentsDocumentDetailsPanel extends Component {
     this.args.documentContainer.type = this.documentType;
     yield this.args.documentContainer.save();
     this.isEditingDetails = false;
-    this.replacementFile = null;
-    this.isUploadingReplacementFile = !this.isUploadingReplacementFile;
+    this.replacementSourceFile = null;
+    this.isUploadingReplacementSourceFile = !this.isUploadingReplacementSourceFile;
   }
 
-  @action
-  async toggleUploadReplacementFile() {
-    await this.replacementFile?.destroyRecord();
-    this.replacementFile = null;
-    this.isUploadingReplacementFile = !this.isUploadingReplacementFile;
-  }
+  // @action
+  // async toggleUploadReplacementFile() {
+  //   await this.replacementSourceFile?.destroyRecord();
+  //   this.replacementSourceFile = null;
+  //   this.isUploadingReplacementSourceFile = !this.isUploadingReplacementSourceFile;
+  // }
 
   @action
   openEditDetails() {

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1072,5 +1072,6 @@
   "newsletters-tabs-overview": "Alle berichten",
   "source-file-lowercase": "bronbestand",
   "word-document": "Word document",
+  "upload": "Opladen",
   "as": "als"
 }


### PR DESCRIPTION
BASE: ACCEPTANCE :warning: 

Fix for flag in https://kanselarij.atlassian.net/browse/KAS-3584

- Fixed a typo in document-card.
- Changed file to show in viewer is word file when available, fallback to pdf or piece (profiles who can see piece but not file)
- Renamed some variables to indicate what file we are replacing  (future work may include also replacing the actual pdf file here)
- Added a translation. Did not find a design where there is no sourcefile, so was unsure how to name the button in that case so went for generic "Opladen"