### PR TITLE
KAS-3798: AuLink styling valt (inline) qua font-size te groot uit binnen Kaleidos

### DIFF
--- a/app/components/auk/pagination.hbs
+++ b/app/components/auk/pagination.hbs
@@ -10,6 +10,7 @@
           @icon="chevron-left"
           @disabled={{this.isFirstPage}}
           {{on "click" @onPreviousPage}}
+          class="auk-u-text-vertical-align-middle"
         >
           {{t "previous"}}
         </AuButton>
@@ -21,6 +22,7 @@
           @iconAlignment="right"
           @disabled={{this.isLastPage}}
           {{on "click" @onNextPage}}
+          class="auk-u-text-vertical-align-middle"
         >
           {{t "next"}}
         </AuButton>

--- a/app/components/documents/document-card.hbs
+++ b/app/components/documents/document-card.hbs
@@ -45,8 +45,6 @@
                   {{datetime-at this.piece.created}}
                   {{#if this.piece.file.derived}}
                     {{t "as"}}
-                    {{!-- TODO: AuLinkExternal has a font-size of 16px (because it uses the same size as buttons), but that's larger than normal text (which uses 14px).
-                    Currently this link looks a little larger than the surrounding text. --}}
                     <AuLinkExternal
                       data-test-document-card-primary-source-link
                       href={{this.piece.file.namedDownloadLink}}

--- a/app/components/number-pagination.hbs
+++ b/app/components/number-pagination.hbs
@@ -14,6 +14,7 @@
           @icon="chevron-left"
           @disabled={{this.isFirstPage}}
           {{action "changePage" this.links.prev}}
+          class="auk-u-text-vertical-align-middle"
         >
           {{t "previous"}}
         </AuButton>
@@ -25,6 +26,7 @@
           @iconAlignment="right"
           @disabled={{this.isLastPage}}
           {{action "changePage" this.links.next}}
+          class="auk-u-text-vertical-align-middle"
         >
           {{t "next"}}
         </AuButton>

--- a/app/styles/au/_au-components.scss
+++ b/app/styles/au/_au-components.scss
@@ -194,15 +194,14 @@ $au-button-height: 3.4rem;
   }
 }
 
-.au-c-button,
-.au-c-link {
+.au-c-button {
   vertical-align: middle;
 }
 
 .au-c-button--link,
 .au-c-button--tertiary,
-.au-c-link {
-  font-size: $au-button-font-size;
+.au-c-button--link-secondary {
+  vertical-align: baseline;
 }
 
 .au-c-icon {

--- a/app/styles/auk/_auk-additions.scss
+++ b/app/styles/auk/_auk-additions.scss
@@ -373,3 +373,9 @@ table tr.lt-expanded-row {
     }
   }
 }
+
+// Alignment helpers
+
+.auk-u-text-vertical-align-middle {
+  vertical-align: middle;
+}


### PR DESCRIPTION
**Tickets binnen Jira:** 
- https://kanselarij.atlassian.net/browse/KAS-3798

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.