### PR TITLE
KAS-3644: Ingeklapte versie van agenda sidebar heeft niet voldoende plaats voor "Vorige agenda's" titel

### DIFF
--- a/app/components/agenda/side-nav.hbs
+++ b/app/components/agenda/side-nav.hbs
@@ -78,7 +78,7 @@
       {{/each}}
     </ul>
 
-    {{#if (gt (get @reverseSortedAgendas "length") 1)}}
+    {{#if (and @isOpen (gt (get @reverseSortedAgendas "length") 1))}}
       <Auk::Navbar @skin="gray-200" class="auk-u-border-top">
         <AuHeading @level="3" @skin="functional">
           {{t "previous-agendas"}}


### PR DESCRIPTION
**Tickets binnen Jira:** 
- https://kanselarij.atlassian.net/browse/KAS-3644

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.