### PR TITLE
KAS-3942: Synchroniseren van witruimte bij au-c-content elementen tussen editor en read-only view

### DIFF
--- a/app/styles/addon-overrides/_ember-rdfa-editor.scss
+++ b/app/styles/addon-overrides/_ember-rdfa-editor.scss
@@ -82,6 +82,15 @@ $say-editor-border-radius: $au-input-border-radius;
     @include au-font-size(1.8rem);
   }
 
+  > * + * {
+    margin-top: 1.5rem;
+  }
+
+  > p + ul,
+  > p + ol {
+    margin-top: 0;
+  }
+
   ul,
   ol {
     margin-left: 2.8rem;

--- a/app/styles/au/_au-components.scss
+++ b/app/styles/au/_au-components.scss
@@ -153,7 +153,7 @@ $au-button-height: 3.4rem;
   }
 
   ul:not(.au-c-list-horizontal) li + li { // override list item spacing to match the one in Kaleidos a bit more
-    margin-top: 0.3rem;
+    margin-top: 0.1rem;
   }
 
   ul.au-c-list  li + li { // this styling needs to be reset again unfortunately
@@ -163,6 +163,11 @@ $au-button-height: 3.4rem;
   // override child (and heading) spacing to match the one in Kaleidos a bit more
   > * + * {
     margin-top: 1.5rem;
+  }
+
+  > p + ul,
+  > p + ol {
+    margin-top: 0.2rem;
   }
 
   > * + h1,


### PR DESCRIPTION
**Tickets binnen Jira:** 
- https://kanselarij.atlassian.net/browse/KAS-3942

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.