### PR TITLE
Feature/kas 2793 remove signed document

### DIFF
--- a/app/components/documents/document-card.hbs
+++ b/app/components/documents/document-card.hbs
@@ -167,6 +167,17 @@
                   </AuLink>
                   <AuHr />
                 {{/if}}
+                {{#if this.mayRemoveSignFlow}}
+                  <AuButton
+                    @skin="link"
+                    @alert={{true}}
+                    {{on "click" this.deleteSignFlow}}
+                    role="menuitem"
+                  >
+                    {{t "delete-signed-piece"}}
+                  </AuButton>
+                  <AuHr />
+                {{/if}}
                 <AuButton
                   data-test-document-card-delete
                   @skin="link"
@@ -256,6 +267,17 @@
   @message={{t "delete-document-container-message"}}
   @onConfirm={{this.verifyDeleteDocumentContainer}}
   @onCancel={{this.cancelDeleteDocumentContainer}}
+  @confirmMessage={{t "delete"}}
+  @confirmIcon="trash"
+  @alert={{true}}
+/>
+
+<ConfirmationModal
+  @modalOpen={{this.isOpenVerifyDeleteSignFlow}}
+  @title={{t "delete-signed-piece"}}
+  @message={{t "verify-delete-signed-piece"}}
+  @onConfirm={{this.verifyDeleteSignFlow}}
+  @onCancel={{this.cancelDeleteSignFlow}}
   @confirmMessage={{t "delete"}}
   @confirmIcon="trash"
   @alert={{true}}

--- a/app/components/documents/document-card.js
+++ b/app/components/documents/document-card.js
@@ -40,6 +40,8 @@ export default class DocumentsDocumentCardComponent extends Component {
   @tracked documentContainer;
   @tracked isDraftAccessLevel;
   @tracked signMarkingActivity;
+  @tracked isOpenVerifyDeleteSignFlow = false;
+  @tracked signedpiece;
 
   @tracked uploadedFile;
   @tracked newPiece;
@@ -62,6 +64,13 @@ export default class DocumentsDocumentCardComponent extends Component {
     return !this.signMarkingActivity
       && this.signaturesEnabled
       && this.currentSession.may('manage-signatures');
+  }
+
+  get mayRemoveSignFlow() {
+    return this.signMarkingActivity
+      && this.signedPiece
+      && this.signaturesEnabled
+      && this.currentSession.may('remove-signatures');
   }
 
   @task
@@ -127,6 +136,7 @@ export default class DocumentsDocumentCardComponent extends Component {
   @task
   *loadSignatureRelatedData() {
     this.signMarkingActivity = yield this.piece.signMarkingActivity;
+    this.signedPiece = yield this.args.piece.signedPiece;
   }
 
   @task
@@ -285,5 +295,22 @@ export default class DocumentsDocumentCardComponent extends Component {
       return await this.signatureService.canManageSignFlow(this.args.piece);
     }
     return false;
+  }
+
+  @action
+  deleteSignFlow() {
+    this.isOpenVerifyDeleteSignFlow = true;
+  }
+
+  @action
+  cancelDeleteSignFlow() {
+    this.isOpenVerifyDeleteSignFlow = false;
+  }
+
+  @action
+  async verifyDeleteSignFlow() {
+    await this.signatureService.removeSignFlow(this.args.piece);
+    await this.loadSignatureRelatedData.perform();
+    this.isOpenVerifyDeleteSignFlow = false;
   }
 }

--- a/app/components/documents/document-details-panel.hbs
+++ b/app/components/documents/document-details-panel.hbs
@@ -179,23 +179,35 @@
       </Auk::KeyValue>
       {{#if (and this.isSignaturesEnabled (await (this.canViewSignedPiece)))}}
         {{#if @piece.signedPiece.file}}
-          <Auk::KeyValue
-            @key={{t "signed-document"}}
-          >
-            <AuLinkExternal
-              href={{await @piece.signedPiece.namedDownloadLinkPromise}}
-              @skin="primary"
-              @icon="download"
-              @iconAlignment="left"
-              download
-            >
-              {{@piece.signedPiece.name}}.{{@piece.signedPiece.file.extension}}
-            </AuLinkExternal>
-            <AccessLevelPill 
-              @accessLevel={{await @piece.signedPiece.accessLevel}} 
-              @isEditable={{false}}
-            />
-          </Auk::KeyValue>
+          <div class="auk-key-value-item">
+            <div class="auk-key-value-item__label">{{t "signed-document"}}</div>
+            <div class="auk-key-value-item__value au-u-flex au-u-flex--vertical-center au-u-flex--spaced-small">
+              <AuLinkExternal
+                href={{await @piece.signedPiece.namedDownloadLinkPromise}}
+                @skin="primary"
+                @icon="download"
+                @iconAlignment="left"
+                download
+              >
+                {{@piece.signedPiece.name}}.{{@piece.signedPiece.file.extension}}
+              </AuLinkExternal>
+              {{#if (user-may "remove-signatures")}}
+                <AuButton
+                  @skin="naked"
+                  @alert={{true}}
+                  @icon="trash"
+                  @hideText={{true}}
+                  {{on "click" (fn (mut this.isOpenVerifyDeleteSignFlow) true)}}
+                >
+                  {{t "delete"}}
+                </AuButton>
+              {{/if}}
+              <AccessLevelPill 
+                @accessLevel={{await @piece.signedPiece.accessLevel}} 
+                @isEditable={{false}}
+              />
+            </div>
+          </div>
         {{/if}}
       {{/if}}
     </Auk::Panel::Body>
@@ -214,5 +226,21 @@
     @message={{t "delete-document-message"}}
     @onCancel={{fn (mut this.isOpenVerifyDeleteModal) false}}
     @onVerify={{this.verifyDeleteDocument}}
+  />
+{{/if}}
+
+{{#if this.isOpenVerifyDeleteSignFlow}}
+  {{!-- TODO: vl-refactor --}}
+  {{!-- We can't use AuModal here because said modals get rendered inside a
+        "wormhole" div. The current component is also part of a modal which gets
+        rendered in the same "wormhole", so opening another AuModal here will
+        overwrite the existing page content, and break the route. If AuModals
+        ever support rendering multiple modals over each other, we can use one
+        here, otherwise we might want to make the doc view not be a modal. --}}
+  <WebComponents::VlModalVerify
+    @title={{t "delete-signed-piece"}}
+    @message={{t "verify-delete-signed-piece"}}
+    @onCancel={{fn (mut this.isOpenVerifyDeleteSignFlow) false}}
+    @onVerify={{this.verifyDeleteSignFlow}}
   />
 {{/if}}

--- a/app/components/documents/document-details-panel.js
+++ b/app/components/documents/document-details-panel.js
@@ -21,6 +21,7 @@ export default class DocumentsDocumentDetailsPanel extends Component {
   @tracked isOpenVerifyDeleteModal = false;
   @tracked isReplacingSourceFile = false;
   @tracked isUploadingReplacementSourceFile = false;
+  @tracked isOpenVerifyDeleteSignFlow = false;
   @tracked replacementSourceFile;
   @tracked documentType;
   @tracked accessLevel;
@@ -124,6 +125,12 @@ export default class DocumentsDocumentDetailsPanel extends Component {
       this.args.didDeletePiece(this.args.piece);
     }
     this.isOpenVerifyDeleteModal = false;
+  }
+
+  @action
+  async verifyDeleteSignFlow() {
+    await this.signatureService.removeSignFlow(this.args.piece)
+    this.isOpenVerifyDeleteSignFlow = false;
   }
   
   canViewConfidentialPiece = async () => {

--- a/app/config/permissions.js
+++ b/app/config/permissions.js
@@ -20,6 +20,7 @@ const {
 // - manage-signatures: currently everything related to digital signing. Will be detailed later
 //     in order to distinguish people that should prepare the flow, effectively sign, etc
 // - manage-only-specific-signatures: allow the profile to only create signing flows for their own mandatee.
+// - remove-signatures: Remove the signed piece and all data of a sign-flow 
 // - search-publication-flows
 // - manage-publication-flows: General viewing and editing of publication flows
 // - manage-documents: modifying document details, uploading new versions, removing.
@@ -50,6 +51,7 @@ const groups = [
     defaultRoute: 'agendas',
     permissions: [
       'manage-signatures',
+      'remove-signatures',
       'manage-agenda-versions',
       'manage-agendaitems',
       'manage-decisions',
@@ -80,6 +82,7 @@ const groups = [
     defaultRoute: 'agendas',
     permissions: [
       'manage-signatures',
+      'remove-signatures',
       'manage-agenda-versions',
       'manage-agendaitems',
       'manage-decisions',
@@ -106,6 +109,7 @@ const groups = [
     defaultRoute: 'agendas',
     permissions: [
       'manage-signatures',
+      'remove-signatures',
       'manage-agenda-versions',
       'manage-agendaitems',
       'manage-decisions',

--- a/app/serializers/piece.js
+++ b/app/serializers/piece.js
@@ -4,7 +4,6 @@ const SKIP_SERIALIZED = [
   'agendaitems',
   'submissionActivity',
   'signedPiece',
-  'unsignedPiece',
   'signMarkingActivity',
   'signCompletionActivity'
 ];

--- a/app/services/signature-service.js
+++ b/app/services/signature-service.js
@@ -126,4 +126,26 @@ export default class SignatureService extends Service {
     }
     return false;
   }
+
+  async removeSignFlow(piece) {
+    const signMarkingActivity = await piece.signMarkingActivity;
+    if (signMarkingActivity) {
+      const signSubcase = await signMarkingActivity.signSubcase;
+      const signFlow = await signSubcase?.signFlow;
+      // const signPreparationActivity = await signSubcase?.signPreparationActivity;
+      // const signCompletionActivity = await signSubcase?.signCompletionActivity;
+      // const signApprovalActivities = await signSubcase?.signApprovalActivities;
+      // const signSigningActivities = await signSubcase?.signSigningActivities;
+      // const signRefusalActivities = await signSubcase?.signRefusalActivities;
+      const signedPiece = await piece.signedPiece;
+
+      await signedPiece?.destroyRecord();
+      await 
+      await signSubcase?.destroyRecord();
+      await signFlow?.destroyRecord();
+      await signMarkingActivity.destroyRecord();
+      await piece.belongsTo('signedPiece').reload();
+      await piece.belongsTo('signMarkingActivity').reload();
+    }
+  }
 }

--- a/app/services/signature-service.js
+++ b/app/services/signature-service.js
@@ -132,15 +132,30 @@ export default class SignatureService extends Service {
     if (signMarkingActivity) {
       const signSubcase = await signMarkingActivity.signSubcase;
       const signFlow = await signSubcase?.signFlow;
-      // const signPreparationActivity = await signSubcase?.signPreparationActivity;
-      // const signCompletionActivity = await signSubcase?.signCompletionActivity;
-      // const signApprovalActivities = await signSubcase?.signApprovalActivities;
-      // const signSigningActivities = await signSubcase?.signSigningActivities;
-      // const signRefusalActivities = await signSubcase?.signRefusalActivities;
       const signedPiece = await piece.signedPiece;
+      const signedFile = await signedPiece?.file;
+      const signPreparationActivity = await signSubcase?.signPreparationActivity;
+      const signCompletionActivity = await signSubcase?.signCompletionActivity;
+      const signCancellationActivity = await signSubcase?.signCancellationActivity;
+      const signApprovalActivities = await signSubcase?.signApprovalActivities;
+      const signSigningActivities = await signSubcase?.signSigningActivities;
+      const signRefusalActivities = await signSubcase?.signRefusalActivities;
 
+      // delete in reverse order of creation
+      await signedFile?.destroyRecord();
       await signedPiece?.destroyRecord();
-      await 
+      await signPreparationActivity?.destroyRecord();
+      await signCompletionActivity?.destroyRecord();
+      await signCancellationActivity?.destroyRecord();
+      await signApprovalActivities?.map(async (activity) => {
+        await activity.destroyRecord
+      })
+      await signSigningActivities?.map(async (activity) => {
+        await activity.destroyRecord
+      })
+      await signRefusalActivities?.map(async (activity) => {
+        await activity.destroyRecord
+      })
       await signSubcase?.destroyRecord();
       await signFlow?.destroyRecord();
       await signMarkingActivity.destroyRecord();

--- a/app/services/signature-service.js
+++ b/app/services/signature-service.js
@@ -148,13 +148,13 @@ export default class SignatureService extends Service {
       await signCompletionActivity?.destroyRecord();
       await signCancellationActivity?.destroyRecord();
       await signApprovalActivities?.map(async (activity) => {
-        await activity.destroyRecord
+        await activity.destroyRecord()
       })
       await signSigningActivities?.map(async (activity) => {
-        await activity.destroyRecord
+        await activity.destroyRecord()
       })
       await signRefusalActivities?.map(async (activity) => {
-        await activity.destroyRecord
+        await activity.destroyRecord()
       })
       await signSubcase?.destroyRecord();
       await signFlow?.destroyRecord();

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1215,5 +1215,7 @@
   "create-sign-flow-conflicting-signers-title": "Ondertekenaars zijn niet automatisch ingevuld",
   "create-sign-flow-conflicting-signers-message": "De gekozen bestanden zijn geagendeerd door verschillende ministers waardoor Kaleidos de ondertekenaars niet automatisch kan bepalen.",
   "creating-sign-flows-message": "Handtekenstromen worden aangemaakt. Dit kan even duren.",
-  "ongoing": "In verwerking"
+  "ongoing": "In verwerking",
+  "delete-signed-piece": "Getekend document verwijderen",
+  "verify-delete-signed-piece": "Bent u zeker dat u het getekend document wilt verwijderen? Deze actie kan niet meer ongedaan gemaakt worden. Het volledige handtekenprocess voor dit document zal mee verwijderd worden."
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-2793

- Added a new permission to remove signflow related data
- Added a service call to clean up everything related to a sign flow.
- Added dropdown in document-card actions (with permission)
- Added trash button in document details panel in doc viewer (with permission)

## Wait with merging until KAS-4099 is resolved (PR will be based on this branch). Some fixes made there to delete the activities
- [ ] https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1754