### PR TITLE
Remove unused relation between piece and news-item

### DIFF
--- a/app/models/news-item.js
+++ b/app/models/news-item.js
@@ -17,6 +17,5 @@ export default class NewsItem extends ModelWithModifier {
 
   @belongsTo('agenda-item-treatment') agendaItemTreatment;
 
-  @hasMany('piece', { inverse: null }) attachments;
   @hasMany('themes', { inverse: null }) themes;
 }

--- a/app/models/piece.js
+++ b/app/models/piece.js
@@ -36,7 +36,6 @@ export default class Piece extends Model {
   @belongsTo('decision-activity', {
     inverse: null
   }) decisionActivity;
-  @belongsTo('news-item') newsItem;
   @belongsTo('meeting', {
     inverse: null
   }) meeting;


### PR DESCRIPTION
Relation only exists for legacy data and is created on export to Themis outside of Kaleidos