### PR TITLE
KAS-3633 change approval creation only for regular meeting

### DIFF
--- a/app/controllers/agendas.js
+++ b/app/controllers/agendas.js
@@ -106,9 +106,9 @@ export default class AgendasController extends Controller {
       sort: '-planned-start',
     });
     const kind = await this.newMeeting.kind;
-    const broader = await kind?.broader;
-    const isAnnexMeeting = broader?.uri === CONSTANTS.MEETING_KINDS.ANNEX;
-    if (!isAnnexMeeting && closestMeeting) {
+    const isRegularMeeting = kind.uri === CONSTANTS.MEETING_KINDS.MINISTERRAAD;
+    // Only a regular meeting should get an approval agendaitem
+    if (isRegularMeeting && closestMeeting) {
       await this.createAgendaitemToApproveMinutes(
         agenda,
         this.newMeeting,

--- a/cypress/integration/all-flaky-tests/subcase.spec.js
+++ b/cypress/integration/all-flaky-tests/subcase.spec.js
@@ -53,7 +53,7 @@ context('Subcase tests', () => {
 
   before(() => {
     cy.login('Admin');
-    cy.createAgenda('Elektronische procedure', agendaDate, 'Zaal oxford bij Cronos Leuven');
+    cy.createAgenda(null, agendaDate, 'Zaal oxford bij Cronos Leuven');
     cy.logoutFlow();
   });
 

--- a/cypress/integration/e2e/propagatie-overheid.spec.js
+++ b/cypress/integration/e2e/propagatie-overheid.spec.js
@@ -40,7 +40,7 @@ context('Propagation to other graphs', () => {
       'Cypress test voor het propageren naar overheid',
       'In voorbereiding',
       'Principiële goedkeuring m.h.o. op adviesaanvraag');
-    cy.createAgenda('Elektronische procedure', agendaDate, 'Zaal oxford bij Cronos Leuven');
+    cy.createAgenda(null, agendaDate, 'Zaal oxford bij Cronos Leuven');
 
     cy.openAgendaForDate(agendaDate);
     cy.addAgendaitemToAgenda(subcaseTitle1);

--- a/cypress/integration/unit/agenda-reopen-previous.spec.js
+++ b/cypress/integration/unit/agenda-reopen-previous.spec.js
@@ -27,7 +27,7 @@ context('Agenda reopen previous tests', () => {
   const reopenPreviousVersion = 'Vorige versie heropenen';
 
   it('should delete current design agenda and reopen previous accepted agenda', () => {
-    cy.createAgenda('Elektronische procedure', dateToCreateAgenda, 'Reopen previous test');
+    cy.createAgenda(null, dateToCreateAgenda, 'Reopen previous test');
     cy.openAgendaForDate(dateToCreateAgenda);
     cy.setFormalOkOnItemWithIndex(0);
     cy.get(agenda.agendaSideNav.agenda).should('have.length', 1);


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3633

- No more approval agendaitem for any agenda except the regular meeting.
- Updated tests