### PR TITLE
Feature/kas 3803 basic plausible metrics

### DIFF
--- a/app/modifiers/plausible-click.js
+++ b/app/modifiers/plausible-click.js
@@ -1,0 +1,26 @@
+import Modifier from 'ember-modifier';
+import { inject as service } from '@ember/service';
+
+export default class PlausibleClickModifier extends Modifier {
+  @service plausible;
+
+  get eventName() {
+    return this.args.positional[0];
+  }
+
+  get props() {
+    return this.args.named;
+  }
+
+  onClick = () => {
+    this.plausible.trackEvent(this.eventName, this.props);
+  }
+
+  didInstall() {
+    this.element.addEventListener('click', this.onClick);
+  }
+
+  willRemove() {
+    this.element.removeEventListener('click', this.onClick);
+  }
+}

--- a/app/services/plausible.js
+++ b/app/services/plausible.js
@@ -1,0 +1,37 @@
+import PlausibleService from 'ember-plausible/services/plausible';
+import { inject as service } from '@ember/service';
+
+export default class ExtendedPlausibleService extends PlausibleService {
+  @service currentSession;
+  @service router;
+  @service session;
+
+  firstEvent = true;
+
+  constructor() {
+    super(...arguments);
+
+    this.router.on('routeDidChange', (transition) => {
+      if (this.session.isAuthenticated && this.currentSession.role) {
+        if (transition.from?.name === 'login') {
+          super.trackEvent('Aanmelding (per rol)', { rol: this.currentSession.role.label });
+        }
+        if (!transition.from) {
+          // transition.from === undefined when opening the app (by navigating to it or refreshing)
+          super.trackEvent('Gebruikssessie (per rol)', { rol: this.currentSession.role.label });
+        } else if (transition.from?.name !== transition.to?.name) {
+          // Some buttons let you go to the current route, that shouldn't count as a page view
+          super.trackEvent('Pageview (per rol)', { rol: this.currentSession.role.label });
+        }
+      }
+    });
+  }
+
+  trackEvent(eventName, props = {}) {
+    super.trackEvent(eventName, props);
+    if (this.firstEvent) {
+      super.trackEvent('Eerste actie', { eventName, ...props });
+      this.firstEvent = false;
+    }
+  }
+}

--- a/app/services/plausible.js
+++ b/app/services/plausible.js
@@ -13,13 +13,12 @@ export default class ExtendedPlausibleService extends PlausibleService {
 
     this.router.on('routeDidChange', (transition) => {
       if (this.session.isAuthenticated && this.currentSession.role) {
-        if (transition.from?.name === 'login') {
-          super.trackEvent('Aanmelding (per rol)', { rol: this.currentSession.role.label });
-        }
         if (!transition.from) {
           // transition.from === undefined when opening the app (by navigating to it or refreshing)
-          super.trackEvent('Gebruikssessie (per rol)', { rol: this.currentSession.role.label });
-        } else if (transition.from?.name !== transition.to?.name) {
+          super.trackEvent('Gebruikerssessie (per rol)', { rol: this.currentSession.role.label });
+        } else if (transition.from.name === 'login') {
+          super.trackEvent('Aanmelding (per rol)', { rol: this.currentSession.role.label });
+        } else if (transition.from.name !== transition.to?.name) {
           // Some buttons let you go to the current route, that shouldn't count as a page view
           super.trackEvent('Pageview (per rol)', { rol: this.currentSession.role.label });
         }

--- a/app/templates/agenda/agendaitems/agendaitem.hbs
+++ b/app/templates/agenda/agendaitems/agendaitem.hbs
@@ -17,6 +17,7 @@
         <Auk::Tab
           @route="agenda.agendaitems.agendaitem.decisions"
           data-test-agendaitem-nav-decision-tab
+          {{plausible-click "Actie" category="Beslissingfiche van agendapunt opvragen"}}
         >
           {{capitalize (t "decision")}}
         </Auk::Tab>
@@ -26,6 +27,7 @@
           <Auk::Tab
             @route="agenda.agendaitems.agendaitem.news-item"
             data-test-agendaitem-nav-newsletter-tab
+            {{plausible-click "Actie" category="Kort bestek van agendapunt opvragen"}}
           >
             {{capitalize (t "newsletter")}}
           </Auk::Tab>

--- a/app/templates/agenda/agendaitems/agendaitem.hbs
+++ b/app/templates/agenda/agendaitems/agendaitem.hbs
@@ -17,7 +17,7 @@
         <Auk::Tab
           @route="agenda.agendaitems.agendaitem.decisions"
           data-test-agendaitem-nav-decision-tab
-          {{plausible-click "Actie" category="Beslissingfiche van agendapunt opvragen"}}
+          {{plausible-click "Actie" category="Beslissingsfiche van agendapunt opvragen"}}
         >
           {{capitalize (t "decision")}}
         </Auk::Tab>


### PR DESCRIPTION
- Extends the Plausible service to facilitate tracking user role types as well as "first action of session" tracking
- Adds a `plausible-click` modifier that sends a custom event whenever the attached DOM element is clicked
- Adds "action tracking" for opening the Decisions and Kort bestek views in the agendaitem

Note: I also wrote code to track opening the Nota of an agendaitem, snippet:

```js
{{(if
  this.documentContainer.isNota
  (modifier
    "plausible-click" "Actie" category="Nota van agendapunt opvragen"
  )
)}}
```

`ember-template-lint` complains about `{{(`, but that should be valid handlebars syntax (at least, it compiles and I can see the result in my browser). The syntax is also how you're supposed to have conditional modifiers, see [this blog post](https://v5.chriskrycho.com/journal/conditional-modifiers-and-helpers-in-emberjs/#the-basics).

I suspect it's because we're using an outdated version of `ember-template-lint`, but I didn't want to start upgrading packages in a production "hotfix".

In any case, once we've upgraded Ember, we should be able to add that back in.

To add the action tracking in Plausible, the following goals need to be added:
- Actie
- Eerste actie
- Aanmelding (per rol)
- Gebruikssessie (per rol)
- Pageview (per rol)

Before implementing all the tracking actions defined in the spreadsheet, I would recommend going over what we want to track and how. The goal tracking in Plausible's UI may not be as flexible as desired (e.g., it doesn't seem to be possible to select multiple goals as a filter), so we'll want to check if we can get what we want from it. Otherwise, we should explore if [Plausible's Stats API](https://plausible.io/docs/stats-api) can get us the data we want, or if we need to play around with which events we send to Plausible.

Plausible screensots:

This contains most of the basic session-related data we want, like number of unique visitors, number of page views, session duration:
![image](https://user-images.githubusercontent.com/22411874/207895308-a4e6d9c0-e160-464e-b64f-ea1dffafde2d.png)

Country of origin, device, OS, browser, ... are also included by default:
![image](https://user-images.githubusercontent.com/22411874/207895527-56d72705-487b-49d2-843b-a78756eb4192.png)

Action tracking is done using Plausible's goals:
![image](https://user-images.githubusercontent.com/22411874/207895667-68542bed-ead1-4328-b790-8f0580df617e.png)
![image](https://user-images.githubusercontent.com/22411874/207895706-2a056ff4-bf15-4377-bd09-dcbda041fcf2.png)
![image](https://user-images.githubusercontent.com/22411874/207895750-a062defe-afbc-4266-8b08-d6eb3269d9fd.png)

It is possible to select a goal and filter on it. E.g., select `Admin` in `Pageviews (per rol)`, then we can see the pages which were viewed by admin users:
![image](https://user-images.githubusercontent.com/22411874/207896059-a677a603-b280-4fa5-9443-2a7ee143bcfb.png)

Custom Jenkins run:
- http://kal-kastaar.s.redpencil.io:8080/job/kaleidos/job/custom_frontend_backend_combination/336/