### PR TITLE
fix: add an override for transitive ember-auto-focus dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,5 +153,10 @@
   },
   "engines": {
     "node": "12 || 14 || >= 16"
+  },
+  "overrides": {
+    "@appuniversum/ember-appuniversum": {
+      "@zestia/ember-auto-focus": "4.4.0"
+    }
   }
 }


### PR DESCRIPTION
It bumped ember-modifier to v4 but that breaks our app until we upgrade.