### PR TITLE
fix: link agendaitems without short title from document result card

### DIFF
--- a/app/components/search/result-cards/document.hbs
+++ b/app/components/search/result-cards/document.hbs
@@ -34,20 +34,30 @@
         …<SanitizeHtml @raw={{true}} @value={{object-at 0 @contentHighlight}} />…
       </p>
     {{/if}}
-    {{#if (and @agendaitemShortTitle @meetingId @agendaId @agendaitemId)}}
+    {{#if (and @meetingId @agendaId @agendaitemId)}}
       <p class="au-u-para-small au-u-muted">
-        {{t "uploaded-in-thing" thing=(t "agendaitem")}}
-        <AuLink
-          @route="agenda.agendaitems.agendaitem"
-          @models={{array @meetingId @agendaId @agendaitemId}}
-        >
-          <span>
-            <SanitizeHtml
-              @raw={{true}}
-              @value={{@agendaitemShortTitle}}
-            />
-          </span>
-        </AuLink>
+        {{#if @agendaitemShortTitle}}
+          {{t "uploaded-in-thing" thing=(t "agendaitem")}}
+          <AuLink
+            @route="agenda.agendaitems.agendaitem"
+            @models={{array @meetingId @agendaId @agendaitemId}}
+          >
+            <span>
+              <SanitizeHtml
+                @raw={{true}}
+                @value={{@agendaitemShortTitle}}
+              />
+            </span>
+          </AuLink>
+        {{else}}
+          {{t "uploaded-in"}}
+          <AuLink
+            @route="agenda.agendaitems.agendaitem"
+            @models={{array @meetingId @agendaId @agendaitemId}}
+          >
+            {{t "agendaitem"}}
+          </AuLink>
+        {{/if}}
       </p>
     {{else}}
       <p class="au-u-para-small au-u-muted">

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1157,6 +1157,7 @@
   "and-one-other-subcase": "en nog 1 andere procedurestap",
   "and-n-other-subcases": "en nog {n} andere procedurestappen",
   "also-found-in": "Ook gevonden in",
+  "uploaded-in": "Geüpload in",
   "uploaded-in-thing": "Geüpload in {thing}",
   "creation-date": "Aanmaakdatum",
   "all-content": "Alle inhoud",


### PR DESCRIPTION
Mostly legacy data doesn't containt short titles for agendaitems. Ideally we index both the agendaitem short- and long title in the pieces index, but that's currently not the case. For the time being, when an agendaitem lacks a shortTitle we will just show no title and make "agendapunt" clickable.