### PR TITLE
KAS-3869: Show previous agenda versions in agendaitem card

### DIFF
--- a/app/components/search/result-cards/agendaitem.hbs
+++ b/app/components/search/result-cards/agendaitem.hbs
@@ -45,14 +45,15 @@
         {{@agendaSerialNumber}}
       </span>
     </p>
-    {{! <p class="au-u-para-small au-u-margin-top-none au-u-muted">
-      Ook gevonden in
-      <AuLink @skin="secondary">
-        Versie B
-      </AuLink>,
-      <AuLink @skin="secondary">
-        Versie A
-      </AuLink>
-    </p> }}
+    {{#if @pastAgendaVersions}}
+      <p class="au-u-para-small au-u-margin-top-none au-u-muted">
+        {{t "also-found-in"}}
+        {{#each @pastAgendaVersions as |pastAgendaVersion|}}
+          <AuLink @skin="secondary">
+            {{t "version"}} {{pastAgendaVersion}}{{#if (has-next pastAgendaVersion @pastAgendaVersions)}},{{/if}}
+          </AuLink>
+        {{/each}}
+      </p>
+    {{/if}}
   </c.content>
 </AuCard>

--- a/app/routes/search/agendaitems.js
+++ b/app/routes/search/agendaitems.js
@@ -135,7 +135,7 @@ export default class AgendaitemSearchRoute extends Route {
       (agendaitem) => {
         const entry = { ...agendaitem.attributes, ...agendaitem.highlight };
         entry.id = agendaitem.id;
-        console.log(entry.shortTitle);
+        this.postProcessPastAgendaVersions(entry);
 
         if (entry.shortTitle && Array.isArray(entry.shortTitle)) {
           entry.shortTitle = entry.shortTitle.join('');
@@ -169,5 +169,15 @@ export default class AgendaitemSearchRoute extends Route {
       controller.isLoadingModel = false;
     });
     return true;
+  }
+
+  postProcessPastAgendaVersions(entry) {
+    const pastAgendaitems = entry.agendaitemTreatment.agendaitems;
+    if (Array.isArray(pastAgendaitems)) {
+      entry.pastAgendaVersions = pastAgendaitems
+        .map((agendaitem) => agendaitem.agendaSerialNumber)
+        .filter((agendaSerialNumber) => agendaSerialNumber != entry.agendaSerialNumber)
+        .sort();
+    }
   }
 }

--- a/app/routes/search/agendaitems.js
+++ b/app/routes/search/agendaitems.js
@@ -172,12 +172,14 @@ export default class AgendaitemSearchRoute extends Route {
   }
 
   postProcessPastAgendaVersions(entry) {
-    const pastAgendaitems = entry.agendaitemTreatment.agendaitems;
-    if (Array.isArray(pastAgendaitems)) {
-      entry.pastAgendaVersions = pastAgendaitems
-        .map((agendaitem) => agendaitem.agendaSerialNumber)
-        .filter((agendaSerialNumber) => agendaSerialNumber != entry.agendaSerialNumber)
-        .sort();
+    if (entry.agendaitemTreatment) {
+      const pastAgendaitems = entry.agendaitemTreatment.agendaitems;
+      if (Array.isArray(pastAgendaitems)) {
+        entry.pastAgendaVersions = pastAgendaitems
+          .map((agendaitem) => agendaitem.agendaSerialNumber)
+          .filter((agendaSerialNumber) => agendaSerialNumber != entry.agendaSerialNumber)
+          .sort();
+      }
     }
   }
 }

--- a/app/templates/search/agendaitems.hbs
+++ b/app/templates/search/agendaitems.hbs
@@ -70,6 +70,7 @@
             @agendaItemId={{row.id}}
             @shortTitle={{row.shortTitle}}
             @title={{row.title}}
+            @pastAgendaVersions={{row.pastAgendaVersions}}
           />
         </td>
       </:body>

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1156,5 +1156,6 @@
   "found-inside": "Gevonden in",
   "found-in-thing": "Gevonden in {thing}",
   "and-one-other-subcase": "en nog 1 andere procedurestap",
-  "and-n-other-subcases": "en nog {n} andere procedurestappen"
+  "and-n-other-subcases": "en nog {n} andere procedurestappen",
+  "also-found-in": "Ook gevonden in"
 }


### PR DESCRIPTION
Displas the "Ook gevonden in Agenda X" message in agendaitem result cards when an agendaitem is found multiple versions of an agenda.

Related PRs:
- [ ] https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/369