### PR TITLE
KAS-3647: Sommige titels binnen Nota's worden niet correct weergegeven (Kort bestek)

### DIFF
--- a/app/components/newsletter-item/print.hbs
+++ b/app/components/newsletter-item/print.hbs
@@ -31,12 +31,12 @@
                 </div>
               </div>
             {{/if}}
-            {{#if (and (not @newsletterItem) @agendaitem.title)}}
-              <div class="auk-u-mt auk-u-border-left l-printable-newsletter__title">
-                {{@agendaitem.title}}
-              </div>
-            {{/if}}
           </div>
+          {{#if (and (not @newsletterItem) @agendaitem.title)}}
+            <div class="auk-u-mt auk-u-border-left l-printable-newsletter__title">
+              {{@agendaitem.title}}
+            </div>
+          {{/if}}
         {{else}}
           <h4 data-test-newsletter-item-print-title class="auk-h4 auk-u-m-0">
             {{@newsletterItem.title}}


### PR DESCRIPTION
**Tickets binnen Jira:** 
- https://kanselarij.atlassian.net/browse/KAS-3647

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.