### PR TITLE
KAS-3459 add alert for retracted and postponed

### DIFF
--- a/app/controllers/agenda/agendaitems/agendaitem/index.js
+++ b/app/controllers/agenda/agendaitems/agendaitem/index.js
@@ -20,6 +20,7 @@ export default class IndexAgendaitemAgendaitemsAgendaController extends Controll
   @tracked submitter;
   @tracked newsletterInfo;
   @tracked mandatees;
+  @tracked decisionActivity;
 
   @tracked isEditingAgendaItemTitles = false;
 

--- a/app/routes/agenda/agendaitems/agendaitem/index.js
+++ b/app/routes/agenda/agendaitems/agendaitem/index.js
@@ -31,6 +31,8 @@ export default class DetailAgendaitemAgendaitemsAgendaRoute extends Route {
     }
     const agendaItemTreatment = await model.treatment;
     this.newsletterInfo = await agendaItemTreatment?.newsletterInfo;
+    this.decisionActivity = await agendaItemTreatment?.decisionActivity;
+    await this.decisionActivity?.decisionResultCode;
     // When routing here from agenda overview with stale data, we need to reload several relations
     // The reload in model refreshes only the attributes and includes relations, makes saves with stale relation data possible
     await model.hasMany('mandatees').reload();

--- a/app/templates/agenda/agendaitems/agendaitem/index.hbs
+++ b/app/templates/agenda/agendaitems/agendaitem/index.hbs
@@ -1,3 +1,23 @@
+{{#let this.model.treatment.decisionActivity.decisionResultCode as |drc|}}
+  {{#if drc.isRetracted}}
+    <Auk::Alert @skin="warning" @message={{t "retracted-item"}}/>
+  {{/if}}
+  {{#if drc.isPostponed}}
+    <div class="auk-alert auk-alert--warning">
+      <div class="auk-alert__body">
+        <Auk::Badge @icon="alert-triangle" @skin={{"warning"}}/>
+        <div class="auk-alert__text">
+          <p class="auk-u-text-pre-line auk-alert__message">{{t "postponed-item"}}</p>
+        </div>
+      </div>
+      {{!-- <Auk::dropdownMenu
+        @skin="primary"
+        @label={{"Opnieuw agenderen"}}
+      /> --}}
+    </div>
+  {{/if}}
+{{/let}}
+
 <Auk::Toolbar class="auk-u-mb-4" as |Toolbar|>
   <Toolbar.Group @position="left" as |Group|>
     <Group.Item>

--- a/app/templates/agenda/agendaitems/agendaitem/index.hbs
+++ b/app/templates/agenda/agendaitems/agendaitem/index.hbs
@@ -1,8 +1,7 @@
-{{#let this.model.treatment.decisionActivity.decisionResultCode as |drc|}}
-  {{#if drc.isRetracted}}
+{{#let this.model.treatment.decisionActivity.decisionResultCode as |resultCode|}}
+  {{#if resultCode.isRetracted}}
     <Auk::Alert @skin="warning" @message={{t "retracted-item"}}/>
-  {{/if}}
-  {{#if drc.isPostponed}}
+  {{else if resultCode.isPostponed}}
     <div class="auk-alert auk-alert--warning">
       <div class="auk-alert__body">
         <Auk::Badge @icon="alert-triangle" @skin={{"warning"}}/>

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -291,7 +291,7 @@
   "overview": "Overzicht",
   "phases": "Fases",
   "postpone": "Uitstellen",
-  "postponed-item": "Dit punt is uitgesteld.",
+  "postponed-item": "Dit agendapunt is uitgesteld.",
   "postponed-subcase": "Deze procedurestap is uitgesteld op ",
   "preparation-text": "Voorbereidende tekst voor de persagenda",
   "press-agenda": "Persagenda voor",
@@ -1078,6 +1078,6 @@
   "retract": "Intrekken",
   "retracted": "Ingetrokken",
   "retract-revert": "Intrekken ongedaan maken",
-  "retracted-item": "Dit punt is ingetrokken.",
+  "retracted-item": "Dit agendapunt is ingetrokken.",
   "retracted-subcase": "Deze procedurestap is ingetrokken op "
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3459

- Added the loading of relations needed to `afterModel`
- Added alert for retracted and postponed
- Already made headway for the `Auk:DropdowMenu` for next ticket, there is currently no option to pass a block in the `Auk::Alert` so made a semi copy. If we decide to change the `Auk::Alert` template we could but seemed out of scope right now.
- Reused some translations string but changed the vague "punt" to "agendapunt"


Questions.
- We show some pills in the same route in the titels panel.
Does this replace those pills? the screenshot in ticket does not have that pill.
- With the relations loaded in the route, we could pass the `DecisionActivity` to `Agenda::Agendaitem::AgendaitemControls` so we don't need a loading task there.
