### PR TITLE
KAS-3807: Only allow dragging of agendaitems in edit mode

### DIFF
--- a/app/components/agenda/agenda-overview.hbs
+++ b/app/components/agenda/agenda-overview.hbs
@@ -65,7 +65,6 @@
                 {{sortable-item
                   model=agendaitem
                   distance="30"
-                  handle=this.dragHandleClass
                   disabled=(not this.canDragAgendaitems)
                 }}
               >
@@ -106,7 +105,6 @@
             {{sortable-item
               model=announcement
               distance="30"
-              handle=this.dragHandleClass
               disabled=(not this.canDragAgendaitems)
             }}
           >

--- a/app/components/agenda/agenda-overview.hbs
+++ b/app/components/agenda/agenda-overview.hbs
@@ -66,7 +66,7 @@
                   model=agendaitem
                   distance="30"
                   handle=this.dragHandleClass
-                  disabled=(not this.canEdit)
+                  disabled=(not this.canDragAgendaitems)
                 }}
               >
                 <Agenda::AgendaOverview::AgendaOverviewItem
@@ -77,7 +77,7 @@
                   @isNew={{includes agendaitem @newItems}}
                   @showFormallyOkStatus={{@currentAgenda.status.isDesignAgenda}}
                   @isEditingFormallyOkStatus={{this.isEditingOverview}}
-                  @showDragHandle={{this.canEdit}}
+                  @showDragHandle={{this.canDragAgendaitems}}
                 />
               </li>
             {{/each}}
@@ -107,7 +107,7 @@
               model=announcement
               distance="30"
               handle=this.dragHandleClass
-              disabled=(not this.canEdit)
+              disabled=(not this.canDragAgendaitems)
             }}
           >
             <Agenda::AgendaOverview::AgendaOverviewItem
@@ -118,7 +118,7 @@
               @isNew={{includes announcement @newItems}}
               @showFormallyOkStatus={{@currentAgenda.status.isDesignAgenda}}
               @isEditingFormallyOkStatus={{this.isEditingOverview}}
-              @showDragHandle={{this.canEdit}}
+              @showDragHandle={{this.canDragAgendaitems}}
             />
           </li>
         {{/each}}

--- a/app/components/agenda/agenda-overview.hbs
+++ b/app/components/agenda/agenda-overview.hbs
@@ -1,9 +1,9 @@
 <div class="vlc-agenda-items auk-u-m-8">
-  {{#if this.isEditingOverview}}
+  {{#if @isEditingOverview}}
     <ChangesAlert
       @message={{t "editing-agenda-overview"}}
       @buttonText={{t "end-editing-overview"}}
-      @clearAction={{this.toggleIsEditingOverview}}
+      @clearAction={{@toggleIsEditingOverview}}
     />
   {{/if}}
   <Auk::Toolbar @auto={{true}} class="auk-u-mb-3">
@@ -28,12 +28,12 @@
             {{if @showModifiedOnly (t "show-all") (t "show-changes")}}
           </AuButton>
           {{#if this.canEdit}}
-            {{#unless this.isEditingOverview}}
+            {{#unless @isEditingOverview}}
               <AuButton
                 data-test-agenda-overview-formally-ok-edit={{true}}
                 @skin="naked"
                 @icon="pencil"
-                {{on "click" this.toggleIsEditingOverview}}
+                {{on "click" @toggleIsEditingOverview}}
               >
                 {{t "edit"}}
               </AuButton>
@@ -75,7 +75,7 @@
                   @previousAgenda={{@previousAgenda}}
                   @isNew={{includes agendaitem @newItems}}
                   @showFormallyOkStatus={{@currentAgenda.status.isDesignAgenda}}
-                  @isEditingFormallyOkStatus={{this.isEditingOverview}}
+                  @isEditingFormallyOkStatus={{@isEditingOverview}}
                   @showDragHandle={{this.canDragAgendaitems}}
                 />
               </li>
@@ -115,7 +115,7 @@
               @previousAgenda={{@previousAgenda}}
               @isNew={{includes announcement @newItems}}
               @showFormallyOkStatus={{@currentAgenda.status.isDesignAgenda}}
-              @isEditingFormallyOkStatus={{this.isEditingOverview}}
+              @isEditingFormallyOkStatus={{@isEditingOverview}}
               @showDragHandle={{this.canDragAgendaitems}}
             />
           </li>

--- a/app/components/agenda/agenda-overview.js
+++ b/app/components/agenda/agenda-overview.js
@@ -1,7 +1,5 @@
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
 
 export default class AgendaOverview extends Component {
   /**
@@ -15,22 +13,17 @@ export default class AgendaOverview extends Component {
    * @argument onReorderAgendaitems: trigger the parent's action when we reorder agendaitems (by dragging)
    * @argument showModifiedOnly: if we should filter only on modified agendaitems
    * @argument toggleShowModifiedOnly: toggle the parent to set the modified filter on or off
+   * @argument isEditingOverview {Boolean} If the overview is in edit mode
+   * @argument toggleIsEditingOverview {Function} Function to call to toggle editing state
    */
 
   @service currentSession;
-
-  @tracked isEditingOverview = null;
 
   get canEdit() {
     return this.currentSession.may('manage-agendaitems') && this.args.currentAgenda.status.get('isDesignAgenda');
   }
 
   get canDragAgendaitems() {
-    return this.canEdit && this.isEditingOverview;
-  }
-
-  @action
-  toggleIsEditingOverview() {
-    this.isEditingOverview = !this.isEditingOverview;
+    return this.canEdit && this.args.isEditingOverview;
   }
 }

--- a/app/components/agenda/agenda-overview.js
+++ b/app/components/agenda/agenda-overview.js
@@ -19,8 +19,6 @@ export default class AgendaOverview extends Component {
 
   @service currentSession;
 
-  dragHandleClass = '.ki-drag-handle-2';
-
   @tracked isEditingOverview = null;
 
   get canEdit() {

--- a/app/components/agenda/agenda-overview.js
+++ b/app/components/agenda/agenda-overview.js
@@ -27,6 +27,10 @@ export default class AgendaOverview extends Component {
     return this.currentSession.may('manage-agendaitems') && this.args.currentAgenda.status.get('isDesignAgenda');
   }
 
+  get canDragAgendaitems() {
+    return this.canEdit && this.isEditingOverview;
+  }
+
   @action
   toggleIsEditingOverview() {
     this.isEditingOverview = !this.isEditingOverview;

--- a/app/components/agenda/agenda-overview/agenda-overview-item.hbs
+++ b/app/components/agenda/agenda-overview/agenda-overview-item.hbs
@@ -14,7 +14,7 @@
   <div data-test-agenda-overview-item-container class="vlc-agenda-items__body">
     <h4 class="vlc-agenda-items__subject">
       {{#if @showDragHandle}}
-        <div class="vlc-agenda-items__cursor">
+        <div class="vlc-agenda-items__cursor" {{sortable-handle}}>
           <AuIcon
             data-test-agenda-overview-item-dragging
             class="auk-u-cursor-grab auk-u-text-muted"

--- a/app/components/agenda/agenda-overview/agenda-overview-item.hbs
+++ b/app/components/agenda/agenda-overview/agenda-overview-item.hbs
@@ -14,12 +14,13 @@
   <div data-test-agenda-overview-item-container class="vlc-agenda-items__body">
     <h4 class="vlc-agenda-items__subject">
       {{#if @showDragHandle}}
-        <div class="vlc-agenda-items__cursor" {{sortable-handle}}>
+        <div class="vlc-agenda-items__cursor">
           <AuIcon
             data-test-agenda-overview-item-dragging
             class="auk-u-cursor-grab auk-u-text-muted"
             @icon="drag-handle-2"
             @size="large"
+            {{sortable-handle}}
           />
         </div>
       {{/if}}

--- a/app/controllers/agenda/agendaitems.js
+++ b/app/controllers/agenda/agendaitems.js
@@ -43,6 +43,7 @@ export default class AgendaAgendaitemsController extends Controller {
   @tracked documentLoadCount = 0;
   @tracked totalCount = 0;
   @tracked isLoading;
+  @tracked isEditingOverview = false;
 
   // @tracked filter; // TODO: don't do tracking on qp's before updating to Ember 3.22+ (https://github.com/emberjs/ember.js/issues/18715)
   // @tracked showModifiedOnly;

--- a/app/templates/agenda/agendaitems.hbs
+++ b/app/templates/agenda/agendaitems.hbs
@@ -54,6 +54,8 @@
             @onReorderAgendaitems={{perform this.assignNewPriorities}}
             @showModifiedOnly={{this.showModifiedOnly}}
             @toggleShowModifiedOnly={{this.toggleShowModifiedOnly}}
+            @isEditingOverview={{this.isEditingOverview}}
+            @toggleIsEditingOverview={{toggle "isEditingOverview" this}}
           />
           {{#if this.assignNewPriorities.isRunning}}
             <WebComponents::LoadingOverlay />

--- a/cypress/integration/unit/profile-admin.spec.js
+++ b/cypress/integration/unit/profile-admin.spec.js
@@ -144,6 +144,7 @@ context('Testing the application as Admin user', () => {
       cy.get(agenda.agendaActions.planReleaseDocuments).should('not.exist');
       cy.get(agenda.agendaActions.publishToWeb).should('not.exist');
       cy.get(agenda.agendaActions.unpublishFromWeb).should('not.exist');
+      cy.clickReverseTab('Overzicht'); // close dropdown
 
       // Main view - Search
       cy.get(agenda.agendaitemSearch.input);
@@ -151,6 +152,10 @@ context('Testing the application as Admin user', () => {
       // Overview Tab - General actions
       cy.get(agenda.agendaOverview.showChanges);
       cy.get(agenda.agendaOverview.formallyOkEdit);
+
+      // Overview Tab - General action - Dragging
+      cy.get(agenda.agendaOverviewItem.dragging).should('not.exist');
+      cy.get(agenda.agendaOverview.formallyOkEdit).click();
       cy.get(agenda.agendaOverviewItem.dragging);
 
       // Detail Tab - tabs

--- a/cypress/integration/unit/profile-secretarie.spec.js
+++ b/cypress/integration/unit/profile-secretarie.spec.js
@@ -124,6 +124,7 @@ context('Testing the application as Kanselarij user', () => {
       cy.get(agenda.agendaActions.planReleaseDocuments).should('not.exist');
       cy.get(agenda.agendaActions.publishToWeb).should('not.exist');
       cy.get(agenda.agendaActions.unpublishFromWeb).should('not.exist');
+      cy.clickReverseTab('Overzicht'); // close dropdown
 
       // Main view - Search
       cy.get(agenda.agendaitemSearch.input);
@@ -131,6 +132,10 @@ context('Testing the application as Kanselarij user', () => {
       // Overview Tab - General actions
       cy.get(agenda.agendaOverview.showChanges);
       cy.get(agenda.agendaOverview.formallyOkEdit);
+
+      // Overview Tab - General action - Dragging
+      cy.get(agenda.agendaOverviewItem.dragging).should('not.exist');
+      cy.get(agenda.agendaOverview.formallyOkEdit).click();
       cy.get(agenda.agendaOverviewItem.dragging);
 
       // Detail Tab - tabs


### PR DESCRIPTION
- Only allows agendaitem re-ordering in edit mode
- Only allows dragging agendaitems from the drag handle (six dots next to the number)
- Ensures that edit mode stays active while reordering agendaitems

Jenkins run:
- http://kal-kastaar.s.redpencil.io:8080/job/kaleidos/job/custom_frontend_backend_combination_2/69/