### PR TITLE
Remove unexisting route from router.js

### DIFF
--- a/app/components/m-header.hbs
+++ b/app/components/m-header.hbs
@@ -27,7 +27,7 @@
           {{#if (user-may "manage-newsletter-infos")}}
             <Auk::Tab
               @route="newsletters"
-              @current-when="newsletters newsletter print-overviews.newsletter"
+              @current-when="newsletters newsletter"
               data-test-m-header-newsletters
             >
               {{t "newsletter"}}

--- a/app/router.js
+++ b/app/router.js
@@ -69,10 +69,6 @@ Router.map(function() {
       this.route('overview', { path: '/klad', });
       this.route('agendaitems', { path: '/agendapunten', });
     });
-    this.route('newsletter', { path: '/kort-bestek/:agenda_id', }, function() {
-      this.route('overview', { path: '/klad', });
-      this.route('loading', { path: '/laden', });
-    });
     this.route('loading', { path: '/laden', });
   });
 


### PR DESCRIPTION
Remove unexisting `print-overviews.newletter` route from `router.js`. 
Should be a no-brainer, but awaiting tests to be sure.