### PR TITLE
Hotfix/search result headers & highlighting

### DIFF
--- a/app/components/search/result-cards/case.hbs
+++ b/app/components/search/result-cards/case.hbs
@@ -7,8 +7,7 @@
   <card.header>
     <div class="au-u-flex">
       <p class="au-u-para-small au-u-muted au-u-medium">
-        {{t "case-created"}}
-        {{date @created}}
+        {{date @sessionDate}}
       </p>
       {{#if (eq @isArchived "true")}}
         <AuPill @size="small" @skin="border">{{t "deleted-case"}}</AuPill>

--- a/app/styles/auk/_auk-additions.scss
+++ b/app/styles/auk/_auk-additions.scss
@@ -343,6 +343,6 @@ table tr.lt-expanded-row {
 // Result cards
 // Workaround until we adapt mu-search to send more specific tags for highlights
 .result-card em {
-  font-weight: bold;
   font-style: inherit;
+  background: #E4EBF5;
 }

--- a/app/templates/search/cases.hbs
+++ b/app/templates/search/cases.hbs
@@ -66,7 +66,7 @@
       <:body as |row|>
         <td>
           <Search::ResultCards::Case
-            @created={{row.attributes.created}}
+            @sessionDate={{row.attributes.sessionDates}}
             @shortTitle={{row.highlight.shortTitle}}
             @title={{row.highlight.title}}
             @caseId={{row.id}}

--- a/app/templates/search/documents.hbs
+++ b/app/templates/search/documents.hbs
@@ -18,7 +18,7 @@
       @pageIdx={{this.page}}
       @nbOfItems={{this.model.length}}
       @searchText={{this.searchText}}
-      @searchType={{t "cases"}}
+      @searchType={{t "documents"}}
       @onSortChange={{this.selectSort}}
       @sortOptions={{this.sortOptions}}
       @sort={{this.sort}}

--- a/app/templates/search/news-items.hbs
+++ b/app/templates/search/news-items.hbs
@@ -6,7 +6,7 @@
       @pageIdx={{this.page}}
       @nbOfItems={{this.model.length}}
       @searchText={{this.searchText}}
-      @searchType={{t "agenda"}}
+      @searchType={{t "news-items"}}
       @onSortChange={{this.selectSort}}
       @sortOptions={{this.sortOptions}}
       @sort={{this.sort}}

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1161,5 +1161,6 @@
   "and-n-other-subcases": "en nog {n} andere procedurestappen",
   "also-found-in": "Ook gevonden in",
   "uploaded-in-thing": "Geüpload in {thing}",
-  "creation-date": "Aanmaakdatum"
+  "creation-date": "Aanmaakdatum",
+  "news-items": "Kort bestek berichten"
 }


### PR DESCRIPTION
Fixes the wrong headers in search results & adds light blue highlighting instead of bolding.

EDIT: Also replaces the display date on case result cards with the session date instead of the creation date.