### PR TITLE
KAS-3690 add plausible package and config and setup in application route

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -14,14 +14,12 @@ export default class ApplicationRoute extends Route {
   @service currentSession;
   @service fileService;
   @service router;
-  @service metrics;
   @service userAgent;
   @service plausible;
 
   constructor() {
     super(...arguments);
     this.setupPlausible();
-    this.setupTracking();
   }
 
   async beforeModel() {
@@ -62,15 +60,6 @@ export default class ApplicationRoute extends Route {
       || browser.isChrome
       || browser.isSafari
       || browser.isChromeHeadless); // Headless in order not to break automated tests.
-  }
-
-  setupTracking() {
-    this.router.on('routeDidChange', () => {
-      this.metrics.trackPage({
-        page: this.router.currentURL,
-        title: this.router.currentRouteName,
-      });
-    });
   }
 
   setupPlausible() {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 import { setDefaultOptions } from 'date-fns';
 import { nlBE } from 'date-fns/locale';
+import ENV from 'frontend-kaleidos/config/environment';
 
 export default class ApplicationRoute extends Route {
   @service conceptStore;
@@ -15,9 +16,11 @@ export default class ApplicationRoute extends Route {
   @service router;
   @service metrics;
   @service userAgent;
+  @service plausible;
 
   constructor() {
     super(...arguments);
+    this.setupPlausible();
     this.setupTracking();
   }
 
@@ -68,6 +71,19 @@ export default class ApplicationRoute extends Route {
         title: this.router.currentRouteName,
       });
     });
+  }
+
+  setupPlausible() {
+    const { domain, apiHost } = ENV.plausible;
+    if (
+      domain !== '{{ANALYTICS_APP_DOMAIN}}' &&
+      apiHost !== '{{ANALYTICS_API_HOST}}'
+    ) {
+      this.plausible.enable({
+        domain,
+        apiHost,
+      });
+    }
   }
 
   @action

--- a/app/routes/newsletters/search.js
+++ b/app/routes/newsletters/search.js
@@ -3,14 +3,11 @@ import { action } from '@ember/object';
 import { isEmpty, isPresent } from '@ember/utils';
 import search from 'frontend-kaleidos/utils/mu-search';
 import Snapshot from 'frontend-kaleidos/utils/snapshot';
-import { inject as service } from '@ember/service';
 import parseDate from '../../utils/parse-date-search-param';
 import startOfDay from 'date-fns/startOfDay';
 import endOfDay from 'date-fns/endOfDay';
 
 export default class NewsletterInfosSearchRoute extends Route {
-  @service metrics;
-
   queryParams = {
     searchText: {
       refreshModel: true,
@@ -123,21 +120,6 @@ export default class NewsletterInfosSearchRoute extends Route {
         return entry;
       }
     );
-  }
-
-  afterModel(model) {
-    const keyword = this.filterParams.searchText;
-    let count;
-    if (model && model.meta && isPresent(model.meta.count)) {
-      count = model.meta.count;
-    } else {
-      count = false;
-    }
-    this.metrics.invoke('trackSiteSearch', {
-      keyword,
-      category: 'newslettersSearch',
-      searchCount: count,
-    });
   }
 
   setupController(controller, model) {

--- a/app/routes/search/agenda-items.js
+++ b/app/routes/search/agenda-items.js
@@ -1,14 +1,12 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
-import { isEmpty, isPresent } from '@ember/utils';
+import { isEmpty } from '@ember/utils';
 import moment from 'moment';
 import search from 'frontend-kaleidos/utils/mu-search';
 import Snapshot from 'frontend-kaleidos/utils/snapshot';
-import { inject as service } from '@ember/service';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 
 export default class AgendaitemSearchRoute extends Route {
-  @service metrics;
   queryParams = {
     types: {
       refreshModel: true,
@@ -105,21 +103,6 @@ export default class AgendaitemSearchRoute extends Route {
       const entry = agendaitem.attributes;
       entry.id = agendaitem.id;
       return entry;
-    });
-  }
-
-  afterModel(model) {
-    const keyword = this.paramsFor('search').searchText;
-    let count;
-    if (model && model.meta && isPresent(model.meta.count)) {
-      count = model.meta.count;
-    } else {
-      count = false;
-    }
-    this.metrics.invoke('trackSiteSearch', {
-      keyword,
-      category: 'agendaItemsSearch',
-      searchCount: count,
     });
   }
 

--- a/app/routes/search/cases.js
+++ b/app/routes/search/cases.js
@@ -1,14 +1,11 @@
 import Route from '@ember/routing/route';
-import { isEmpty, isPresent } from '@ember/utils';
+import { isEmpty } from '@ember/utils';
 import { action } from '@ember/object';
 import moment from 'moment';
 import search from 'frontend-kaleidos/utils/mu-search';
 import Snapshot from 'frontend-kaleidos/utils/snapshot';
-import { inject as service } from '@ember/service';
 
 export default class CasesSearchRoute extends Route {
-  @service metrics;
-
   queryParams = {
     includeArchived: {
       refreshModel: true,
@@ -124,21 +121,6 @@ export default class CasesSearchRoute extends Route {
       entry.id = searchData.id;
       postProcessDates(searchData);
       return entry;
-    });
-  }
-
-  afterModel(model) {
-    const keyword = this.paramsFor('search').searchText;
-    let count;
-    if (model && model.meta && isPresent(model.meta.count)) {
-      count = model.meta.count;
-    } else {
-      count = false;
-    }
-    this.metrics.invoke('trackSiteSearch', {
-      keyword,
-      category: 'CasesSearch',
-      searchCount: count,
     });
   }
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -11,18 +11,6 @@ module.exports = function (environment) {
       allowEmpty: true,
       outputFormat:'DD-MM-YYYY',
     },
-    metricsAdapters: [
-      {
-        name: 'Matomo',
-        environments: ['production'],
-        config: {
-          scriptUrl: 'https://dev-kaleidos-matomo.redpencil.io', // Can optionally be CDN-sourced
-          trackerUrl: 'https://dev-kaleidos-matomo.redpencil.io',
-          siteId: '{{METRICS_SITE_ID}}',
-          disableCookies: true, // <- for GDPR
-        },
-      }
-    ],
     featureFlags: {
       'editor-html-paste': false,
       'editor-browser-delete': true,

--- a/config/environment.js
+++ b/config/environment.js
@@ -61,6 +61,13 @@ module.exports = function (environment) {
         },
       },
     },
+    'ember-plausible': {
+      enabled: false,
+    },
+    plausible: {
+      domain: '{{ANALYTICS_APP_DOMAIN}}',
+      apiHost: '{{ANALYTICS_API_HOST}}',
+    },
   };
 
   if (environment === 'development') {

--- a/package.json
+++ b/package.json
@@ -107,8 +107,6 @@
     "ember-load-initializers": "^2.1.2",
     "ember-math-helpers": "^2.12.0",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-metrics": "^0.16.0",
-    "ember-metrics-matomo-adapter": "^0.2.0",
     "ember-modifier": "^1.0.3",
     "ember-moment": "^10.0.0",
     "ember-mu-transform-helpers": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "ember-mu-transform-helpers": "^2.1.2",
     "ember-named-blocks-polyfill": "^0.2.4",
     "ember-page-title": "^6.2.2",
+    "ember-plausible": "^0.1.1",
     "ember-power-select": "^5.0.4",
     "ember-prism": "^0.7.0",
     "ember-promise-helpers": "^1.0.9",


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3690


- implementing plausible (done I think? custom events and goals out of scope)
- removing matomo (not done, don't we want to run both analytics in parallel for accuracy?)
- testing (I don't have a plausible login that I know of, how does one connect with the api host)
