### PR TITLE
KAS-3738 implement warning for uploading on agendaitem with approved …

### DIFF
--- a/app/components/documents/document-card.js
+++ b/app/components/documents/document-card.js
@@ -140,7 +140,11 @@ export default class DocumentsDocumentCardComponent extends Component {
   @action
   async openUploadModal() {
     if (this.args.onOpenUploadModal) {
-      await this.args.onOpenUploadModal();
+      // opening model depending on calculations made in parent
+      const shouldOpen = await this.args.onOpenUploadModal();
+      if (shouldOpen === false) { // explicit checking on boolean
+        return;
+      }
     }
     this.isOpenUploadModal = true;
   }

--- a/app/controllers/agenda/agendaitems/agendaitem/documents.js
+++ b/app/controllers/agenda/agendaitems/agendaitem/documents.js
@@ -56,8 +56,8 @@ export default class DocumentsAgendaitemsAgendaController extends Controller {
   @action
   async openPieceUploadModal() {
     await this.ensureFreshData.perform();
-    const mayDocsBeEdited = await this.checkIfDocumentsMayBeEdited();
-    if (mayDocsBeEdited) {
+    const canDocsBeEdited = await this.checkIfDocumentsCanBeEdited();
+    if (canDocsBeEdited) {
       this.isOpenPieceUploadModal = true;
     }
   }
@@ -65,15 +65,15 @@ export default class DocumentsAgendaitemsAgendaController extends Controller {
   @action
   async openUploadModalForNewPiece() {
     await this.ensureFreshData.perform();
-    const mayDocsBeEdited = await this.checkIfDocumentsMayBeEdited();
-    if (mayDocsBeEdited) {
+    const canDocsBeEdited = await this.checkIfDocumentsCanBeEdited();
+    if (canDocsBeEdited) {
       return true;
     }
     return false;
   }
 
   @action
-  async checkIfDocumentsMayBeEdited() {
+  async checkIfDocumentsCanBeEdited() {
     const agendaStatus = await this.currentAgenda.belongsTo('status').reload();
     const isAgendaDraftOrLegacy = agendaStatus.isDesignAgenda || this.meeting.isPreKaleidos;
     if (!isAgendaDraftOrLegacy) {
@@ -211,8 +211,8 @@ export default class DocumentsAgendaitemsAgendaController extends Controller {
   *updateRelatedAgendaitemsAndSubcase(pieces) {
     yield this.ensureFreshData.perform(); // some other user could have saved agendaitem before we pressed save
     if (!this.hasConfirmedDocEditOnApproved) {
-      const mayDocsBeEdited = yield this.checkIfDocumentsMayBeEdited();
-      if (!mayDocsBeEdited) {
+      const canDocsBeEdited = yield this.checkIfDocumentsCanBeEdited();
+      if (!canDocsBeEdited) {
         // delete without a warning, upload not allowed or confirmed
         if (this.newPieces.length) {
           yield this.cancelUploadPieces.perform();

--- a/app/controllers/agenda/agendaitems/agendaitem/documents.js
+++ b/app/controllers/agenda/agendaitems/agendaitem/documents.js
@@ -26,7 +26,8 @@ export default class DocumentsAgendaitemsAgendaController extends Controller {
   @tracked isOpenBatchDetailsModal = false;
   @tracked isOpenPieceUploadModal = false;
   @tracked isOpenPublicationModal = false;
-  @tracked isOpenVerifyUploadOnApproved = false;
+  @tracked isOpenWarnDocEditOnApproved = false;
+  @tracked hasConfirmedDocEditOnApproved = false;
   @tracked newPieces = A([]);
   @tracked newAgendaitemPieces;
   @tracked agendaitem;
@@ -55,30 +56,57 @@ export default class DocumentsAgendaitemsAgendaController extends Controller {
   @action
   async openPieceUploadModal() {
     await this.ensureFreshData.perform();
-    // warn users if they are uploading on an approved agenda
-    const agendaStatus = await this.currentAgenda.belongsTo('status').reload();
-    if (agendaStatus.isDesignAgenda || this.meeting.isPreKaleidos) {
+    const mayDocsBeEdited = await this.checkIfDocumentsMayBeEdited();
+    if (mayDocsBeEdited) {
       this.isOpenPieceUploadModal = true;
-    } else {
-      await this.currentAgenda.nextVersion;
-      this.openVerifyUploadOnApproved();
     }
   }
 
   @action
-  openVerifyUploadOnApproved() {
-    this.isOpenVerifyUploadOnApproved = true;
+  async openUploadModalForNewPiece() {
+    await this.ensureFreshData.perform();
+    const mayDocsBeEdited = await this.checkIfDocumentsMayBeEdited();
+    if (mayDocsBeEdited) {
+      return true;
+    }
+    return false;
   }
 
   @action
-  verifyUploadOnApproved() {
-    this.isOpenVerifyUploadOnApproved = false;
-    this.isOpenPieceUploadModal = true;
+  async checkIfDocumentsMayBeEdited() {
+    const agendaStatus = await this.currentAgenda.belongsTo('status').reload();
+    const isAgendaDraftOrLegacy = agendaStatus.isDesignAgenda || this.meeting.isPreKaleidos;
+    if (!isAgendaDraftOrLegacy) {
+      await this.currentAgenda.belongsTo('nextVersion').reload();
+      await this.openWarnUploadOnApproved.perform();
+    }
+    return isAgendaDraftOrLegacy || this.hasConfirmedDocEditOnApproved;
+  }
+
+
+  @task
+  *openWarnUploadOnApproved() {
+    this.isOpenWarnDocEditOnApproved = true;
+    this.hasConfirmedDocEditOnApproved = false;
+    // The user has about 60 seconds to confirm
+    for (let index = 0; index < 120; index++) {
+      if (this.isOpenWarnDocEditOnApproved) {
+        yield timeout(500);
+      }
+    }
+    this.isOpenWarnDocEditOnApproved = false;
   }
 
   @action
-  async () {
-    this.isOpenPieceUploadModal = true;
+  closeWarnDocEditOnApproved() {
+    this.isOpenWarnDocEditOnApproved = false;
+    this.hasConfirmedDocEditOnApproved = false;
+  }
+
+  @action
+  confirmDocEditOnApproved() {
+    this.isOpenWarnDocEditOnApproved = false;
+    this.hasConfirmedDocEditOnApproved = true;
   }
 
   @action
@@ -144,6 +172,13 @@ export default class DocumentsAgendaitemsAgendaController extends Controller {
   }
 
   @task
+  *cancelAddPiece(piece) {
+    const file = yield piece.file;
+    yield file.destroyRecord();
+    yield piece.destroyRecord();
+  }
+
+  @task
   *deletePiece(piece) {
     const file = yield piece.file;
     yield file.destroyRecord();
@@ -175,6 +210,22 @@ export default class DocumentsAgendaitemsAgendaController extends Controller {
   @task
   *updateRelatedAgendaitemsAndSubcase(pieces) {
     yield this.ensureFreshData.perform(); // some other user could have saved agendaitem before we pressed save
+    if (!this.hasConfirmedDocEditOnApproved) {
+      const mayDocsBeEdited = yield this.checkIfDocumentsMayBeEdited();
+      if (!mayDocsBeEdited) {
+        // delete without a warning, upload not allowed or confirmed
+        if (this.newPieces.length) {
+          yield this.cancelUploadPieces.perform();
+        } else {
+          const deletePromises = pieces.map(async (piece) => {
+            await this.cancelAddPiece.perform(piece);
+          });
+          yield all(deletePromises);
+        }
+        return;
+      }
+    }
+
     // Failsafe, if we got to a situation where the user has old pieces data when saving new pieces, we refresh the relation to avoid stale data
     // The improved concurrency check should be enough, but as long as we save here, the risk of saving old data exists
     yield this.agendaitem.hasMany('pieces').reload();

--- a/app/routes/agenda/agendaitems/agendaitem/documents.js
+++ b/app/routes/agenda/agendaitems/agendaitem/documents.js
@@ -71,6 +71,7 @@ export default class DocumentsAgendaitemAgendaitemsAgendaRoute extends Route {
     controller.isOpenBatchDetailsModal = false;
     controller.isOpenPieceUploadModal = false;
     controller.isOpenPublicationModal = false;
+    controller.hasConfirmedDocEditOnApproved = false;
     controller.currentAgenda = this.currentAgenda;
     controller.previousAgenda = this.previousAgenda;
     controller.agendaActivity = this.agendaActivity;

--- a/app/templates/agenda/agendaitems/agendaitem/documents.hbs
+++ b/app/templates/agenda/agendaitems/agendaitem/documents.hbs
@@ -40,7 +40,7 @@
       @pieces={{this.model.pieces}}
       @highlightedPieces={{this.newAgendaitemPieces}}
       @agendaContext={{hash meeting=this.meeting agenda=this.currentAgenda agendaitem=this.agendaitem}}
-      @onOpenUploadModal={{perform this.ensureFreshData}}
+      @onOpenUploadModal={{this.openUploadModalForNewPiece}}
       @onAddPiece={{perform this.addPiece}}
       @didDeleteContainer={{this.refresh}}
       @markForSignature={{this.markForSignature}}
@@ -121,9 +121,9 @@
 {{/if}}
 
 <ConfirmationModal
-  @modalOpen={{this.isOpenVerifyUploadOnApproved}}
-  @onConfirm={{this.verifyUploadOnApproved}}
-  @onCancel={{set this "isOpenVerifyUploadOnApproved" false}}
+  @modalOpen={{this.isOpenWarnDocEditOnApproved}}
+  @onConfirm={{this.confirmDocEditOnApproved}}
+  @onCancel={{this.closeWarnDocEditOnApproved}}
 >
   <:title>
     {{t "documents-on-approved-agenda-title"}}


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3738

## :warning: started from acceptance

This ticket was requested to be implemented before the final agenda's of 2022 so branched from acceptance.

- reworked the current warning/confirmation modal to be more generic (was only usable to open 1 specific upload modal)
- Added checking the callback of a  `document-card` `this.args.method` instead of also implementing the very specific logic there
- Changed the modal so it would appear:
    - when adding new documents on approved agendas
    - when finalizing adding new documents on approved agendas if you started uploading on design agenda but status changed
    - when adding new versions to existing documents on approved agendas
    - when finalizing adding new versions to existing documents on approved agendas if you started uploading on design agenda but status changed
    - does not appear on legacy or design agendas.  
    
how it works:
When trying any of the actions above we verify if uploading should be allowed.
if not, a manual confirmation is needed.
We show the confirmation modal.
- If not pressed within 60 seconds or cancelled, we just stop doing anything and close the confirmation modal.
     - if the action was finalizing doc upload, we delete the uploaded docs without extra confirmation (ok?)
- if confirm is pressed, we assume the user knows what they are doing and continue as normal. The window opens in less then 0.5 seconds with the for loop timeout strategy (we need the modal to stay up for awhile + our main code waits for that task to finish before its continues.


Comments:
- Not fully tested yet, enough to know that deletes happen after cancelling or not responding
- the for loop is quite basic, I've tried `waitForProperty` on the `@tracked` property, but doesn't seem to work properly. Github issues hinted at avoiding it. Room for improvement.
- Added more code to already complex `updateRelatedAgendaitemsAndSubcase`. May be better off separating some of that code in well named "private" methods
- Noticed now that I used `mayDocsBeEdited`, will have to rename that to avoid permission confusions.

Will continue with this on monday if it can wait. Feedback welcome
