### PR TITLE
KAS-3770: Set not formally ok when changing government fields

### DIFF
--- a/app/controllers/agenda/agendaitems/agendaitem/index.js
+++ b/app/controllers/agenda/agendaitems/agendaitem/index.js
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { reorderAgendaitemsOnAgenda } from 'frontend-kaleidos/utils/agendaitem-utils';
+import { setNotYetFormallyOk } from 'frontend-kaleidos/utils/agendaitem-utils';
 
 export default class IndexAgendaitemAgendaitemsAgendaController extends Controller {
   @service store;
@@ -97,5 +98,7 @@ export default class IndexAgendaitemAgendaitemsAgendaController extends Controll
     governmentAreas.clear();
     governmentAreas.pushObjects(newGovernmentAreas);
     await this.subcase.save();
+    setNotYetFormallyOk(this.model);
+    await this.model.save();
   }
 }

--- a/app/controllers/cases/case/subcases/subcase/index.js
+++ b/app/controllers/cases/case/subcases/subcase/index.js
@@ -2,6 +2,7 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { setNotYetFormallyOk } from 'frontend-kaleidos/utils/agendaitem-utils';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 
 export default class CasesCaseSubcasesSubcaseIndexController extends Controller {
@@ -47,6 +48,14 @@ export default class CasesCaseSubcasesSubcaseIndexController extends Controller 
     governmentAreas.clear();
     governmentAreas.pushObjects(newGovernmentAreas);
     await this.model.subcase.save();
+    const agendaitemsOnDesignAgendaToEdit = await this.store.query('agendaitem', {
+      'filter[agenda-activity][subcase][:id:]': this.model.subcase.id,
+      'filter[agenda][status][:uri:]': CONSTANTS.AGENDA_STATUSSES.DESIGN,
+    });
+    await Promise.all(agendaitemsOnDesignAgendaToEdit.map(async (agendaitem) => {
+      setNotYetFormallyOk(agendaitem);
+      return agendaitem.save();
+    }));
   }
 
   @action


### PR DESCRIPTION
When editing the government fields of an agendaitem (both from the agendaitem view and the subcase view), changing the government fields will cause the agendaitem to no longer be formally Ok