### PR TITLE
fix: solve bug where editing subcase mandatees doesn't always propagate

### DIFF
--- a/app/services/agendaitem-and-subcase-properties-sync.js
+++ b/app/services/agendaitem-and-subcase-properties-sync.js
@@ -16,6 +16,12 @@ const setNewPropertiesToModel = async(model, propertiesToSet, resetFormallyOk = 
 
   const keys = Object.keys(propertiesToSet);
   for (const key of keys) {
+    // Do not remove this seemingly unnecessary get!
+    // If we don't fetch the relationship we want to set here before setting it,
+    // for some unknown reason Ember will overwrite its value with the original
+    // relationship when saving the model, in particular when it does the
+    // preEditOrSaveCheck in the _saveAllowed method when fetching modifiedBy.
+    await model.get(key);
     model.set(key, propertiesToSet[key]);
   }
 


### PR DESCRIPTION
When editing the mandatees of a subcase that is already linked to an agendaitem, while the agendaitem isn't loaded in memory (e.g. by navigating to the subcase not via the agendaitem or by refreshing the page on the subcase route), the first changes would not propagate to the agendaitem. This would result in new mandatees being attached to the subcase, but not to the agendaitem.

The true cause of the bug is still unclear, but ensuring that we load the mandatees before setting and saving them prevents the erroneous behaviour from occurring. We should still investigate what exactly is going on and whether it's a bug in our code or a bug in Ember, and if the latter whether it's already been fixed in a newer version.