### PR TITLE
KAS-3535:  Assign notified to sign flow

### DIFF
--- a/app/components/signatures/create-sign-flow.hbs
+++ b/app/components/signatures/create-sign-flow.hbs
@@ -109,7 +109,11 @@
         </Toolbar.Group>
         <Toolbar.Group @position="right" as |Group|>
           <Group.Item>
-            <AuButton @skin="secondary" @icon="plus">
+            <AuButton
+              @skin="secondary"
+              @icon="plus"
+              {{on "click" (toggle "showNotificationAddressesModal" this)}}
+            >
               {{t "add"}}
             </AuButton>
           </Group.Item>
@@ -118,10 +122,21 @@
     </Auk::Panel::Header>
     <Auk::Panel::Body class="auk-u-p-0">
       <Auk::List @bordered={{true}}>
-        {{#each this.notificationAddresses}}
+        {{#each this.notificationAddresses as |notificationAddress|}}
           <Auk::List::Item
             class="auk-o-flex auk-o-flex--justify-between auk-o-flex--vertical-center"
-          />
+          >
+            {{notificationAddress}}
+            <AuButton
+              @skin="naked"
+              @alert={{true}}
+              @hideText={{true}}
+              @icon="trash"
+              {{on "click" (fn this.removeNotificationAddress notificationAddress)}}
+            >
+              {{t "delete"}}
+            </AuButton>
+          </Auk::List::Item>
         {{else}}
           <Auk::List::Item>
             {{t "no-notification-addresses-selected"}}
@@ -145,6 +160,14 @@
       @title={{t "add-approval"}}
       @onConfirm={{this.saveApprover}}
       @onCancel={{toggle "showApproversModal" this}}
+    />
+  {{/if}}
+
+  {{#if this.showNotificationAddressesModal}}
+    <Signatures::EmailModal
+      @title={{t "add-notification"}}
+      @onConfirm={{this.saveNotificationAddress}}
+      @onCancel={{toggle "showNotificationAddressesModal" this}}
     />
   {{/if}}
 {{/if}}

--- a/app/components/signatures/create-sign-flow.js
+++ b/app/components/signatures/create-sign-flow.js
@@ -14,9 +14,11 @@ export default class SignaturesCreateSignFlowComponent extends Component {
 
   @tracked showMinisterModal = false;
   @tracked showApproversModal = false;
+  @tracked showNotificationAddressesModal = false;
 
   @tracked signers = new TrackedArray([]);
   @tracked approvers = new TrackedArray([]);
+  @tracked notificationAddresses = new TrackedArray([]);
 
   primeMinister = null;
 
@@ -57,6 +59,17 @@ export default class SignaturesCreateSignFlowComponent extends Component {
   @action
   removeApprover(approver) {
     this.approvers.removeObject(approver);
+  }
+
+  @action
+  saveNotificationAddress(address) {
+    this.notificationAddresses.addObject(address);
+    this.showNotificationAddressesModal = false;
+  }
+
+  @action
+  removeNotificationAddress(address) {
+    this.notificationAddresses.removeObject(address);
   }
 
   saveSigners = task(async (selected) => {

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1207,5 +1207,6 @@
   "filter-content": "Filter inhoud",
   "apply": "Toepassen",
   "email-address": "E-mailadres",
-  "add-approval": "Goedkeuring toevoegen"
+  "add-approval": "Goedkeuring toevoegen",
+  "add-notification": "Notificatie toevoegen"
 }


### PR DESCRIPTION
Adds a modal for adding notification addresses. These addresses are just stored in a list, later when we actually create the sign flow we will use the list to fill in the necessary activity attributes.