### PR TITLE
KAS-3816: Stop using Observer and Evented APIs for jobs

### DIFF
--- a/app/components/agenda/agenda-header/agenda-actions.js
+++ b/app/components/agenda/agenda-header/agenda-actions.js
@@ -273,10 +273,9 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
           timeOut: 3 * 60 * 1000,
         }
       );
-      this.jobMonitor.register(job);
-      job.on('didEnd', this, async function (status) {
+      this.jobMonitor.register(job, async (job) => {
         this.toaster.clear(inCreationToast);
-        if (status === job.SUCCESS) {
+        if (job.status === job.SUCCESS) {
           const url = await fileDownloadUrlFromJob(job, name);
           debug(`Archive ready. Prompting for download now (${url})`);
           fileDownloadToast.options.downloadLink = url;

--- a/app/controllers/publications/overview/reports.js
+++ b/app/controllers/publications/overview/reports.js
@@ -44,11 +44,10 @@ export default class PublicationsOverviewReportsController extends Controller {
     );
     const job = this.createExportJob(reportTypeEntry, userParams);
     await job.save();
-    this.jobMonitor.register(job);
     const thisRouteName = this.router.currentRouteName;
-    job.on('didEnd', this, async (status) => {
+    this.jobMonitor.register(job, async (job) => {
       this.toaster.clear(generatingToast);
-      if (status === job.SUCCESS) {
+      if (job.status === job.SUCCESS) {
         const file = await job.generated;
         const downloadFileToast = {
           title: this.intl.t('publication-reports--toast-ready--title'),

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -1,15 +1,7 @@
 import Model, { attr } from '@ember-data/model';
-// eslint-disable-next-line ember/no-computed-properties-in-native-classes
-import { computed } from '@ember/object';
-import Evented from '@ember/object/evented';
 import CONFIG from 'frontend-kaleidos/config/constants';
 
-// FIXME: De Evented API en het gebruik van observers is deprecated, we zullen
-// hier dus ook van moeten afstappen. We moeten de code in de volgende plaatsen
-// ook aanpassen:
-// - publications.overview.reports controller
-// - Agenda::AgendaHeader::AgendaActions component
-export default class JobModel extends Model.extend(Evented) {
+export default class JobModel extends Model {
   RUNNING = CONFIG.JOB_STATUSSES.RUNNING;
   SUCCESS = CONFIG.JOB_STATUSSES.SUCCESS;
   FAILED = CONFIG.JOB_STATUSSES.FAILED;
@@ -19,17 +11,6 @@ export default class JobModel extends Model.extend(Evented) {
   @attr('datetime') timeStarted;
   @attr('datetime') timeEnded;
 
-  constructor() {
-    super(...arguments);
-    // eslint-disable-next-line ember/no-observers, ember/classic-decorator-no-classic-methods
-    this.addObserver('hasEnded', function () {
-      if (this.hasEnded) {
-        this.trigger('didEnd', this.status);
-      }
-    });
-  }
-
-  @computed('status', 'FAILED', 'SUCCESS')
   get hasEnded() {
     return this.status === this.SUCCESS || this.status === this.FAILED;
   }

--- a/app/services/job-monitor.js
+++ b/app/services/job-monitor.js
@@ -1,21 +1,19 @@
 import Service from '@ember/service';
-import { A } from '@ember/array';
 import { task, timeout } from 'ember-concurrency';
 
 export default class JobMonitorService extends Service {
-  jobs = A([]);
 
-  register(job) {
-    this.jobs.pushObject(job);
-    this.monitorJobProgress.perform(job);
+  register(job, callbackFn) {
+    this.monitorJobProgress.perform(job, callbackFn);
   }
 
   @task
-  *monitorJobProgress(job) {
+  *monitorJobProgress(job, callbackFn) {
     while (!job.hasEnded) {
       yield timeout(1000);
       yield job.reload();
     }
+    yield callbackFn(job);
     return job;
   }
 }


### PR DESCRIPTION
Now, the job monitor invokes the callback function that we previously ran when the didEnd event occurred. Events are no longer necessary because we can just check the job status inside the job monitor polling mechanism.