### PR TITLE
Unauthorized error message on 403 Forbidden on mock-login

### DIFF
--- a/app/templates/mock-login.hbs
+++ b/app/templates/mock-login.hbs
@@ -10,10 +10,17 @@
             <div class="auk-panel auk-u-mb-8">
               <MockLogin as |login|>
                 {{#if login.errorMessage}}
-                  <Auk::Alert
-                    @skin="error"
-                    @message={{login.errorMessage}}
-                  />
+                  {{#if (includes "403" (w (lowercase login.errorMessage)))}}
+                    <Auk::Alert
+                      @skin="error"
+                      @message={{t "application-unauthorized-message"}}
+                    />
+                  {{else}}
+                    <Auk::Alert
+                      @skin="error"
+                      @message={{login.errorMessage}}
+                    />
+                  {{/if}}
                 {{/if}}
                 {{#if this.model.length}}
                   <ul class="auk-list auk-list--view" data-test-mock-login-list>

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -636,6 +636,7 @@
   "file-viewer-type-unsupported": "Bestanden van het bestandstype \"{fileType}\" worden momenteel niet ondersteund om in de applicatie te bekijken. Gelieve het bestand te downloaden.",
   "document-unauthorized": "Geen toegang",
   "document-unauthorized-message": "U hebt geen toegang tot dit document",
+  "application-unauthorized-message": "U hebt geen toegang tot de applicatie",
   "style-guide-basic": "Basics",
   "style-guide-typography": "Typography",
   "style-guide-components": "Components",


### PR DESCRIPTION
More clear error message on mock-login when user doesn't have access to the application (for example because account is blocked)