### PR TITLE
Feature/kas 3913 revert toon aangepaste punten toggle in agenda

### DIFF
--- a/app/components/agenda/agenda-detail/sidebar.hbs
+++ b/app/components/agenda/agenda-detail/sidebar.hbs
@@ -7,6 +7,17 @@
         </h4>
       </Auk::Toolbar::Item>
     </Auk::Toolbar::Group>
+    <Auk::Toolbar::Group @position="right">
+      <Auk::Toolbar::Item>
+        {{!-- TODO: this button needs to be displayed in a smaller size --}}
+        <AuButton
+          @skin="link"
+          {{on "click" @toggleShowModifiedOnly}}
+        >
+          {{if @showModifiedOnly (t "show-all") (t "show-changes")}}
+        </AuButton>
+      </Auk::Toolbar::Item>
+    </Auk::Toolbar::Group>
   </Auk::Toolbar>
 </Auk::Navbar>
 <div>

--- a/app/components/agenda/agenda-detail/sidebar.js
+++ b/app/components/agenda/agenda-detail/sidebar.js
@@ -6,6 +6,8 @@ import templateOnly from '@ember/component/template-only';
   * @argument announcements: Array of agendaitems with type announcement
   * @argument newItems: items to be marked as "new on this agenda"
   * @argument currentAgenda: the agenda that is currently open
+  * @argument showModifiedOnly: if we should filter only on modified agendaitems
+  * @argument toggleShowModifiedOnly: toggle the parent to set the modified filter on or off
   * @argument activeItem: the currently selected agendaitem
   */
 export default templateOnly();

--- a/app/components/agenda/agenda-overview.hbs
+++ b/app/components/agenda/agenda-overview.hbs
@@ -20,6 +20,13 @@
     <Auk::Toolbar::Group @position="right">
       <Auk::Toolbar::Item>
         <AuButtonGroup>
+          <AuButton
+            data-test-agenda-overview-show-changes={{true}}
+            @skin="naked"
+            {{on "click" @toggleShowModifiedOnly}}
+          >
+            {{if @showModifiedOnly (t "show-all") (t "show-changes")}}
+          </AuButton>
           {{#if this.canEdit}}
             {{#unless @isEditingOverview}}
               <AuButton

--- a/app/components/agenda/agenda-overview.js
+++ b/app/components/agenda/agenda-overview.js
@@ -11,6 +11,8 @@ export default class AgendaOverview extends Component {
    * @argument currentAgenda: the agenda that is currently open
    * @argument previousAgenda: the previous version of the currently open agenda
    * @argument onReorderAgendaitems: trigger the parent's action when we reorder agendaitems (by dragging)
+   * @argument showModifiedOnly: if we should filter only on modified agendaitems
+   * @argument toggleShowModifiedOnly: toggle the parent to set the modified filter on or off
    * @argument isEditingOverview {Boolean} If the overview is in edit mode
    * @argument toggleIsEditingOverview {Function} Function to call to toggle editing state
    */

--- a/app/controllers/agenda/agendaitems.js
+++ b/app/controllers/agenda/agendaitems.js
@@ -22,6 +22,9 @@ export default class AgendaAgendaitemsController extends Controller {
       filter: {
         type: 'string',
       },
+      showModifiedOnly: {
+        type: 'boolean',
+      },
       anchor: {
         type: 'string',
       },
@@ -45,6 +48,7 @@ export default class AgendaAgendaitemsController extends Controller {
   @tracked isEditingOverview = false;
 
   // @tracked filter; // TODO: don't do tracking on qp's before updating to Ember 3.22+ (https://github.com/emberjs/ember.js/issues/18715)
+  // @tracked showModifiedOnly;
   // @tracked anchor;
 
   get id() {
@@ -113,6 +117,11 @@ export default class AgendaAgendaitemsController extends Controller {
       await this.throttledLoadingService.loadPieces.perform(agendaitem);
       this.documentLoadCount++;
     }));
+  }
+
+  @action
+  toggleShowModifiedOnly() {
+    set(this,'showModifiedOnly', !this.showModifiedOnly);
   }
 
   scrollToAnchor() {

--- a/app/routes/agenda/agendaitems.js
+++ b/app/routes/agenda/agendaitems.js
@@ -12,6 +12,10 @@ export default class AgendaAgendaitemsRoute extends Route {
     filter: {
       refreshModel: true,
     },
+    showModifiedOnly: {
+      refreshModel: true,
+      as: 'toon_enkel_gewijzigd',
+    },
     anchor: {
       refreshModel: false,
     },
@@ -50,6 +54,14 @@ export default class AgendaAgendaitemsRoute extends Route {
       newItems = await this.agendaService.newAgendaItems(agenda.id, previousAgenda.id);
     } else {
       newItems = agendaitems;
+    }
+
+    if (params.showModifiedOnly) {
+      // "modified" here is interpreted as "new item or existing item with changes in its related documents"
+      if (previousAgenda) {
+        const modItems = await this.agendaService.modifiedAgendaItems(agenda.id, previousAgenda.id, ['documents']);
+        agendaitems = agendaitems.filter((item) => [...new Set(newItems.concat(modItems))].includes(item));
+      }
     }
 
     if (params.filter) {

--- a/app/services/agenda-service.js
+++ b/app/services/agenda-service.js
@@ -46,6 +46,22 @@ export default class AgendaService extends Service {
     return itemsFromStore;
   }
 
+  async modifiedAgendaItems(currentAgendaId, comparedAgendaId, scopeFields) {
+    // scopefields specify which fields to base upon for determining if an item was modified
+    const url = `/agendas/${currentAgendaId}/compare/${comparedAgendaId}/agenda-items?changeset=modified&scope=${scopeFields.join(',')}`;
+    const response = await fetch(url);
+    const payload = await response.json();
+    const itemsFromStore = [];
+    for (const item of payload.data) {
+      let itemFromStore = this.store.peekRecord(singularize(item.type), item.id);
+      if (!itemFromStore) {
+        itemFromStore = await this.store.queryRecord(singularize(item.type), item.id);
+      }
+      itemsFromStore.push(itemFromStore);
+    }
+    return itemsFromStore;
+  }
+
   async changedPieces(currentAgendaId, comparedAgendaId, agendaItemId) {
     if (!this.currentSession.may('view-document-version-info')) {
       return [];

--- a/app/templates/agenda/agendaitems.hbs
+++ b/app/templates/agenda/agendaitems.hbs
@@ -18,6 +18,8 @@
             @announcements={{this.model.announcements}}
             @newItems={{this.model.newItems}}
             @currentAgenda={{this.agenda}}
+            @showModifiedOnly={{this.showModifiedOnly}}
+            @toggleShowModifiedOnly={{this.toggleShowModifiedOnly}}
             @activeItem={{this.selectedAgendaitem}}
           />
         </div>
@@ -50,6 +52,8 @@
             @currentAgenda={{this.agenda}}
             @previousAgenda={{this.previousAgenda}}
             @onReorderAgendaitems={{perform this.assignNewPriorities}}
+            @showModifiedOnly={{this.showModifiedOnly}}
+            @toggleShowModifiedOnly={{this.toggleShowModifiedOnly}}
             @isEditingOverview={{this.isEditingOverview}}
             @toggleIsEditingOverview={{toggle "isEditingOverview" this}}
           />

--- a/cypress/integration/all-flaky-tests/profile-minister.spec.js
+++ b/cypress/integration/all-flaky-tests/profile-minister.spec.js
@@ -102,6 +102,7 @@ context('Testing the application as Minister user', () => {
       cy.get(agenda.agendaitemSearch.input);
 
       // Overview Tab - General actions
+      cy.get(agenda.agendaOverview.showChanges);
       cy.get(agenda.agendaOverview.formallyOkEdit).should('not.exist');
       cy.get(agenda.agendaOverviewItem.dragging).should('not.exist');
 
@@ -202,6 +203,7 @@ context('Testing the application as Minister user', () => {
       cy.get(agenda.agendaitemSearch.input);
 
       // Overview Tab - General actions
+      cy.get(agenda.agendaOverview.showChanges);
       cy.get(agenda.agendaOverview.formallyOkEdit).should('not.exist');
       cy.get(agenda.agendaOverviewItem.dragging).should('not.exist');
 

--- a/cypress/integration/all-flaky-tests/profile-overheidsorganisatie.spec.js
+++ b/cypress/integration/all-flaky-tests/profile-overheidsorganisatie.spec.js
@@ -102,6 +102,7 @@ context('Testing the application as Overheid user', () => {
       cy.get(agenda.agendaitemSearch.input);
 
       // Overview Tab - General actions
+      cy.get(agenda.agendaOverview.showChanges);
       cy.get(agenda.agendaOverview.formallyOkEdit).should('not.exist');
       cy.get(agenda.agendaOverviewItem.dragging).should('not.exist');
 
@@ -194,6 +195,7 @@ context('Testing the application as Overheid user', () => {
       cy.get(agenda.agendaitemSearch.input);
 
       // Overview Tab - General actions
+      cy.get(agenda.agendaOverview.showChanges);
       cy.get(agenda.agendaOverview.formallyOkEdit).should('not.exist');
       cy.get(agenda.agendaOverviewItem.dragging).should('not.exist');
 

--- a/cypress/integration/unit/agenda.spec.js
+++ b/cypress/integration/unit/agenda.spec.js
@@ -269,7 +269,8 @@ context('Agenda tests', () => {
     // let the command do the work
     cy.closeAgenda();
     // Closing an agenda should remove any design agenda
-    // check absence of the formally ok edit
+    // check existence of showChanges and absence of the formally ok edit
+    cy.get(agenda.agendaOverview.showChanges);
     cy.get(agenda.agendaOverview.formallyOkEdit).should('not.exist');
     // By checking the length of agendas and confirming "Agenda A", no other agenda exists
     cy.get(agenda.agendaSideNav.agenda).should('have.length', 1);

--- a/cypress/integration/unit/profile-admin.spec.js
+++ b/cypress/integration/unit/profile-admin.spec.js
@@ -154,6 +154,7 @@ context('Testing the application as Admin user', () => {
       cy.get(agenda.agendaitemSearch.input);
 
       // Overview Tab - General actions
+      cy.get(agenda.agendaOverview.showChanges);
       cy.get(agenda.agendaOverview.formallyOkEdit);
 
       // Overview Tab - General action - Dragging
@@ -314,6 +315,7 @@ context('Testing the application as Admin user', () => {
       cy.get(agenda.agendaitemSearch.input);
 
       // Overview Tab - General actions
+      cy.get(agenda.agendaOverview.showChanges);
       cy.get(agenda.agendaOverview.formallyOkEdit).should('not.exist');
       cy.get(agenda.agendaOverviewItem.dragging).should('not.exist');
 

--- a/cypress/integration/unit/profile-kabinet-dossierbeheerder.spec.js
+++ b/cypress/integration/unit/profile-kabinet-dossierbeheerder.spec.js
@@ -84,6 +84,7 @@ context('Testing the application as Kabinetdossierbeheerder', () => {
       cy.get(agenda.agendaitemSearch.input);
 
       // Overview Tab - General actions
+      cy.get(agenda.agendaOverview.showChanges);
       cy.get(agenda.agendaOverview.formallyOkEdit).should('not.exist');
       cy.get(agenda.agendaOverviewItem.dragging).should('not.exist');
 
@@ -184,6 +185,7 @@ context('Testing the application as Kabinetdossierbeheerder', () => {
       cy.get(agenda.agendaitemSearch.input);
 
       // Overview Tab - General actions
+      cy.get(agenda.agendaOverview.showChanges);
       cy.get(agenda.agendaOverview.formallyOkEdit).should('not.exist');
       cy.get(agenda.agendaOverviewItem.dragging).should('not.exist');
 

--- a/cypress/integration/unit/profile-kabinet-medewerker.spec.js
+++ b/cypress/integration/unit/profile-kabinet-medewerker.spec.js
@@ -84,6 +84,7 @@ context('Testing the application as Kabinetmedewerker', () => {
       cy.get(agenda.agendaitemSearch.input);
 
       // Overview Tab - General actions
+      cy.get(agenda.agendaOverview.showChanges);
       cy.get(agenda.agendaOverview.formallyOkEdit).should('not.exist');
       cy.get(agenda.agendaOverviewItem.dragging).should('not.exist');
 
@@ -184,6 +185,7 @@ context('Testing the application as Kabinetmedewerker', () => {
       cy.get(agenda.agendaitemSearch.input);
 
       // Overview Tab - General actions
+      cy.get(agenda.agendaOverview.showChanges);
       cy.get(agenda.agendaOverview.formallyOkEdit).should('not.exist');
       cy.get(agenda.agendaOverviewItem.dragging).should('not.exist');
 

--- a/cypress/integration/unit/profile-kort-bestek.spec.js
+++ b/cypress/integration/unit/profile-kort-bestek.spec.js
@@ -125,6 +125,7 @@ context('Testing the application as Kort bestek user', () => {
       cy.get(agenda.agendaitemSearch.input);
 
       // Overview Tab - General actions
+      cy.get(agenda.agendaOverview.showChanges);
       cy.get(agenda.agendaOverview.formallyOkEdit).should('not.exist');
       cy.get(agenda.agendaOverviewItem.dragging).should('not.exist');
 
@@ -230,6 +231,7 @@ context('Testing the application as Kort bestek user', () => {
       cy.get(agenda.agendaitemSearch.input);
 
       // Overview Tab - General actions
+      cy.get(agenda.agendaOverview.showChanges);
       cy.get(agenda.agendaOverview.formallyOkEdit).should('not.exist');
       cy.get(agenda.agendaOverviewItem.dragging).should('not.exist');
 

--- a/cypress/integration/unit/profile-ovrb.spec.js
+++ b/cypress/integration/unit/profile-ovrb.spec.js
@@ -101,6 +101,7 @@ context('Testing the application as OVRB', () => {
       cy.get(agenda.agendaitemSearch.input);
 
       // Overview Tab - General actions
+      cy.get(agenda.agendaOverview.showChanges);
       cy.get(agenda.agendaOverview.formallyOkEdit).should('not.exist');
       cy.get(agenda.agendaOverviewItem.dragging).should('not.exist');
 
@@ -198,6 +199,7 @@ context('Testing the application as OVRB', () => {
       cy.get(agenda.agendaitemSearch.input);
 
       // Overview Tab - General actions
+      cy.get(agenda.agendaOverview.showChanges);
       cy.get(agenda.agendaOverview.formallyOkEdit).should('not.exist');
       cy.get(agenda.agendaOverviewItem.dragging).should('not.exist');
 

--- a/cypress/integration/unit/profile-secretarie.spec.js
+++ b/cypress/integration/unit/profile-secretarie.spec.js
@@ -126,6 +126,7 @@ context('Testing the application as Secretarie user', () => {
       cy.get(agenda.agendaitemSearch.input);
 
       // Overview Tab - General actions
+      cy.get(agenda.agendaOverview.showChanges);
       cy.get(agenda.agendaOverview.formallyOkEdit);
 
       // Overview Tab - General action - Dragging
@@ -286,6 +287,7 @@ context('Testing the application as Secretarie user', () => {
       cy.get(agenda.agendaitemSearch.input);
 
       // Overview Tab - General actions
+      cy.get(agenda.agendaOverview.showChanges);
       cy.get(agenda.agendaOverview.formallyOkEdit).should('not.exist');
       cy.get(agenda.agendaOverviewItem.dragging).should('not.exist');
 

--- a/cypress/integration/unit/profile-vlaams-parlement.spec.js
+++ b/cypress/integration/unit/profile-vlaams-parlement.spec.js
@@ -84,6 +84,7 @@ context('Testing the application as Vlaams Parlement', () => {
       cy.get(agenda.agendaitemSearch.input);
 
       // Overview Tab - General actions
+      cy.get(agenda.agendaOverview.showChanges);
       cy.get(agenda.agendaOverview.formallyOkEdit).should('not.exist');
       cy.get(agenda.agendaOverviewItem.dragging).should('not.exist');
 
@@ -176,6 +177,7 @@ context('Testing the application as Vlaams Parlement', () => {
       cy.get(agenda.agendaitemSearch.input);
 
       // Overview Tab - General actions
+      cy.get(agenda.agendaOverview.showChanges);
       cy.get(agenda.agendaOverview.formallyOkEdit).should('not.exist');
       cy.get(agenda.agendaOverviewItem.dragging).should('not.exist');
 

--- a/cypress/selectors/agenda.selectors.js
+++ b/cypress/selectors/agenda.selectors.js
@@ -69,6 +69,7 @@ const selectors = {
   // agenda-overview
   agendaOverview: {
     notesSectionTitle: '[data-test-agenda-overview-section-title-notes]',
+    showChanges: '[data-test-agenda-overview-show-changes]',
     formallyOkEdit: '[data-test-agenda-overview-formally-ok-edit]',
   },
 

--- a/cypress/support/commands/agenda-commands.js
+++ b/cypress/support/commands/agenda-commands.js
@@ -489,7 +489,7 @@ function addAgendaitemToAgenda(subcaseTitle) {
  */
 function toggleShowChanges() {
   cy.log('toggleShowChanges');
-  cy.clickReverseTab('Overzicht');
+  // cy.clickReverseTab('Overzicht');
   cy.get(auk.loader).should('not.exist'); // data is not loading
   cy.get(agenda.agendaOverview.showChanges).click();
   // data loading is triggered so we check for the loader

--- a/cypress/support/commands/agenda-commands.js
+++ b/cypress/support/commands/agenda-commands.js
@@ -482,6 +482,22 @@ function addAgendaitemToAgenda(subcaseTitle) {
 }
 
 /**
+ * @description Toggles the show changes
+ * @name toggleShowChanges
+ * @memberOf Cypress.Chainable#
+ * @function
+ */
+function toggleShowChanges() {
+  cy.log('toggleShowChanges');
+  cy.clickReverseTab('Overzicht');
+  cy.get(auk.loader).should('not.exist'); // data is not loading
+  cy.get(agenda.agendaOverview.showChanges).click();
+  // data loading is triggered so we check for the loader
+  cy.get(auk.loader).should('not.exist');
+  cy.log('/toggleShowChanges');
+}
+
+/**
  * @description Checks if an agendaitem with a specific name exists on an agenda,
  * if you want to open the agendaitem at the same time, use cy.openDetailOfAgendaitem(agendaitemName)
  * @name agendaitemExists
@@ -724,6 +740,7 @@ Cypress.Commands.add('deleteAgenda', deleteAgenda);
 Cypress.Commands.add('setFormalOkOnItemWithIndex', setFormalOkOnItemWithIndex);
 Cypress.Commands.add('approveDesignAgenda', approveDesignAgenda);
 Cypress.Commands.add('addAgendaitemToAgenda', addAgendaitemToAgenda);
+Cypress.Commands.add('toggleShowChanges', toggleShowChanges);
 Cypress.Commands.add('agendaitemExists', agendaitemExists);
 Cypress.Commands.add('openDetailOfAgendaitem', openDetailOfAgendaitem);
 Cypress.Commands.add('changeSelectedAgenda', changeSelectedAgenda);

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -475,6 +475,8 @@
   "normal-meeting": "Niet-elektronisch",
   "flemish-government": "Vlaamse Regering",
   "added-agendaitem-text": "Nieuw agendapunt",
+  "show-changes": "Toon aangepaste punten",
+  "show-all": "Toon alle punten",
   "national-number": "VO-ID",
   "last-name": "Achternaam",
   "group": "Groep",


### PR DESCRIPTION
This is a revert of https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1614

Automatic revert on github failed because of conflicts. Checked out the current `development` branch, and then reverted the 3 commits in the original PR (not the merge) 1 by 1. Then resolved the conflicts (by always choosing `development`) and added the translation keys back in.

I left the tests to the newer ones that check for the green markers, especially in case the users decide later on that this function can be removed after all... @ValenberghsSven you can decide to add the `toggleShowChanges` action back in the tests if you prefer to have both of them, but for me this is not required. 