### PR TITLE
Bugfix/kas 3641 clear search dates

### DIFF
--- a/app/components/auk/datepicker.hbs
+++ b/app/components/auk/datepicker.hbs
@@ -1,5 +1,10 @@
-<div class="auk-input-with-icon {{@class}}" {{did-update this.updateEnable this.enable}}>
-  <Auk::Icon @name="calendar"/>
+<div
+  class="auk-input-with-icon
+    {{@class}}
+    {{if @enableClear "auk-input-with-clear-action"}}"
+  {{did-update this.updateEnable this.enable}}
+>
+  <Auk::Icon @name="calendar" />
   <EmberFlatpickr
     data-test-auk-datepickr
     class="auk-input auk-input--block {{this.error}}"
@@ -25,4 +30,12 @@
     @defaultHour={{@defaultHour}}
     @defaultMinute={{@defaultMinute}}
   />
+  {{#if @enableClear}}
+    <Auk::Button
+      @skin="muted-borderless"
+      @layout="icon-only"
+      @icon="x"
+      {{on "click" @onClear}}
+    />
+  {{/if}}
 </div>

--- a/app/templates/newsletters/search.hbs
+++ b/app/templates/newsletters/search.hbs
@@ -22,6 +22,8 @@
         <Auk::Datepicker
           @date={{this.dateFromBuffer}}
           @onChange={{set this "dateFromBuffer"}}
+          @enableClear={{this.dateFromBuffer}}
+          @onClear={{set this "dateFromBuffer" undefined}}
         />
       </div>
       <div class="auk-form-group auk-u-position-relative au-u-margin-bottom-none au-u-1-6" data-test-route-search-date-to>
@@ -29,6 +31,8 @@
         <Auk::Datepicker
           @date={{this.dateToBuffer}}
           @onChange={{set this "dateToBuffer"}}
+          @enableClear={{this.dateToBuffer}}
+          @onClear={{set this "dateToBuffer" undefined}}
         />
       </div>
       <div class="auk-form-group au-u-margin-bottom-none au-u-1-6">

--- a/app/templates/publications/overview/search.hbs
+++ b/app/templates/publications/overview/search.hbs
@@ -42,6 +42,8 @@
         <Auk::Datepicker
           @date={{this.dateFromBuffer}}
           @onChange={{set this "dateFromBuffer"}}
+          @enableClear={{this.dateFromBuffer}}
+          @onClear={{set this "dateFromBuffer" undefined}}
         />
       </div>
       <div class="auk-form-group au-u-margin-bottom-none auk-u-position-relative au-u-1-6" data-test-route-search-date-to>
@@ -49,6 +51,8 @@
         <Auk::Datepicker
           @date={{this.dateToBuffer}}
           @onChange={{set this "dateToBuffer"}}
+          @enableClear={{this.dateToBuffer}}
+          @onClear={{set this "dateToBuffer" undefined}}
         />
       </div>
       <div class="auk-form-group au-u-margin-bottom-none au-u-1-6">

--- a/app/templates/search.hbs
+++ b/app/templates/search.hbs
@@ -60,6 +60,8 @@
           <Auk::Datepicker
             @date={{this.dateFromBuffer}}
             @onChange={{set this "dateFromBuffer"}}
+            @enableClear={{this.dateFromBuffer}}
+            @onClear={{set this "dateFromBuffer" undefined}}
           />
         </div>
       </div>
@@ -69,6 +71,8 @@
           <Auk::Datepicker
             @date={{this.dateToBuffer}}
             @onChange={{set this "dateToBuffer"}}
+            @enableClear={{this.dateToBuffer}}
+            @onClear={{set this "dateToBuffer" undefined}}
           />
         </div>
       </div>


### PR DESCRIPTION
Started from ACCEPTANCE :warning: 

- add the option to clear a date with a button on the datepicker
- implement the clearing on the search route for agendaitem/cases, newsletter and publications