### PR TITLE
fix: don't open documents in new tab, even from agenda overview

### DIFF
--- a/app/components/documents/document-badge.hbs
+++ b/app/components/documents/document-badge.hbs
@@ -1,6 +1,6 @@
 <div class="auk-o-flex auk-o-flex--spaced auk-o-flex--vertical-center">
   <a
-    href={{@doc.viewDocumentURL}} target="_blank" rel="noreferrer noopener"
+    href={{@doc.viewDocumentURL}} rel="noreferrer noopener"
     data-test-document-badge-link
   >
     <Auk::Icon @name={{if @isHighlighted "document-added" "document"}} />


### PR DESCRIPTION
Forgot this case in the agenda overview page where documents are listed in badges. Don't open them in new tabs.

Jenkins: http://kal-kastaar.s.redpencil.io:8080/job/kaleidos/job/custom_frontend_backend_combination/330/