### PR TITLE
Hotfix: "Naar dossier" button in publication flow is broken

### DIFF
--- a/app/components/publications/publication/case/inscription/inscription-panel.hbs
+++ b/app/components/publications/publication/case/inscription/inscription-panel.hbs
@@ -87,7 +87,7 @@
                   @layout="icon-right"
                   @icon="chevron-right"
                   @route="cases.case.subcases"
-                  @model={{@publicationFlow.case.id}}
+                  @model={{@publicationFlow.case.decisionmakingFlow.id}}
                 >
                   {{t "to-case"}}
                 </Auk::Button>


### PR DESCRIPTION
We now want to pass the decisionmakingFlow id, not the case's id.

Custom Jenkins run: http://kal-kastaar.s.redpencil.io:8080/job/kaleidos/job/custom_frontend_backend_combination/307/