### PR TITLE
test: update the profile names for Kabinet roles

### DIFF
--- a/cypress/integration/unit/user-organisation-management.spec.js
+++ b/cypress/integration/unit/user-organisation-management.spec.js
@@ -150,8 +150,8 @@ context('testing user and organisation management', () => {
       checkRoleFilterSingle('Ondersteuning Vlaamse Regering en Betekeningen', 12);
       checkRoleFilterSingle('Kort bestek redactie', 12);
       checkRoleFilterSingle('Minister', 12);
-      checkRoleFilterSingle('Kabinetdossierbeheerder', 12);
-      checkRoleFilterSingle('Kabinetmedewerker', 12);
+      checkRoleFilterSingle('Kabinetsdossierbeheerder', 12);
+      checkRoleFilterSingle('Kabinetsmedewerker', 12);
       checkRoleFilterSingle('Overheidsorganisatie', 12);
       checkRoleFilterSingle('Vlaams Parlement', 12);
     });


### PR DESCRIPTION
They're now Kabinet*s*dossierbeheerder and
Kabinet*s*medewerker.

Should fix one of the failing tests on dev branch.