### PR TITLE
KAS-3815 use different subcase type for cypress tests

### DIFF
--- a/cypress/integration/all-flaky-tests/mandatee-assigning.spec.js
+++ b/cypress/integration/all-flaky-tests/mandatee-assigning.spec.js
@@ -41,7 +41,7 @@ context('Assigning a mandatee to agendaitem or subcase should update linked subc
     const type = 'Nota';
     const SubcaseTitleShort = `Cypress test: assign mandatee - ${currentTimestamp()}`;
     const subcaseTitleLong = 'Cypress test voor het toewijzen van een minister voor agendering vanuit procedurestap';
-    const subcaseType = 'In voorbereiding';
+    const subcaseType = 'Principiële goedkeuring';
     const subcaseName = 'Principiële goedkeuring m.h.o. op adviesaanvraag';
     cy.visit('/dossiers/E14FB4BA-3347-11ED-B8A0-F82C0F9DE1CF/deeldossiers');
     cy.addSubcase(type, SubcaseTitleShort, subcaseTitleLong, subcaseType, subcaseName);
@@ -79,7 +79,7 @@ context('Assigning a mandatee to agendaitem or subcase should update linked subc
     const type = 'Nota';
     const SubcaseTitleShort = `Cypress test: assign mandatee - ${currentTimestamp()}`;
     const subcaseTitleLong = 'Cypress test voor het toewijzen van een minister na agendering vanuit procedurestap';
-    const subcaseType = 'In voorbereiding';
+    const subcaseType = 'Principiële goedkeuring';
     const subcaseName = 'Principiële goedkeuring m.h.o. op adviesaanvraag';
     cy.visit('/dossiers/E14FB4BA-3347-11ED-B8A0-F82C0F9DE1CF/deeldossiers');
     cy.addSubcase(type, SubcaseTitleShort, subcaseTitleLong, subcaseType, subcaseName);
@@ -117,7 +117,7 @@ context('Assigning a mandatee to agendaitem or subcase should update linked subc
     const type = 'Nota';
     const SubcaseTitleShort = `Cypress test: assign mandatee - ${currentTimestamp()}`;
     const subcaseTitleLong = 'Cypress test voor het toewijzen van een minister vanuit agendaitem op ontwerpagenda';
-    const subcaseType = 'In voorbereiding';
+    const subcaseType = 'Principiële goedkeuring';
     const subcaseName = 'Principiële goedkeuring m.h.o. op adviesaanvraag';
     cy.visit('/dossiers/E14FB4BA-3347-11ED-B8A0-F82C0F9DE1CF/deeldossiers');
     cy.addSubcase(type, SubcaseTitleShort, subcaseTitleLong, subcaseType, subcaseName);

--- a/cypress/integration/all-flaky-tests/subcase.spec.js
+++ b/cypress/integration/all-flaky-tests/subcase.spec.js
@@ -64,7 +64,7 @@ context('Subcase tests', () => {
   it('should open an existing case and add a subcase', () => {
     const type = 'Nota';
     const subcaseTitleLong = 'Cypress test voor het aanmaken van een procedurestap';
-    const subcaseType = 'In voorbereiding';
+    const subcaseType = 'Principiële goedkeuring';
     const subcaseName = 'Principiële goedkeuring m.h.o. op adviesaanvraag';
     cy.visit('/dossiers/E14FB50A-3347-11ED-B8A0-F82C0F9DE1CF/deeldossiers');
     cy.addSubcase(type, subcaseTitleShort, subcaseTitleLong, subcaseType, subcaseName);
@@ -104,7 +104,7 @@ context('Subcase tests', () => {
     const type = 'Nota';
     const shortSubcaseTitle = `Cypress test: delete subcase - ${currentTimestamp()}`;
     const subcaseTitleLong = 'Cypress test voor het aanmaken en verwijderen van een procedurestap';
-    const subcaseType = 'In voorbereiding';
+    const subcaseType = 'Principiële goedkeuring';
     const subcaseName = 'Principiële goedkeuring m.h.o. op adviesaanvraag';
     cy.visit('/dossiers/E14FB50A-3347-11ED-B8A0-F82C0F9DE1CF/deeldossiers');
     cy.addSubcase(type, shortSubcaseTitle, subcaseTitleLong, subcaseType, subcaseName);
@@ -117,7 +117,7 @@ context('Subcase tests', () => {
     const type = 'Nota';
     const shortSubcaseTitle = `Cypress test: delete subcase not possible - ${currentTimestamp()}`;
     const subcaseTitleLong = 'Cypress test voor niet kunnen verwijderen van een procedurestap';
-    const subcaseType = 'In voorbereiding';
+    const subcaseType = 'Principiële goedkeuring';
     const subcaseName = 'Principiële goedkeuring m.h.o. op adviesaanvraag';
     cy.visit('/dossiers/E14FB50A-3347-11ED-B8A0-F82C0F9DE1CF/deeldossiers');
     cy.addSubcase(type, shortSubcaseTitle, subcaseTitleLong, subcaseType, subcaseName);
@@ -134,7 +134,7 @@ context('Subcase tests', () => {
     const type = 'Nota';
     const shortSubcaseTitle = `Cypress test: Link to agenda item ok - ${currentTimestamp()}`;
     const subcaseTitleLong = 'Cypress test voor te klikken op de link naar agenda vanuit procedurestap';
-    const subcaseType = 'In voorbereiding';
+    const subcaseType = 'Principiële goedkeuring';
     const subcaseName = 'Principiële goedkeuring m.h.o. op adviesaanvraag';
     cy.visit('/dossiers/E14FB50A-3347-11ED-B8A0-F82C0F9DE1CF/deeldossiers');
     cy.addSubcase(type, shortSubcaseTitle, subcaseTitleLong, subcaseType, subcaseName);
@@ -165,7 +165,7 @@ context('Subcase tests', () => {
     const type = 'Mededeling';
     const shortSubcaseTitle = `Cypress test: Mededeling - ${currentTimestamp()}`;
     const subcaseTitleLong = 'Cypress test doorstromen changes agendaitem to subcase';
-    const subcaseType = 'In voorbereiding';
+    const subcaseType = 'Principiële goedkeuring';
     const subcaseName = 'Principiële goedkeuring m.h.o. op adviesaanvraag';
 
     // Aanmaken Dossier

--- a/cypress/integration/e2e/propagatie-overheid.spec.js
+++ b/cypress/integration/e2e/propagatie-overheid.spec.js
@@ -38,7 +38,7 @@ context('Propagation to other graphs', () => {
     cy.addSubcase('Nota',
       subcaseTitle1,
       'Cypress test voor het propageren naar overheid',
-      'In voorbereiding',
+      'Principiële goedkeuring',
       'Principiële goedkeuring m.h.o. op adviesaanvraag');
     cy.createAgenda(null, agendaDate, 'Zaal oxford bij Cronos Leuven');
 

--- a/cypress/integration/unit/agendaitem-changes.spec.js
+++ b/cypress/integration/unit/agendaitem-changes.spec.js
@@ -74,7 +74,7 @@ context('Agendaitem changes tests', () => {
   it('should add an agendaitem of type remark and highlight it as added', () => {
     const caseLink = 'dossiers/E14FB4CE-3347-11ED-B8A0-F82C0F9DE1CF/deeldossiers';
     cy.visit(caseLink);
-    cy.addSubcase('Mededeling', subcaseTitle3, `${subcaseTitle3} lange titel`, 'In voorbereiding', 'Principiële goedkeuring m.h.o. op adviesaanvraag');
+    cy.addSubcase('Mededeling', subcaseTitle3, `${subcaseTitle3} lange titel`, 'Principiële goedkeuring', 'Principiële goedkeuring m.h.o. op adviesaanvraag');
     cy.visitAgendaWithLink(agendaURL);
     cy.changeSelectedAgenda('Ontwerpagenda');
     // when toggling show changes  the agendaitem added since current agenda should show

--- a/cypress/integration/unit/delete-BIS.spec.js
+++ b/cypress/integration/unit/delete-BIS.spec.js
@@ -38,7 +38,7 @@ context('Delete BIS tests', () => {
     cy.addSubcase('Nota',
       subcaseTitle1,
       'Cypress test voor het propageren naar overheid',
-      'In voorbereiding',
+      'Principiële goedkeuring',
       'Principiële goedkeuring m.h.o. op adviesaanvraag');
     cy.createAgenda(null, agendaDate, 'Zaal oxford bij Cronos Leuven');
 

--- a/cypress/integration/unit/search.spec.js
+++ b/cypress/integration/unit/search.spec.js
@@ -331,7 +331,7 @@ context('Search tests', () => {
       const subcaseTitleShort = `Cypress test: add subcase with accenten in title - ${currentTimestamp}`;
       const type = 'Nota';
       const subcaseTitleLong = 'Cypress test met accenten in title';
-      const subcaseType = 'In voorbereiding';
+      const subcaseType = 'Principiële goedkeuring';
       const subcaseName = 'Principiële goedkeuring m.h.o. op adviesaanvraag';
 
       cy.createAgenda(null, agendaDate, null);

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -164,7 +164,6 @@
   "end-date": "Einddatum",
   "environment": "omgeving",
   "error": "Er is iets misgelopen..",
-  "example-subcase": "In voorbereiding",
   "document-name": "Naam document",
   "file-type": "Bestandstype",
   "files-of": "bestanden van de",


### PR DESCRIPTION
In addition to https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/357/files