### PR TITLE
Replace ALL non-breaking spaces with normal spaces

### DIFF
--- a/app/components/newsletter-item/edit-panel.js
+++ b/app/components/newsletter-item/edit-panel.js
@@ -64,22 +64,19 @@ export default class NewsletterItemEditPanelComponent extends Component {
     this.newsletterItem.finished = this.isFinished;
     this.newsletterItem.themes = this.selectedThemes;
     try {
-      // The editor introduces &nbsp; instead of normal spaces to work around
-      // certain browsers' behavior where normal spaces on outer ends of text nodes
-      // aren't rendered in the content-editable. In recent versions of the editor however,
-      // this &nbsp;-inserting seems to happen too often, which results in very long
-      // lines that don't break, which is undesired.
-      // Here we replace all &nbsp's that don't lean against html tags in an attempt
-      // to keep the editor's workaround behavior, while replacing unnecessary &nbsp;'s
+      // As of v0.59.1, the editor inserts &nbsp; whenever a user selects text
+      // and makes it bold. It also inserts &nbsp; when a user starts typing
+      // in the middle of already existing text. Additionally, it should insert
+      // &nbsp; whenever a user types multiple spaces after each other, otherwise
+      // they get collapsed.
       //
-      // See KAS-3598 for some extra context. This workaround was removed
-      // becuase at first it didn't seem to apply anymore. But then we found
-      // that the erroneous &nbsp; insertion happened when writing in the middle
-      // of a line. That is, when writing in the editor from a clean slate,
-      // normal spaces were inserted. But when writing in the middle of such a
-      // sentence, all new spaces would become non-breaking spaces.
-      // See also: https://github.com/lblod/ember-rdfa-editor/issues/317
-      //
+      // The last case is not really important to us, if a user complains about
+      // it we will deal with it later. But we do care about the first two cases,
+      // because users complain about the flow of text breaking up outside of the
+      // editor (e.g. when viewing the Kort Bestek text). It's also important when
+      // we send it off via Mailchimp, because it also has impact on the layout
+      // in mail readers. For that reason, we now strip ALL &nbsp; regardless of
+      // whether they hug html tags or not.
       const richtext = this.editorInstance.htmlContent;
       const cleanedHtml = richtext.replaceAll(/&nbsp;/gm, ' ');
       this.newsletterItem.richtext = cleanedHtml;

--- a/app/components/newsletter-item/edit-panel.js
+++ b/app/components/newsletter-item/edit-panel.js
@@ -81,7 +81,7 @@ export default class NewsletterItemEditPanelComponent extends Component {
       // See also: https://github.com/lblod/ember-rdfa-editor/issues/317
       //
       const richtext = this.editorInstance.htmlContent;
-      const cleanedHtml = richtext.replaceAll(/(?<!>)&nbsp;(?!<)/gm, ' ');
+      const cleanedHtml = richtext.replaceAll(/&nbsp;/gm, ' ');
       this.newsletterItem.richtext = cleanedHtml;
     } catch {
       // pass


### PR DESCRIPTION
The editor inserts `&nbsp;` when making selected text bold. These insertions are erroneous, and will get fixed at some point. In the meantime, we will replace all non-breaking spaces with normal spaces, to ensure that text flows as expected when shown in the Kaleidos app and in the Mailchimp mails.

The editor should not insert non-breaking spaces anymore, except when multiple spaces are typed one after another, so it's OK to replace all non-breaking spaces with normal spaces.

Jenkins run:
- http://kal-kastaar.s.redpencil.io:8080/job/kaleidos/job/custom_frontend_backend_combination_2/53/