### PR TITLE
KAS-3893: Bump mu-cl-resources to feature branch

### DIFF
--- a/app/components/agenda/agenda-header/agenda-tabs.js
+++ b/app/components/agenda/agenda-header/agenda-tabs.js
@@ -23,7 +23,7 @@ export default class AgendaAgendaHeaderAgendaTabsComponent extends Component {
       // sorting on type prevents defaulting to an announcement when there are notas
       return yield this.store.queryOne('agendaitem', {
         'filter[agenda][:id:]': this.args.currentAgenda.id,
-        sort: 'type,number',
+        sort: 'type.position,number',
       });
     }
     return null;

--- a/app/components/publications/publication/publication-activities/publication-request-modal.js
+++ b/app/components/publications/publication/publication-activities/publication-request-modal.js
@@ -36,6 +36,7 @@ export default class PublicationsPublicationPublicationActivitiesPublicationRequ
   get isLoading() {
     return (
       this.loadProofPieces.isRunning ||
+      this.setEmailFields.isRunning ||
       this.cancel.isRunning ||
       this.save.isRunning
     );
@@ -44,6 +45,7 @@ export default class PublicationsPublicationPublicationActivitiesPublicationRequ
   get isCancelDisabled() {
     return (
       this.loadProofPieces.isRunning ||
+      this.setEmailFields.isRunning ||
       this.cancel.isRunning ||
       this.save.isRunning
     );

--- a/app/routes/agenda/agendaitems.js
+++ b/app/routes/agenda/agendaitems.js
@@ -36,7 +36,7 @@ export default class AgendaAgendaitemsRoute extends Route {
       'filter[agenda][:id:]': agenda.id,
       include: 'type',
       'page[size]': PAGE_SIZE.AGENDAITEMS,
-      sort: 'type,number',
+      sort: 'type.position,number',
     });
 
     // Ensure mandatee data for each agendaitem is loaded

--- a/cypress/integration/unit/publication-publications.spec.js
+++ b/cypress/integration/unit/publication-publications.spec.js
@@ -53,6 +53,7 @@ context('Publications proofs tests', () => {
     cy.get(auk.formHelpText).contains('Datum verstreken');
     // check if requestmessage contains the targetEndDate
     cy.get(publication.publicationActivities.request).click();
+    cy.get(auk.loader).should('not.exist');
     cy.get(publication.publicationRequest.message).invoke('val')
       .as('value');
     cy.get('@value').should(($p) => {


### PR DESCRIPTION
Before we sorted agendaitems on `type,number`, which does not do what we expect, it sorts on the `type` relationship, which currently mu-cl-resources interprets as "sort on each property of this relationship". Additionally this results in faulty responses from the new construct-based fetches branch. What we really want is to sort on the `type`'s `position`, so let's just do that instead.

Related PR:
- [x] https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/372
- [x] https://github.com/kanselarij-vlaanderen/cache-warmup-service/pull/12