### PR TITLE
Bugfix/kas 3717 new subcase documents invisible

### DIFF
--- a/app/components/agenda/agendaitem/agendaitem-postponed.js
+++ b/app/components/agenda/agendaitem/agendaitem-postponed.js
@@ -68,12 +68,20 @@ export default class AgendaitemPostponed extends Component {
 
   @task
   *reProposeForAgenda(meeting) {
-    const submissionActivities = yield this.store.query('submission-activity', {
+    const submissionActivitiesFromAgendaActivity = yield this.store.query('submission-activity', {
       'filter[subcase][:id:]': this.args.subcase.id,
       'filter[agenda-activity][:id:]': this.args.agendaActivity.id,
       'page[size]': PAGE_SIZE.ACTIVITIES,
       include: 'pieces', // Make sure we have all pieces, unpaginated
     });
+    // there could be new submission-activities after finalizing agenda
+    const newSubmissionActivities = yield this.store.query('submission-activity', {
+      'filter[subcase][:id:]': this.args.subcase.id,
+      'filter[:has-no:agenda-activity]': true,
+      'page[size]': PAGE_SIZE.ACTIVITIES,
+      include: 'pieces', // Make sure we have all pieces, unpaginated
+    });
+    const submissionActivities = [...submissionActivitiesFromAgendaActivity.toArray(), ...newSubmissionActivities.toArray()];
     const pieces = [];
     for (const submissionActivity of submissionActivities.toArray()) {
       let submissionPieces = yield submissionActivity.pieces;

--- a/app/templates/cases/case/subcases/subcase/documents.hbs
+++ b/app/templates/cases/case/subcases/subcase/documents.hbs
@@ -8,6 +8,15 @@
               {{t "documents"}}
             </h4>
           </Group.Item>
+          <AuPill
+            @size="small"
+            @skin="border"
+            @icon="comment"
+          >
+            <EmberTooltip @side="bottom" @tooltipClass="tooltip-custom">
+              {{t "filtered-subcase-documents"}}
+            </EmberTooltip>
+          </AuPill>
         </Toolbar.Group>
         <Toolbar.Group @position="right" as |Group|>
           {{#if this.model.pieces.length}}

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1131,5 +1131,6 @@
   "show-only-blocked": "Toon enkel geblokkeerde",
   "documents-on-approved-agenda-title": "Documenten wijzigen op een goedgekeurde agenda",
   "documents-on-approved-agenda-with-next-version": "Er is een recentere versie van deze agenda.",
-  "documents-on-approved-agenda-message": "Bent U zeker dat U de documenten wilt wijzigen op deze goedgekeurde agendaversie?"
+  "documents-on-approved-agenda-message": "Bent U zeker dat U de documenten wilt wijzigen op deze goedgekeurde agendaversie?",
+  "filtered-subcase-documents": "Hier worden enkel de documenten getoond die op de meest recente agenda staan + documenten die niet op een agenda staan."
 }


### PR DESCRIPTION
## :information_source: started from ACCEPTANCE

# bugfix for ACCEPTANCE

https://kanselarij.atlassian.net/browse/KAS-3717

subcase-documents:
- added a query for any submissions not on agendas (always happens)
- query for those from latest meeting get added to the "set" of submissions (both queries should be mutually exclusive so no explicit "`Set` array" needed)
- added a tooltip to inform the users this view is filtered. (QUESTION: should we show this to all users or just editors? This is a last minute addition and is not validated by designers)

agendaitem-postponed:
- added a query for any submissions "not on agenda" to add to the previous query of submissions of the current meeting. 

nl-be:
- translation string added