### PR TITLE
KAS-3736 fix: archiveCase use decisionmakingFlow, proxies and router …

### DIFF
--- a/app/routes/cases/overview.js
+++ b/app/routes/cases/overview.js
@@ -1,7 +1,6 @@
 import Route from '@ember/routing/route';
 // eslint-disable-next-line ember/no-mixins
 import DataTableRouteMixin from 'ember-data-table/mixins/route';
-import { action } from '@ember/object';
 
 export default class OverviewCaseRoute extends Route.extend(DataTableRouteMixin) {
   queryParams = {
@@ -33,10 +32,5 @@ export default class OverviewCaseRoute extends Route.extend(DataTableRouteMixin)
       opts['filter[case][is-archived]'] = false;
     }
     return opts;
-  }
-
-  @action
-  refreshModel() {
-    this.refresh();
   }
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3736

## :warning: started from ACCEPTANCE

- fixed `archiveCase` not working with case > decisionmakingFlow > subcases
- fixed `archiveCase` using `then` promise when not really needed.
- using `get('id')` because our row data is a proxy and gave errors. (comments might be overkill though, just for safety ..)
- used `findRecord` in `unarchiveCase` to avoid getting decisionmakingFlow from a proxy (also saving proxy errors).
- used `router.refresh` in both instead of `send('...')` , removed action from route
- added refresh to unarchiving for consistency.


Will add this feature to the testing TODO pile for regression.