### PR TITLE
KAS-3677: Open document preview in same tab

### DIFF
--- a/app/components/documents/document-card.hbs
+++ b/app/components/documents/document-card.hbs
@@ -23,7 +23,7 @@
                 {{/unless}}
               </span>
             </div>
-            <LinkTo @route="document" @model={{this.piece.id}} target="_blank"
+            <LinkTo @route="document" @model={{this.piece.id}}
               class="auk-h4" data-test-document-card-name-value>
               {{this.piece.name}}{{#if this.piece.file}}.{{this.piece.file.extension}}{{/if}}
             </LinkTo>
@@ -179,7 +179,7 @@
                   <div class="vlc-document-card-item" data-test-vl-document-piece>
                     <div class="vlc-document-card-item__title">
                       {{#if piece.file}}
-                        <LinkTo @route="document" @model={{piece.id}} target="_blank"
+                        <LinkTo @route="document" @model={{piece.id}}
                           class="auk-h4 auk-u-m-0 auk-u-mr-4 vlc-document-card-item__title-link"
                           data-test-vl-document-name>
                           {{piece.name}}{{#if piece.file}}.{{piece.file.extension}}{{/if}}

--- a/app/components/documents/linked-document-link.hbs
+++ b/app/components/documents/linked-document-link.hbs
@@ -16,7 +16,6 @@
               data-test-linked-document-link-name
               @route="document"
               @model={{this.lastPiece.id}}
-              target="_blank"
               class="auk-h4"
             >
               {{this.lastPiece.name}}{{#if this.lastPiece.file}}.{{this.lastPiece.file.extension}}{{/if}}

--- a/app/components/publications/documents/document-card-step.hbs
+++ b/app/components/publications/documents/document-card-step.hbs
@@ -13,7 +13,7 @@
                   {{@piece.documentContainer.type.label}}
                 </span>
               </div>
-              <LinkTo @route="document" @model={{@piece.id}} target="_blank" class="auk-h4">
+              <LinkTo @route="document" @model={{@piece.id}} class="auk-h4">
                 {{@piece.name}}{{#if @piece.file}}.{{@piece.file.extension}}{{/if}}
               </LinkTo>
               <div class="vlc-document-card-content__meta">


### PR DESCRIPTION
I left in [this](https://github.com/kanselarij-vlaanderen/frontend-kaleidos/blob/feature/KAS-3677-document-preview-same-tab/app/components/agenda/agenda-header/agenda-version-actions.hbs#L328-L337) instance of opening the preview in a new tab because in that case it doesn't work very well if we open it in the same tab. We're in a menu doing something, if we transition to a new route, when we go back the menu has gone and the user loses that state.