### PR TITLE
fix warning message shows when bronbestand was docx file before conve…

### DIFF
--- a/app/components/documents/document-view.hbs
+++ b/app/components/documents/document-view.hbs
@@ -6,7 +6,7 @@
       class="pdf-view"
     >
     </object>
-  {{else}}
+  {{else if this.showWarning}}
     <div class="auk-u-p-4">
       <Auk::Alert
         @skin="warning"

--- a/app/components/documents/document-view.js
+++ b/app/components/documents/document-view.js
@@ -1,9 +1,19 @@
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
 const PDF_MIME = 'application/pdf';
 const PDF_EXTENSION = 'pdf';
 
 export default class DocumentsDocumentView extends Component {
+  @tracked showWarning = false;
+
+  constructor() {
+    super(...arguments);
+    //this is a workaround to delay the showing of the warning message for incompatible file types
+    setTimeout(() => {
+      this.showWarning = true
+    }, 500)
+  }
   get isPdfDocument() {
     if (this.args.file) {
       return this.args.file.get('format').toLowerCase().includes(PDF_MIME)
@@ -12,4 +22,5 @@ export default class DocumentsDocumentView extends Component {
       return false;
     }
   }
+
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3828

I added a workaround using a timeout that shows the warning after 0.5s if there's a docx file