### PR TITLE
fix: only show correct ministers in checkbox filter

### DIFF
--- a/app/components/search/minister-filter.js
+++ b/app/components/search/minister-filter.js
@@ -111,6 +111,7 @@ export default class SearchMinisterFilterComponent extends Component {
       sort: 'last-name'
     });
     this.pastMinisters = allMinisters
-      .filter((minister) => !this.currentMinisters.includes(minister));
+      .filter((minister) => !this.currentMinisters.includes(minister))
+      .filter((minister) => minister.uri.startsWith('http://themis.vlaanderen.be'));
   }
 }


### PR DESCRIPTION
While we work on properly removing the incorrect ministers, we can at least still show the filter.