### PR TITLE
Use application instance initializer to setup application

### DIFF
--- a/app/instance-initializers/locale.js
+++ b/app/instance-initializers/locale.js
@@ -1,0 +1,19 @@
+import { setDefaultOptions } from 'date-fns';
+import { nlBE } from 'date-fns/locale';
+
+export function initialize(appInstance) {
+  // Set default locale for date-fns
+  setDefaultOptions({ locale: nlBE });
+
+  // Set default locale for moment
+  const moment = appInstance.lookup('service:moment');
+  moment.setLocale('nl-be');
+
+  // Set default locale for intl
+  const intl = appInstance.lookup('service:intl');
+  intl.setLocale(['nl-be']);
+}
+
+export default {
+  initialize
+};

--- a/app/instance-initializers/plausible.js
+++ b/app/instance-initializers/plausible.js
@@ -1,0 +1,19 @@
+import ENV from 'frontend-kaleidos/config/environment';
+
+export function initialize(appInstance) {
+  const plausible = appInstance.lookup('service:plausible');
+  const { domain, apiHost } = ENV.plausible;
+  if (
+    domain !== '{{ANALYTICS_APP_DOMAIN}}' &&
+    apiHost !== '{{ANALYTICS_API_HOST}}'
+  ) {
+    plausible.enable({
+      domain,
+      apiHost,
+    });
+  }
+}
+
+export default {
+  initialize
+};

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -4,7 +4,7 @@ import { inject as service } from '@ember/service';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 import { setDefaultOptions } from 'date-fns';
 import { nlBE } from 'date-fns/locale';
-import ENV from 'frontend-kaleidos/config/environment';
+
 
 export default class ApplicationRoute extends Route {
   @service conceptStore;
@@ -15,12 +15,6 @@ export default class ApplicationRoute extends Route {
   @service fileService;
   @service router;
   @service userAgent;
-  @service plausible;
-
-  constructor() {
-    super(...arguments);
-    this.setupPlausible();
-  }
 
   async beforeModel() {
     // Set default locale for date-fns
@@ -60,19 +54,6 @@ export default class ApplicationRoute extends Route {
       || browser.isChrome
       || browser.isSafari
       || browser.isChromeHeadless); // Headless in order not to break automated tests.
-  }
-
-  setupPlausible() {
-    const { domain, apiHost } = ENV.plausible;
-    if (
-      domain !== '{{ANALYTICS_APP_DOMAIN}}' &&
-      apiHost !== '{{ANALYTICS_API_HOST}}'
-    ) {
-      this.plausible.enable({
-        domain,
-        apiHost,
-      });
-    }
   }
 
   @action

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -2,13 +2,9 @@ import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
-import { setDefaultOptions } from 'date-fns';
-import { nlBE } from 'date-fns/locale';
-
 
 export default class ApplicationRoute extends Route {
   @service conceptStore;
-  @service moment;
   @service intl;
   @service session;
   @service currentSession;
@@ -17,13 +13,6 @@ export default class ApplicationRoute extends Route {
   @service userAgent;
 
   async beforeModel() {
-    // Set default locale for date-fns
-    setDefaultOptions({ locale: nlBE });
-
-    this.moment.setLocale('nl-be');
-
-    this.intl.setLocale(['nl-be']);
-
     if (!this.isSupportedBrowser) {
       this.transitionTo('not-supported');
     }


### PR DESCRIPTION
Inspired by @ValenberghsSven's question on #1570 moving the application setup from the application route to application instance initializers. 

2 initializers have been added:
- `plausible`: enabling/configuring Plausible
- `locale`: setting default locale for `date-fns`, `moment` and `intl`