### PR TITLE
KAS-3977: Disable save button when uploading files

### DIFF
--- a/app/components/documents/document-card/edit-modal.hbs
+++ b/app/components/documents/document-card/edit-modal.hbs
@@ -5,6 +5,7 @@
   @onCancel={{this.cancelEdit}}
   @confirmMessage={{t "save"}}
   @loading={{this.saveEdit.isRunning}}
+  @disabled={{this.isDisabled}}
 >
   <:body>
     <AuCard
@@ -41,10 +42,11 @@
           </AuHelpText>
         {{/if}}
       </c.header>
-      {{#if this.isUploadingReplacementSourceFile}}
+      {{#if this.isReplacingSourceFile}}
         <c.content data-test-document-edit-source-file-replacer>
           <Auk::FileUploader
             @onUpload={{set this "replacementSourceFile"}}
+            @onQueueUpdate={{this.handleReplacementSourceFileUploadQueue}}
           />
         </c.content>
       {{/if}}
@@ -92,10 +94,11 @@
             </AuHelpText>
           {{/if}}
         </c.header>
-        {{#if this.isUploadingReplacementDerivedFile}}
+        {{#if this.isReplacingDerivedFile}}
           <c.content data-test-document-edit-derived-file-replacer>
             <Auk::FileUploader
               @onUpload={{set this "replacementDerivedFile"}}
+              @onQueueUpdate={{this.handleReplacementDerivedFileUploadQueue}}
             />
           </c.content>
         {{/if}}
@@ -117,6 +120,7 @@
         <c.content data-test-document-edit-derived-file-uploader>
           <Auk::FileUploader
             @onUpload={{set this "uploadedDerivedFile"}}
+            @onQueueUpdate={{this.handleDerivedFileUploadQueue}}
           />
         </c.content>
       </AuCard>

--- a/app/components/documents/document-card/edit-modal.js
+++ b/app/components/documents/document-card/edit-modal.js
@@ -14,9 +14,13 @@ export default class DocumentsDocumentCardEditModalComponent extends Component {
   @service toaster;
   @service fileConversionService;
 
+  @tracked isReplacingSourceFile = false;
+  @tracked isReplacingDerivedFile = false;
+  @tracked isUploadingDerivedFile = false;
+  @tracked isDeletingDerivedFile = false;
+
   @tracked isUploadingReplacementSourceFile = false;
   @tracked isUploadingReplacementDerivedFile = false;
-  @tracked isDeletingDerivedFile = false;
 
   @tracked name;
   @tracked uploadedDerivedFile;
@@ -29,18 +33,42 @@ export default class DocumentsDocumentCardEditModalComponent extends Component {
     this.name = this.args.piece.name;
   }
 
+  get isDisabled() {
+    return (
+      this.saveEdit.isRunning
+        || this.isUploadingDerivedFile
+        || this.isUploadingReplacementDerivedFile
+        || this.isUploadingReplacementSourceFile
+    );
+  }
+
+  @action
+  handleDerivedFileUploadQueue({ uploadIsRunning, uploadIsCompleted}) {
+    this.isUploadingDerivedFile = uploadIsRunning && !uploadIsCompleted;
+  }
+
+  @action
+  handleReplacementSourceFileUploadQueue({ uploadIsRunning, uploadIsCompleted}) {
+    this.isUploadingReplacementSourceFile = uploadIsRunning && !uploadIsCompleted;
+  }
+
+  @action
+  handleReplacementDerivedFileUploadQueue({ uploadIsRunning, uploadIsCompleted}) {
+    this.isUploadingReplacementDerivedFile = uploadIsRunning && !uploadIsCompleted;
+  }
+
   @action
   async toggleUploadReplacementSourceFile() {
     await this.replacementSourceFile?.destroyRecord();
     this.replacementSourceFile = null;
-    this.isUploadingReplacementSourceFile = !this.isUploadingReplacementSourceFile;
+    this.isReplacingSourceFile = !this.isReplacingSourceFile;
   }
 
   @action
   async toggleUploadReplacementDerivedFile() {
     await this.replacementDerivedFile?.destroyRecord();
     this.replacementDerivedFile = null;
-    this.isUploadingReplacementDerivedFile = !this.isUploadingReplacementDerivedFile;
+    this.isReplacingDerivedFile = !this.isReplacingDerivedFile;
   }
 
   @action
@@ -48,11 +76,11 @@ export default class DocumentsDocumentCardEditModalComponent extends Component {
     this.name = null;
 
     await this.replacementSourceFile?.destroyRecord();
-    this.isUploadingReplacementSourceFile = false;
+    this.isReplacingSourceFile = false;
     this.replacementSourceFile = null;
 
     await this.replacementDerivedFile?.destroyRecord();
-    this.isUploadingReplacementDerivedFile = false;
+    this.isReplacingDerivedFile = false;
     this.replacementDerivedFile = null;
 
     await this.uploadedDerivedFile?.destroyRecord();
@@ -110,10 +138,10 @@ export default class DocumentsDocumentCardEditModalComponent extends Component {
 
     this.name = null;
 
-    this.isUploadingReplacementSourceFile = false;
+    this.isReplacingSourceFile = false;
     this.replacementSourceFile = null;
 
-    this.isUploadingReplacementDerivedFile = false;
+    this.isReplacingDerivedFile = false;
     this.replacementDerivedFile = false;
 
     this.uploadedDerivedFile = null;

--- a/app/components/documents/document-details-panel.hbs
+++ b/app/components/documents/document-details-panel.hbs
@@ -54,14 +54,17 @@
             @icon="upload"
             @iconAlignment="left"
             @skin="secondary"
-            {{on "click" (toggle "isUploadingReplacementSourceFile" this)}}
+            {{on "click" (toggle "isReplacingSourceFile" this)}}
           >
             {{t (if @piece.file "replace" "upload")}}
           </AuButton>
         </div>
       </Auk::KeyValue>
-      {{#if this.isUploadingReplacementSourceFile}}
-        <Auk::FileUploader @onUpload={{set this "replacementSourceFile"}} />
+      {{#if this.isReplacingSourceFile}}
+        <Auk::FileUploader
+          @onUpload={{set this "replacementSourceFile"}}
+          @onQueueUpdate={{this.handleReplacementFileUploadQueue}}
+        />
       {{/if}}
     </Auk::Panel::Body>
     <Auk::Panel::Footer>

--- a/app/components/documents/document-details-panel.js
+++ b/app/components/documents/document-details-panel.js
@@ -17,6 +17,7 @@ export default class DocumentsDocumentDetailsPanel extends Component {
 
   @tracked isEditingDetails = false;
   @tracked isOpenVerifyDeleteModal = false;
+  @tracked isReplacingSourceFile = false;
   @tracked isUploadingReplacementSourceFile = false;
   @tracked replacementSourceFile;
   @tracked documentType;
@@ -29,7 +30,11 @@ export default class DocumentsDocumentDetailsPanel extends Component {
   }
 
   get isProcessing() {
-    return this.saveDetails.isRunning || this.cancelEditDetails.isRunning;
+    return (
+      this.saveDetails.isRunning
+        || this.cancelEditDetails.isRunning
+        || this.isUploadingReplacementSourceFile
+    );
   }
 
   @task
@@ -39,12 +44,17 @@ export default class DocumentsDocumentDetailsPanel extends Component {
     this.isLastVersionOfPiece = !isPresent(yield this.args.piece.nextPiece);
   }
 
+  @action
+  handleReplacementFileUploadQueue({ uploadIsRunning, uploadIsCompleted}) {
+    this.isUploadingReplacementSourceFile = uploadIsRunning && !uploadIsCompleted;
+  }
+
   @task
   *cancelEditDetails() {
     this.args.piece.rollbackAttributes(); // in case of piece name change
     yield this.loadDetailsData.perform();
     yield this.replacementSourceFile?.destroyRecord();
-    this.isUploadingReplacementSourceFile = false;
+    this.isReplacingSourceFile = false;
     this.replacementSourceFile = null;
     this.isEditingDetails = false;
   }
@@ -81,7 +91,7 @@ export default class DocumentsDocumentDetailsPanel extends Component {
     yield this.args.documentContainer.save();
     this.isEditingDetails = false;
     this.replacementSourceFile = null;
-    this.isUploadingReplacementSourceFile = !this.isUploadingReplacementSourceFile;
+    this.isReplacingSourceFile = !this.isReplacingSourceFile;
   }
 
   @action


### PR DESCRIPTION
Affects source & derived file upload & replacement both in the edit modal of a document card and the document view side panel. Exposes some extra API in `Auk::FileUploader` to achieve this: there's now a callback that gets called whenever the file queue changes (by means of uploading/finishing uploading a file), this can be used at the component consumer side to ensure that save buttons are disabled during upload.

Branches off from PROD but can also be merged in development first if desired.