### PR TITLE
fix mandatees not showing the changes between agendas

### DIFF
--- a/app/components/agenda/compare-agenda-list.hbs
+++ b/app/components/agenda/compare-agenda-list.hbs
@@ -41,7 +41,7 @@
                 {{!-- TODO: these triple curlies are used for displaying a computed string with br tags in it.
                 These items concatenated by <br> should become a list that is iterated over in a .hbs template --}}
                 {{!-- template-lint-disable no-triple-curlies  --}}
-                {{{combinedAgendaitem.groupName}}}
+                {{{combinedAgendaitem.left.groupName}}}
                 {{!-- template-lint-enable no-triple-curlies  --}}
               </div>
             </div>
@@ -50,7 +50,7 @@
                 {{!-- TODO: these triple curlies are used for displaying a computed string with br tags in it.
                 These items concatenated by <br> should become a list that is iterated over in a .hbs template --}}
                 {{!-- template-lint-disable no-triple-curlies  --}}
-                {{{combinedAgendaitem.groupName}}}
+                {{{combinedAgendaitem.right.groupName}}}
                 {{!-- template-lint-enable no-triple-curlies  --}}
               </div>
             </div>


### PR DESCRIPTION
No ticket, noticed this during other ticket.
It looks weird that we show the same mandatees on both sides even when there are changes.

In the testdata I added mandatees to both agendaitems on Agenda B while Agenda A had no mandatees

Before:
![image](https://user-images.githubusercontent.com/22245223/206546696-750f193b-0a1d-4a53-9310-c2a31032e68d.png)


After:
![image](https://user-images.githubusercontent.com/22245223/206546576-31735dda-2298-4da1-aa66-3c78d5b765ca.png)

It makes sense that he second agendaitem on agenda A does not have "geen toekenning" since they belong to the same group. They would not have a yellow banner when looking at agenda A
