### PR TITLE
Feature/kas 3847 extra checks on sending newsletter

### DIFF
--- a/app/components/newsletter/newsletter-header-overview.js
+++ b/app/components/newsletter/newsletter-header-overview.js
@@ -206,7 +206,6 @@ export default class NewsletterHeaderOverviewComponent extends Component {
       'filter[in-newsletter]': true,
     })) > 0;
 
-    // return hasDocumentPublicationPlanned && hasThemes && hasNotas;
     return hasDocumentPublicationPlanned && hasNotasWithThemes;
   }
 

--- a/app/components/newsletter/newsletter-header-overview.js
+++ b/app/components/newsletter/newsletter-header-overview.js
@@ -199,17 +199,15 @@ export default class NewsletterHeaderOverviewComponent extends Component {
     const themisPublicationActivity = themisPublicationActivities.find((activity) => activity.scope.includes(CONSTANTS.THEMIS_PUBLICATION_SCOPES.DOCUMENTS));
 
     const hasDocumentPublicationPlanned = isPresent(themisPublicationActivity?.plannedDate);
-    const hasNotas = (await this.store.count('agendaitem', {
-      'filter[agenda][:id:]': agenda.id,
-      'filter[type][:uri:]': CONSTANTS.AGENDA_ITEM_TYPES.NOTA,
-    })) > 0;
-
-    const hasThemes = (await this.store.count('news-item', {
+    const hasNotasWithThemes = (await this.store.count('news-item', {
       'filter[agenda-item-treatment][agendaitems][agenda][:id:]': agenda.id,
+      'filter[agenda-item-treatment][agendaitems][type][:uri:]': CONSTANTS.AGENDA_ITEM_TYPES.NOTA,
       'filter[:has:themes]': true,
+      'filter[in-newsletter]': true,
     })) > 0;
 
-    return hasDocumentPublicationPlanned && hasThemes && hasNotas;
+    // return hasDocumentPublicationPlanned && hasThemes && hasNotas;
+    return hasDocumentPublicationPlanned && hasNotasWithThemes;
   }
 
   async validateMailCampaign() {

--- a/app/components/subcases/subcase-header.hbs
+++ b/app/components/subcases/subcase-header.hbs
@@ -83,7 +83,6 @@
 {{#if this.promptDeleteCase}}
   <WebComponents::VlModalVerify
     @title="Leeg dossier verwijderen?"
-    @verifyButtonText="Verwijderen"
     @message={{concat
       "Dossier '"
       this.caseToDelete.shortTitle

--- a/app/components/web-components/vl-modal-verify.js
+++ b/app/components/web-components/vl-modal-verify.js
@@ -9,7 +9,7 @@ import { action } from '@ember/object';
  * @param showActions {Boolean}
  * @param showVerify {Boolean}
  * @param buttonType {string}
- * @param buttonText {string}
+ * @param verifyButtonText {string}
  * @param isLoading {string}
  * @param onVerify {Function}
  * @param onCancel {Function}
@@ -28,7 +28,7 @@ export default class WebComponentsVlModalVerify extends Component {
   }
 
   get verifyButtonText() {
-    return this.intl.t(this.args.buttonText ?? 'delete');
+    return this.args.verifyButtonText ?? this.intl.t('delete');
   }
 
   get buttonTypeOrDanger() {


### PR DESCRIPTION
Also unifies the request to one request on news-item to ensure that
we're checking correctly. Otherwise if we check for notas and the
existence of themes separately, we'd allow notas in newsletter without
themes as long as there exists a nota with a theme.