### PR TITLE
KAS-4022: Add approvers to sign flow

### DIFF
--- a/app/components/signatures/create-sign-flow.hbs
+++ b/app/components/signatures/create-sign-flow.hbs
@@ -61,7 +61,11 @@
         </Toolbar.Group>
         <Toolbar.Group @position="right" as |Group|>
           <Group.Item>
-            <AuButton @skin="secondary" @icon="plus">
+            <AuButton
+              @skin="secondary"
+              @icon="plus"
+              {{on "click" (toggle "showApproversModal" this)}}
+            >
               {{t "add"}}
             </AuButton>
           </Group.Item>
@@ -70,10 +74,21 @@
     </Auk::Panel::Header>
     <Auk::Panel::Body class="auk-u-p-0">
       <Auk::List @bordered={{true}}>
-        {{#each this.approvers}}
+        {{#each this.approvers as |approver|}}
           <Auk::List::Item
             class="auk-o-flex auk-o-flex--justify-between auk-o-flex--vertical-center"
-          />
+          >
+            {{approver}}
+            <AuButton
+              @skin="naked"
+              @alert={{true}}
+              @hideText={{true}}
+              @icon="trash"
+              {{on "click" (fn this.removeApprover approver)}}
+            >
+              {{t "delete"}}
+            </AuButton>
+          </Auk::List::Item>
         {{else}}
           <Auk::List::Item>
             {{t "no-approvers-selected"}}
@@ -122,6 +137,14 @@
       @selected={{map-by "id" this.signers}}
       @onConfirm={{this.saveSigners.perform}}
       @onCancel={{toggle "showMinisterModal" this}}
+    />
+  {{/if}}
+
+  {{#if this.showApproversModal}}
+    <Signatures::EmailModal
+      @title={{t "add-approval"}}
+      @onConfirm={{this.saveApprover}}
+      @onCancel={{toggle "showApproversModal" this}}
     />
   {{/if}}
 {{/if}}

--- a/app/components/signatures/create-sign-flow.js
+++ b/app/components/signatures/create-sign-flow.js
@@ -13,7 +13,10 @@ export default class SignaturesCreateSignFlowComponent extends Component {
   @service store;
 
   @tracked showMinisterModal = false;
+  @tracked showApproversModal = false;
+
   @tracked signers = new TrackedArray([]);
+  @tracked approvers = new TrackedArray([]);
 
   primeMinister = null;
 
@@ -44,6 +47,17 @@ export default class SignaturesCreateSignFlowComponent extends Component {
       this.signers.push(mandatee);
     }
   });
+
+  @action
+  saveApprover(approver) {
+    this.approvers.addObject(approver);
+    this.showApproversModal = false;
+  }
+
+  @action
+  removeApprover(approver) {
+    this.approvers.removeObject(approver);
+  }
 
   saveSigners = task(async (selected) => {
     const records = await this.mandateeIdsToRecords(selected);

--- a/app/components/signatures/email-modal.hbs
+++ b/app/components/signatures/email-modal.hbs
@@ -1,0 +1,43 @@
+<Auk::Modal @size="medium">
+  <Auk::Modal::Header
+    @title={{@title}}
+    @onClose={{@onCancel}}
+  />
+  <Auk::Modal::Body>
+    <div class="auk-form-group">
+      <AuLabel>{{t "email-address"}}</AuLabel>
+      <AuInput
+        @onChange={{fn (mut this.emailBuffer)}}
+        @maskOptions={{this.inputmaskOptions}}
+        @warning={{and this.emailBuffer (not this.isValid)}}
+        @type="text"
+        @width="block"
+        class="au-c-input--mask-normal-letter-spacing"
+      />
+    </div>
+  </Auk::Modal::Body>
+  <Auk::Modal::Footer @custom={{true}}>
+    <Auk::Toolbar @size="large" as |Toolbar|>
+      <Toolbar.Group @position="left" as |Group|>
+        <Group.Item>
+          <AuButton
+            @skin="naked"
+            {{on "click" @onCancel}}
+          >
+            {{t "cancel"}}
+          </AuButton>
+        </Group.Item>
+      </Toolbar.Group>
+      <Toolbar.Group @position="right" as |Group|>
+        <Group.Item>
+          <AuButton
+            @disabled={{not this.isValid}}
+            {{on "click" (fn @onConfirm this.emailBuffer)}}
+          >
+            {{t "add"}}
+          </AuButton>
+        </Group.Item>
+      </Toolbar.Group>
+    </Auk::Toolbar>
+  </Auk::Modal::Footer>
+</Auk::Modal>

--- a/app/components/signatures/email-modal.js
+++ b/app/components/signatures/email-modal.js
@@ -1,0 +1,24 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import Inputmask from 'inputmask';
+
+export default class SignaturesEmailModalComponent extends Component {
+  inputmask;
+  @tracked emailBuffer;
+
+  constructor() {
+    super(...arguments);
+
+    this.inputmask = new Inputmask(this.inputmaskOptions);
+  }
+
+  get inputmaskOptions() {
+    return {
+      alias: 'email',
+    };
+  }
+
+  get isValid() {
+    return this.inputmask.isValid(this.emailBuffer);
+  }
+}

--- a/app/styles/au/_au-components.scss
+++ b/app/styles/au/_au-components.scss
@@ -434,3 +434,7 @@ $au-button-height: 3.4rem;
     width: calc(33% - 2rem);
   }
 }
+
+.au-c-input--mask-normal-letter-spacing {
+  letter-spacing: inherit;
+}

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-qunit": "^7.3.1",
     "flatpickr": "^4.6.13",
+    "inputmask": "^5.0.7",
     "loader.js": "^4.7.0",
     "lodash.invert": "^4.3.0",
     "marked": "^4.2.12",

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1205,5 +1205,7 @@
   "preview": "Voorvertoning",
   "filter-on-signer": "Filter op ondertekenaar",
   "filter-content": "Filter inhoud",
-  "apply": "Toepassen"
+  "apply": "Toepassen",
+  "email-address": "E-mailadres",
+  "add-approval": "Goedkeuring toevoegen"
 }


### PR DESCRIPTION
Adds a modal for adding approvers. Approvers are just stored in a flat list, later when we actually create the sign flow we will use the list to create the necessary activities.