### PR TITLE
Feature/kas 4046 sign flow profile restrictions

### DIFF
--- a/app/components/documents/document-card.hbs
+++ b/app/components/documents/document-card.hbs
@@ -55,17 +55,19 @@
                   {{/if}}
                 </p>
               {{/if}}
-              {{#if this.piece.signedPiece.file}}
-                <p>
-                  <AuLinkExternal
-                    href={{await this.piece.signedPiece.namedDownloadLinkPromise}}
-                    download
-                  >
-                    {{t "signed-document"}}
-                  </AuLinkExternal>
-                  {{t "on"}}
-                  {{datetime-at this.piece.signedPiece.created}}
-                </p>
+              {{#if (and this.signaturesEnabled (await (this.canViewSignedPiece)))}}
+                {{#if this.piece.signedPiece.file}}
+                  <p>
+                    <AuLinkExternal
+                      href={{await this.piece.signedPiece.namedDownloadLinkPromise}}
+                      download
+                    >
+                      {{t "signed-document"}}
+                    </AuLinkExternal>
+                    {{t "on"}}
+                    {{datetime-at this.piece.signedPiece.created}}
+                  </p>
+                {{/if}}
               {{/if}}
             </div>
           </Group.Item>

--- a/app/components/documents/document-card.js
+++ b/app/components/documents/document-card.js
@@ -30,6 +30,7 @@ export default class DocumentsDocumentCardComponent extends Component {
   @service toaster;
   @service intl;
   @service pieceAccessLevelService;
+  @service signatureService;
 
   @tracked isOpenUploadModal = false;
   @tracked isOpenVerifyDeleteModal = false;
@@ -59,6 +60,7 @@ export default class DocumentsDocumentCardComponent extends Component {
 
   get mayCreateSignMarkingActivity() {
     return !this.signMarkingActivity
+      && this.signaturesEnabled
       && this.currentSession.may('manage-signatures');
   }
 
@@ -276,5 +278,9 @@ export default class DocumentsDocumentCardComponent extends Component {
 
   canViewConfidentialPiece = async () => {
     return await this.pieceAccessLevelService.canViewConfidentialPiece(this.args.piece);
+  }
+
+  canViewSignedPiece = async () => {
+    return await this.signatureService.canManageSignFlow(this.args.piece);
   }
 }

--- a/app/components/documents/document-card.js
+++ b/app/components/documents/document-card.js
@@ -281,6 +281,9 @@ export default class DocumentsDocumentCardComponent extends Component {
   }
 
   canViewSignedPiece = async () => {
-    return await this.signatureService.canManageSignFlow(this.args.piece);
+    if (this.currentSession.may('manage-signatures')) {
+      return await this.signatureService.canManageSignFlow(this.args.piece);
+    }
+    return false;
   }
 }

--- a/app/components/documents/document-details-panel.hbs
+++ b/app/components/documents/document-details-panel.hbs
@@ -177,20 +177,22 @@
           {{@piece.name}}
         {{/if}}
       </Auk::KeyValue>
-      {{#if @piece.signedPiece.file}}
-        <Auk::KeyValue
-          @key={{t "signed-document"}}
-        >
-          <AuLinkExternal
-            href={{await @piece.signedPiece.namedDownloadLinkPromise}}
-            @skin="primary"
-            @icon="download"
-            @iconAlignment="left"
-            download
+      {{#if (and this.isSignaturesEnabled (await (this.canViewSignedPiece)))}}
+        {{#if @piece.signedPiece.file}}
+          <Auk::KeyValue
+            @key={{t "signed-document"}}
           >
-            {{@piece.signedPiece.name}}.{{@piece.signedPiece.file.extension}}
-          </AuLinkExternal>
-        </Auk::KeyValue>
+            <AuLinkExternal
+              href={{await @piece.signedPiece.namedDownloadLinkPromise}}
+              @skin="primary"
+              @icon="download"
+              @iconAlignment="left"
+              download
+            >
+              {{@piece.signedPiece.name}}.{{@piece.signedPiece.file.extension}}
+            </AuLinkExternal>
+          </Auk::KeyValue>
+        {{/if}}
       {{/if}}
     </Auk::Panel::Body>
   </Auk::Panel>

--- a/app/components/documents/document-details-panel.js
+++ b/app/components/documents/document-details-panel.js
@@ -2,8 +2,9 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { isPresent } from '@ember/utils';
+import { isPresent, isEmpty } from '@ember/utils';
 import { task } from 'ember-concurrency';
+import ENV from 'frontend-kaleidos/config/environment';
 
 /**
  * @param {Piece} piece
@@ -13,6 +14,8 @@ export default class DocumentsDocumentDetailsPanel extends Component {
   @service fileConversionService;
   @service intl;
   @service toaster;
+  @service signatureService;
+  @service currentSession;
 
   @tracked isEditingDetails = false;
   @tracked isOpenVerifyDeleteModal = false;
@@ -34,6 +37,12 @@ export default class DocumentsDocumentDetailsPanel extends Component {
         || this.cancelEditDetails.isRunning
         || this.isUploadingReplacementSourceFile
     );
+  }
+
+  get isSignaturesEnabled() {
+    const isEnabled = !isEmpty(ENV.APP.ENABLE_SIGNATURES);
+    const hasPermission = this.currentSession.may('manage-signatures');
+    return isEnabled && hasPermission;
   }
 
   @task
@@ -119,5 +128,9 @@ export default class DocumentsDocumentDetailsPanel extends Component {
   
   canViewConfidentialPiece = async () => {
     return await this.pieceAccessLevelService.canViewConfidentialPiece(this.args.piece);
+  }
+
+  canViewSignedPiece = async () => {
+    return await this.signatureService.canManageSignFlow(this.args.piece);
   }
 }

--- a/app/components/documents/document-details-panel.js
+++ b/app/components/documents/document-details-panel.js
@@ -131,6 +131,9 @@ export default class DocumentsDocumentDetailsPanel extends Component {
   }
 
   canViewSignedPiece = async () => {
-    return await this.signatureService.canManageSignFlow(this.args.piece);
+    if (this.currentSession.may('manage-signatures')) {
+      return await this.signatureService.canManageSignFlow(this.args.piece);
+    }
+    return false;
   }
 }

--- a/app/components/documents/document-preview/signatures-tab.hbs
+++ b/app/components/documents/document-preview/signatures-tab.hbs
@@ -7,30 +7,42 @@
       @signMarkingActivity={{this.signMarkingActivity}}
     />
   {{else if this.agendaitem}}
-    <p class="au-u-muted auk-u-mt-2">
-      {{or @piece.documentContainer.type.label (t "no-document-type")}}
-      -
-      {{date this.decisionActivity.startDate}}
-    </p>
-    <h5 class="auk-h4">{{@piece.name}}</h5>
-    <Signatures::CreateSignFlow
-      @piece={{@piece}}
-      @decisionActivity={{this.decisionActivity}}
-      @onChangeSigners={{fn (mut this.signers)}}
-      @onChangeApprovers={{fn (mut this.approvers)}}
-      @onChangeNotificationAddresses={{fn (mut this.notificationAddresses)}}
-    />
+    {{#if this.loadCanCreateSignFlow.isRunning}}
+      <Auk::Loader />
+    {{else if this.canCreateSignFlow}}
+      <p class="au-u-muted auk-u-mt-2">
+        {{or @piece.documentContainer.type.label (t "no-document-type")}}
+        -
+        {{date this.decisionActivity.startDate}}
+      </p>
+      <h5 class="auk-h4">{{@piece.name}}</h5>
+      <Signatures::CreateSignFlow
+        @piece={{@piece}}
+        @decisionActivity={{this.decisionActivity}}
+        @onChangeSigners={{fn (mut this.signers)}}
+        @onChangeApprovers={{fn (mut this.approvers)}}
+        @onChangeNotificationAddresses={{fn (mut this.notificationAddresses)}}
+      />
 
-    <AuToolbar class="auk-u-mt-4" as |Group|>
-      <Group>
-        <AuButton
-          @loading={{this.createSignFlow.isRunning}}
-          {{on "click" this.createSignFlow.perform}}
+      <AuToolbar class="auk-u-mt-4" as |Group|>
+        <Group>
+          <AuButton
+            @loading={{this.createSignFlow.isRunning}}
+            {{on "click" this.createSignFlow.perform}}
+          >
+            {{t "start-signing"}}
+          </AuButton>
+        </Group>
+      </AuToolbar>
+      {{else}}
+        <AuAlert
+          @skin="warning"
+          @icon="alert-triangle"
+          @title={{t "cannot-sign"}}
         >
-          {{t "start-signing"}}
-        </AuButton>
-      </Group>
-    </AuToolbar>
+          <p>{{t "cannot-create-sign-flow-message"}}</p>
+        </AuAlert>
+      {{/if}}
   {{else}}
     <AuAlert
       @skin="warning"

--- a/app/components/documents/document-preview/signatures-tab.hbs
+++ b/app/components/documents/document-preview/signatures-tab.hbs
@@ -7,9 +7,9 @@
       @signMarkingActivity={{this.signMarkingActivity}}
     />
   {{else if this.agendaitem}}
-    {{#if this.loadCanCreateSignFlow.isRunning}}
+    {{#if this.loadCanManageSignFlow.isRunning}}
       <Auk::Loader />
-    {{else if this.canCreateSignFlow}}
+    {{else if this.canManageSignFlow}}
       <p class="au-u-muted auk-u-mt-2">
         {{or @piece.documentContainer.type.label (t "no-document-type")}}
         -

--- a/app/components/documents/document-preview/signatures-tab.js
+++ b/app/components/documents/document-preview/signatures-tab.js
@@ -10,7 +10,7 @@ export default class DocumentsDocumentPreviewDetailsSignaturesTabComponent exten
   @tracked signMarkingActivity;
   @tracked agendaitem;
   @tracked decisionActivity;
-  @tracked canCreateSignFlow = false;
+  @tracked canManageSignFlow = false;
 
   signers = [];
   approvers = [];
@@ -19,7 +19,7 @@ export default class DocumentsDocumentPreviewDetailsSignaturesTabComponent exten
   constructor() {
     super(...arguments);
     this.loadSignatureRelatedData.perform();
-    this.loadCanCreateSignFlow.perform();
+    this.loadCanManageSignFlow.perform();
   }
 
   loadSignatureRelatedData = task(async () => {
@@ -49,7 +49,7 @@ export default class DocumentsDocumentPreviewDetailsSignaturesTabComponent exten
     this.signMarkingActivity = await this.args.piece.signMarkingActivity;
   });
 
-  loadCanCreateSignFlow = task(async () => {
-    this.canCreateSignFlow =  await this.signatureService.canProfileCreateSignFlow(this.args.piece);
+  loadCanManageSignFlow = task(async () => {
+    this.canManageSignFlow =  await this.signatureService.canManageSignFlow(this.args.piece);
   });
 }

--- a/app/components/documents/document-preview/signatures-tab.js
+++ b/app/components/documents/document-preview/signatures-tab.js
@@ -10,6 +10,7 @@ export default class DocumentsDocumentPreviewDetailsSignaturesTabComponent exten
   @tracked signMarkingActivity;
   @tracked agendaitem;
   @tracked decisionActivity;
+  @tracked canCreateSignFlow = false;
 
   signers = [];
   approvers = [];
@@ -18,6 +19,7 @@ export default class DocumentsDocumentPreviewDetailsSignaturesTabComponent exten
   constructor() {
     super(...arguments);
     this.loadSignatureRelatedData.perform();
+    this.loadCanCreateSignFlow.perform();
   }
 
   loadSignatureRelatedData = task(async () => {
@@ -45,5 +47,9 @@ export default class DocumentsDocumentPreviewDetailsSignaturesTabComponent exten
     );
     await this.args.piece.reload();
     this.signMarkingActivity = await this.args.piece.signMarkingActivity;
+  });
+
+  loadCanCreateSignFlow = task(async () => {
+    this.canCreateSignFlow =  await this.signatureService.canProfileCreateSignFlow(this.args.piece);
   });
 }

--- a/app/components/signatures/create-sign-flow.js
+++ b/app/components/signatures/create-sign-flow.js
@@ -55,7 +55,7 @@ export default class SignaturesCreateSignFlowComponent extends Component {
       submitter,
       cosigners,
     } = await getSubmitterAndCosigners(head);
-debugger;
+
     for (let decisionActivity of tail)  {
       const {
         submitter: _submitter,

--- a/app/config/permissions.js
+++ b/app/config/permissions.js
@@ -19,6 +19,7 @@ const {
 // Available permissions are:
 // - manage-signatures: currently everything related to digital signing. Will be detailed later
 //     in order to distinguish people that should prepare the flow, effectively sign, etc
+// - manage-only-specific-signatures: allow the profile to only create signing flows for their own mandatee.
 // - search-publication-flows
 // - manage-publication-flows: General viewing and editing of publication flows
 // - manage-documents: modifying document details, uploading new versions, removing.
@@ -168,6 +169,7 @@ const groups = [
     defaultRoute: 'agendas',
     permissions: [
       'manage-signatures',
+      'manage-only-specific-signatures',
       'view-document-version-info',
       'view-documents-before-release',
       'view-only-specific-confidential-documents'

--- a/app/routes/signatures/index.js
+++ b/app/routes/signatures/index.js
@@ -4,15 +4,23 @@ import { inject as service } from '@ember/service';
 
 export default class SignaturesIndexRoute extends Route {
   @service store;
+  @service currentSession;
 
   localStorageKey = 'signatures.shortlist.minister-filter';
 
   ministerIds = [];
 
-  beforeModel() {
-    this.ministerIds = JSON.parse(
-      localStorage.getItem(this.localStorageKey)
-    ) ?? [];
+  async beforeModel() {
+    if (this.currentSession.may('manage-only-specific-signatures')) {
+      const currentUserOrganization = await this.currentSession.organization;
+      const currentUserOrganizationMandatees = await currentUserOrganization.mandatees;
+      const currentUserOrganizationMandateesIds = currentUserOrganizationMandatees?.map((mandatee) => mandatee.id);
+      this.ministerIds = currentUserOrganizationMandateesIds;
+    } else {
+      this.ministerIds = JSON.parse(
+        localStorage.getItem(this.localStorageKey)
+      ) ?? [];
+    }
   }
 
   async model() {
@@ -51,7 +59,9 @@ export default class SignaturesIndexRoute extends Route {
           }
         };
       }
-
+      if (this.currentSession.may('manage-only-specific-signatures') && !this.ministerIds?.length) {
+        return [];
+      }
       return this.store.query('piece', query);
     }
 

--- a/app/services/signature-service.js
+++ b/app/services/signature-service.js
@@ -104,4 +104,32 @@ export default class SignatureService extends Service {
       }
     }
   }
+
+  async canProfileCreateSignFlow(piece) {
+    if (this.currentSession.may('manage-only-specific-signatures')) {
+      const submissionActivity = await this.store.queryOne('submission-activity', {
+        filter: {
+          pieces: {
+            ':id:': piece?.id,
+          },
+        },
+      });
+      const subcase = await submissionActivity.subcase;
+      if (subcase) {
+        const mandatee = await subcase.requestedBy;
+        if (mandatee) {
+          const currentUserOrganization = await this.currentSession.organization;
+          const currentUserOrganizationMandatees = await currentUserOrganization.mandatees;
+          const currentUserOrganizationMandateesUris = currentUserOrganizationMandatees?.map((mandatee) => mandatee.uri);
+          if (currentUserOrganizationMandateesUris?.includes(mandatee.uri)) {
+            return true;
+          }
+        }
+      }
+    } else {
+      // default to standard permissions
+      return true;
+    }
+    return false;
+  }
 }

--- a/app/services/signature-service.js
+++ b/app/services/signature-service.js
@@ -105,7 +105,8 @@ export default class SignatureService extends Service {
     }
   }
 
-  async canProfileCreateSignFlow(piece) {
+  async canManageSignFlow(piece) {
+    // the base permission 'manage-signatures' does not cover cabinet specific requirements
     if (this.currentSession.may('manage-only-specific-signatures')) {
       const submissionActivity = await this.store.queryOne('submission-activity', {
         filter: {

--- a/app/templates/signatures/index.hbs
+++ b/app/templates/signatures/index.hbs
@@ -16,20 +16,22 @@
       <Group.Item>
         {{! search here}}
       </Group.Item>
-      <Group.Item>
-        {{#if this.filteredMinisters}}
-          <AuButton @skin="naked" {{on "click" this.clearFilter}}>
-            {{t "clear-filter"}}
+      {{#unless (user-may "manage-only-specific-signatures")}}
+        <Group.Item>
+          {{#if this.filteredMinisters}}
+            <AuButton @skin="naked" {{on "click" this.clearFilter}}>
+              {{t "clear-filter"}}
+            </AuButton>
+          {{/if}}
+          <AuButton
+            @skin="secondary"
+            @icon="filter"
+            {{on "click" this.openFilterModal}}
+          >
+            {{t "filter-on-signer"}}
           </AuButton>
-        {{/if}}
-        <AuButton
-          @skin="secondary"
-          @icon="filter"
-          {{on "click" this.openFilterModal}}
-        >
-          {{t "filter-on-signer"}}
-        </AuButton>
-      </Group.Item>
+        </Group.Item>
+      {{/unless}}
       <Group.Item>
         {{! bundle signature here}}
       </Group.Item>

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1208,6 +1208,7 @@
   "start-signing": "Tekenen opstarten",
   "cannot-sign": "Kan niet ondertekenen",
   "cannot-sign-message": "Dit stuk is niet verbonden aan een agendapunt en kan niet aangeboden worden om getekend te worden.",
+  "cannot-create-sign-flow-message": "Dit stuk is niet verbonden aan uw organisatie en kan niet aangeboden worden om getekend te worden.",
   "signed-document": "Getekend document",
   "on": "op"
 }

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1208,7 +1208,7 @@
   "start-signing": "Tekenen opstarten",
   "cannot-sign": "Kan niet ondertekenen",
   "cannot-sign-message": "Dit stuk is niet verbonden aan een agendapunt en kan niet aangeboden worden om getekend te worden.",
-  "cannot-create-sign-flow-message": "Dit stuk is niet verbonden aan uw organisatie en kan niet aangeboden worden om getekend te worden.",
+  "cannot-create-sign-flow-message": "Dit stuk is niet ingediend door uw mandataris en kan niet aangeboden worden om getekend te worden.",
   "signed-document": "Getekend document",
   "on": "op"
 }


### PR DESCRIPTION
Combines 2 tickets:
https://kanselarij.atlassian.net/browse/KAS-4046
https://kanselarij.atlassian.net/browse/KAS-4049
 
The first ticket mentions making it not possible for certain profiles to start signature flow.
In the signature route, it would make more sense to set the filtered ministers in favor of showing wrong ones but blocking the buttons
That filtering is the second ticket so made sense to keep them together.

## changes:

document-card:
- wrapped the download link of `signedPiece` with feature flag and general permissions.
- wrapped the download link with new permission for dossierbeheerder to only show the link if the `subcase.requestedBy` matches the organization mandatees (async action getter into service call)

(document-preview)  => document-details-panel
- wrapped the download link of `signedPiece` with feature flag and general permissions.
- wrapped the download link with new permission for dossierbeheerder to only show the link if the `subcase.requestedBy` matches the organization mandatees (async action getter into service call)

(document-preview)  => signatures-tab (already hidden by feature flag and permissions)
- wrapped the creation of sign-flow with new dossierbeheerder to only show them if the `subcase.requestedBy` matches the organization mandatees (async action getter into service call)
- show a warning message if viewing a document that does not match with mandatees.

permissions.js
- added new permission to view and manage only specific signature flows

signatures route/controller/template:
- hidden ministerfilter
- added the new permissions to filter out the results from the shortlist service to only get the `pieces`  where the `subcase.requestedBy` matches the organization mandatees (or nothing if they have no minister assigned)
- in that case, we don't use the local storage key.

nl-be.json
- added translation for the warning