### PR TITLE
KAS-4099 implement removing sign-flow data from signature tab

### DIFF
--- a/app/components/documents/document-card.hbs
+++ b/app/components/documents/document-card.hbs
@@ -167,6 +167,17 @@
                   </AuLink>
                   <AuHr />
                 {{/if}}
+                {{#if this.mayRemoveSignFlow}}
+                  <AuButton
+                    @skin="link"
+                    @alert={{true}}
+                    {{on "click" this.deleteSignFlow}}
+                    role="menuitem"
+                  >
+                    {{t "delete-signed-piece"}}
+                  </AuButton>
+                  <AuHr />
+                {{/if}}
                 <AuButton
                   data-test-document-card-delete
                   @skin="link"
@@ -256,6 +267,17 @@
   @message={{t "delete-document-container-message"}}
   @onConfirm={{this.verifyDeleteDocumentContainer}}
   @onCancel={{this.cancelDeleteDocumentContainer}}
+  @confirmMessage={{t "delete"}}
+  @confirmIcon="trash"
+  @alert={{true}}
+/>
+
+<ConfirmationModal
+  @modalOpen={{this.isOpenVerifyDeleteSignFlow}}
+  @title={{t "delete-signed-piece"}}
+  @message={{t "verify-delete-signed-piece"}}
+  @onConfirm={{this.verifyDeleteSignFlow}}
+  @onCancel={{this.cancelDeleteSignFlow}}
   @confirmMessage={{t "delete"}}
   @confirmIcon="trash"
   @alert={{true}}

--- a/app/components/documents/document-card.hbs
+++ b/app/components/documents/document-card.hbs
@@ -167,17 +167,6 @@
                   </AuLink>
                   <AuHr />
                 {{/if}}
-                {{#if this.mayRemoveSignFlow}}
-                  <AuButton
-                    @skin="link"
-                    @alert={{true}}
-                    {{on "click" this.deleteSignFlow}}
-                    role="menuitem"
-                  >
-                    {{t "delete-signed-piece"}}
-                  </AuButton>
-                  <AuHr />
-                {{/if}}
                 <AuButton
                   data-test-document-card-delete
                   @skin="link"
@@ -267,17 +256,6 @@
   @message={{t "delete-document-container-message"}}
   @onConfirm={{this.verifyDeleteDocumentContainer}}
   @onCancel={{this.cancelDeleteDocumentContainer}}
-  @confirmMessage={{t "delete"}}
-  @confirmIcon="trash"
-  @alert={{true}}
-/>
-
-<ConfirmationModal
-  @modalOpen={{this.isOpenVerifyDeleteSignFlow}}
-  @title={{t "delete-signed-piece"}}
-  @message={{t "verify-delete-signed-piece"}}
-  @onConfirm={{this.verifyDeleteSignFlow}}
-  @onCancel={{this.cancelDeleteSignFlow}}
   @confirmMessage={{t "delete"}}
   @confirmIcon="trash"
   @alert={{true}}

--- a/app/components/documents/document-card.js
+++ b/app/components/documents/document-card.js
@@ -40,6 +40,8 @@ export default class DocumentsDocumentCardComponent extends Component {
   @tracked documentContainer;
   @tracked isDraftAccessLevel;
   @tracked signMarkingActivity;
+  @tracked isOpenVerifyDeleteSignFlow = false;
+  @tracked signedpiece;
 
   @tracked uploadedFile;
   @tracked newPiece;
@@ -62,6 +64,13 @@ export default class DocumentsDocumentCardComponent extends Component {
     return !this.signMarkingActivity
       && this.signaturesEnabled
       && this.currentSession.may('manage-signatures');
+  }
+
+  get mayRemoveSignFlow() {
+    return this.signMarkingActivity
+      && this.signedPiece
+      && this.signaturesEnabled
+      && this.currentSession.may('remove-signatures');
   }
 
   @task
@@ -127,6 +136,7 @@ export default class DocumentsDocumentCardComponent extends Component {
   @task
   *loadSignatureRelatedData() {
     this.signMarkingActivity = yield this.piece.signMarkingActivity;
+    this.signedPiece = yield this.args.piece.signedPiece;
   }
 
   @task
@@ -285,5 +295,22 @@ export default class DocumentsDocumentCardComponent extends Component {
       return await this.signatureService.canManageSignFlow(this.args.piece);
     }
     return false;
+  }
+
+  @action
+  deleteSignFlow() {
+    this.isOpenVerifyDeleteSignFlow = true;
+  }
+
+  @action
+  cancelDeleteSignFlow() {
+    this.isOpenVerifyDeleteSignFlow = false;
+  }
+
+  @action
+  async verifyDeleteSignFlow() {
+    await this.signatureService.removeSignFlow(this.args.piece);
+    await this.loadSignatureRelatedData.perform();
+    this.isOpenVerifyDeleteSignFlow = false;
   }
 }

--- a/app/components/documents/document-card.js
+++ b/app/components/documents/document-card.js
@@ -40,8 +40,6 @@ export default class DocumentsDocumentCardComponent extends Component {
   @tracked documentContainer;
   @tracked isDraftAccessLevel;
   @tracked signMarkingActivity;
-  @tracked isOpenVerifyDeleteSignFlow = false;
-  @tracked signedpiece;
 
   @tracked uploadedFile;
   @tracked newPiece;
@@ -64,13 +62,6 @@ export default class DocumentsDocumentCardComponent extends Component {
     return !this.signMarkingActivity
       && this.signaturesEnabled
       && this.currentSession.may('manage-signatures');
-  }
-
-  get mayRemoveSignFlow() {
-    return this.signMarkingActivity
-      && this.signedPiece
-      && this.signaturesEnabled
-      && this.currentSession.may('remove-signatures');
   }
 
   @task
@@ -136,7 +127,6 @@ export default class DocumentsDocumentCardComponent extends Component {
   @task
   *loadSignatureRelatedData() {
     this.signMarkingActivity = yield this.piece.signMarkingActivity;
-    this.signedPiece = yield this.args.piece.signedPiece;
   }
 
   @task
@@ -295,22 +285,5 @@ export default class DocumentsDocumentCardComponent extends Component {
       return await this.signatureService.canManageSignFlow(this.args.piece);
     }
     return false;
-  }
-
-  @action
-  deleteSignFlow() {
-    this.isOpenVerifyDeleteSignFlow = true;
-  }
-
-  @action
-  cancelDeleteSignFlow() {
-    this.isOpenVerifyDeleteSignFlow = false;
-  }
-
-  @action
-  async verifyDeleteSignFlow() {
-    await this.signatureService.removeSignFlow(this.args.piece);
-    await this.loadSignatureRelatedData.perform();
-    this.isOpenVerifyDeleteSignFlow = false;
   }
 }

--- a/app/components/documents/document-details-panel.hbs
+++ b/app/components/documents/document-details-panel.hbs
@@ -191,21 +191,25 @@
               >
                 {{@piece.signedPiece.name}}.{{@piece.signedPiece.file.extension}}
               </AuLinkExternal>
-              {{#if (user-may "remove-signatures")}}
-                <AuButton
-                  @skin="naked"
-                  @alert={{true}}
-                  @icon="trash"
-                  @hideText={{true}}
-                  {{on "click" (fn (mut this.isOpenVerifyDeleteSignFlow) true)}}
-                >
-                  {{t "delete"}}
-                </AuButton>
-              {{/if}}
               <AccessLevelPill 
                 @accessLevel={{await @piece.signedPiece.accessLevel}} 
                 @isEditable={{false}}
               />
+              <AuDropdown
+                @icon="three-dots"
+                @title={{t "more"}}
+                @hideText={{true}}
+                @alignment="right"
+              >
+                <AuButton
+                  @skin="link"
+                  @alert={{true}}
+                  {{on "click" (toggle "isOpenVerifyDeleteSignFlow" this)}}
+                  role="menuitem"
+                >
+                  {{t "delete-signed-piece"}}
+                </AuButton>
+              </AuDropdown>
             </div>
           </div>
         {{/if}}
@@ -240,7 +244,8 @@
   <WebComponents::VlModalVerify
     @title={{t "delete-signed-piece"}}
     @message={{t "verify-delete-signed-piece"}}
-    @onCancel={{fn (mut this.isOpenVerifyDeleteSignFlow) false}}
-    @onVerify={{this.verifyDeleteSignFlow}}
+    @onCancel={{toggle "isOpenVerifyDeleteSignFlow" this}}
+    @onVerify={{this.verifyDeleteSignFlow.perform}}
+    @isLoading={{this.verifyDeleteSignFlow.isRunning}}
   />
 {{/if}}

--- a/app/components/documents/document-details-panel.hbs
+++ b/app/components/documents/document-details-panel.hbs
@@ -179,23 +179,35 @@
       </Auk::KeyValue>
       {{#if (and this.isSignaturesEnabled (await (this.canViewSignedPiece)))}}
         {{#if @piece.signedPiece.file}}
-          <Auk::KeyValue
-            @key={{t "signed-document"}}
-          >
-            <AuLinkExternal
-              href={{await @piece.signedPiece.namedDownloadLinkPromise}}
-              @skin="primary"
-              @icon="download"
-              @iconAlignment="left"
-              download
-            >
-              {{@piece.signedPiece.name}}.{{@piece.signedPiece.file.extension}}
-            </AuLinkExternal>
-            <AccessLevelPill 
-              @accessLevel={{await @piece.signedPiece.accessLevel}} 
-              @isEditable={{false}}
-            />
-          </Auk::KeyValue>
+          <div class="auk-key-value-item">
+            <div class="auk-key-value-item__label">{{t "signed-document"}}</div>
+            <div class="auk-key-value-item__value au-u-flex au-u-flex--vertical-center au-u-flex--spaced-small">
+              <AuLinkExternal
+                href={{await @piece.signedPiece.namedDownloadLinkPromise}}
+                @skin="primary"
+                @icon="download"
+                @iconAlignment="left"
+                download
+              >
+                {{@piece.signedPiece.name}}.{{@piece.signedPiece.file.extension}}
+              </AuLinkExternal>
+              {{#if (user-may "remove-signatures")}}
+                <AuButton
+                  @skin="naked"
+                  @alert={{true}}
+                  @icon="trash"
+                  @hideText={{true}}
+                  {{on "click" (fn (mut this.isOpenVerifyDeleteSignFlow) true)}}
+                >
+                  {{t "delete"}}
+                </AuButton>
+              {{/if}}
+              <AccessLevelPill 
+                @accessLevel={{await @piece.signedPiece.accessLevel}} 
+                @isEditable={{false}}
+              />
+            </div>
+          </div>
         {{/if}}
       {{/if}}
     </Auk::Panel::Body>
@@ -214,5 +226,21 @@
     @message={{t "delete-document-message"}}
     @onCancel={{fn (mut this.isOpenVerifyDeleteModal) false}}
     @onVerify={{this.verifyDeleteDocument}}
+  />
+{{/if}}
+
+{{#if this.isOpenVerifyDeleteSignFlow}}
+  {{!-- TODO: vl-refactor --}}
+  {{!-- We can't use AuModal here because said modals get rendered inside a
+        "wormhole" div. The current component is also part of a modal which gets
+        rendered in the same "wormhole", so opening another AuModal here will
+        overwrite the existing page content, and break the route. If AuModals
+        ever support rendering multiple modals over each other, we can use one
+        here, otherwise we might want to make the doc view not be a modal. --}}
+  <WebComponents::VlModalVerify
+    @title={{t "delete-signed-piece"}}
+    @message={{t "verify-delete-signed-piece"}}
+    @onCancel={{fn (mut this.isOpenVerifyDeleteSignFlow) false}}
+    @onVerify={{this.verifyDeleteSignFlow}}
   />
 {{/if}}

--- a/app/components/documents/document-details-panel.hbs
+++ b/app/components/documents/document-details-panel.hbs
@@ -195,21 +195,23 @@
                 @accessLevel={{await @piece.signedPiece.accessLevel}} 
                 @isEditable={{false}}
               />
-              <AuDropdown
-                @icon="three-dots"
-                @title={{t "more"}}
-                @hideText={{true}}
-                @alignment="right"
-              >
-                <AuButton
-                  @skin="link"
-                  @alert={{true}}
-                  {{on "click" (toggle "isOpenVerifyDeleteSignFlow" this)}}
-                  role="menuitem"
+              {{#if (user-may "remove-signatures")}}
+                <AuDropdown
+                  @icon="three-dots"
+                  @title={{t "more"}}
+                  @hideText={{true}}
+                  @alignment="right"
                 >
-                  {{t "delete-signed-piece"}}
-                </AuButton>
-              </AuDropdown>
+                  <AuButton
+                    @skin="link"
+                    @alert={{true}}
+                    {{on "click" (toggle "isOpenVerifyDeleteSignFlow" this)}}
+                    role="menuitem"
+                  >
+                    {{t "delete-signed-piece"}}
+                  </AuButton>
+                </AuDropdown>
+              {{/if}}
             </div>
           </div>
         {{/if}}

--- a/app/components/documents/document-details-panel.js
+++ b/app/components/documents/document-details-panel.js
@@ -104,6 +104,11 @@ export default class DocumentsDocumentDetailsPanel extends Component {
     this.isReplacingSourceFile = !this.isReplacingSourceFile;
   }
 
+  verifyDeleteSignFlow = task(async () => {
+    await this.signatureService.removeSignFlow(this.args.piece);
+    this.isOpenVerifyDeleteSignFlow = false;
+  })
+
   @action
   openEditDetails() {
     this.isEditingDetails = true;
@@ -125,12 +130,6 @@ export default class DocumentsDocumentDetailsPanel extends Component {
       this.args.didDeletePiece(this.args.piece);
     }
     this.isOpenVerifyDeleteModal = false;
-  }
-
-  @action
-  async verifyDeleteSignFlow() {
-    await this.signatureService.removeSignFlow(this.args.piece)
-    this.isOpenVerifyDeleteSignFlow = false;
   }
   
   canViewConfidentialPiece = async () => {

--- a/app/components/documents/document-details-panel.js
+++ b/app/components/documents/document-details-panel.js
@@ -21,6 +21,7 @@ export default class DocumentsDocumentDetailsPanel extends Component {
   @tracked isOpenVerifyDeleteModal = false;
   @tracked isReplacingSourceFile = false;
   @tracked isUploadingReplacementSourceFile = false;
+  @tracked isOpenVerifyDeleteSignFlow = false;
   @tracked replacementSourceFile;
   @tracked documentType;
   @tracked accessLevel;
@@ -124,6 +125,12 @@ export default class DocumentsDocumentDetailsPanel extends Component {
       this.args.didDeletePiece(this.args.piece);
     }
     this.isOpenVerifyDeleteModal = false;
+  }
+
+  @action
+  async verifyDeleteSignFlow() {
+    await this.signatureService.removeSignFlow(this.args.piece)
+    this.isOpenVerifyDeleteSignFlow = false;
   }
   
   canViewConfidentialPiece = async () => {

--- a/app/components/documents/document-details-panel.js
+++ b/app/components/documents/document-details-panel.js
@@ -107,7 +107,7 @@ export default class DocumentsDocumentDetailsPanel extends Component {
   verifyDeleteSignFlow = task(async () => {
     await this.signatureService.removeSignFlow(this.args.piece);
     this.isOpenVerifyDeleteSignFlow = false;
-  })
+  });
 
   @action
   openEditDetails() {

--- a/app/components/documents/document-preview/signatures-tab.hbs
+++ b/app/components/documents/document-preview/signatures-tab.hbs
@@ -78,6 +78,7 @@
     @title={{t "delete-all-sign-flow-data"}}
     @message={{t "verify-delete-all-sign-flow-data"}}
     @onCancel={{toggle "isOpenVerifyDeleteSignFlow" this}}
-    @onVerify={{this.verifyDeleteSignFlow}}
+    @onVerify={{this.verifyDeleteSignFlow.perform}}
+    @isLoading={{this.verifyDeleteSignFlow.isRunning}}
   />
 {{/if}}

--- a/app/components/documents/document-preview/signatures-tab.hbs
+++ b/app/components/documents/document-preview/signatures-tab.hbs
@@ -2,10 +2,22 @@
   {{#if this.loadSignatureRelatedData.isRunning}}
     <Auk::Loader />
   {{else if this.signMarkingActivity}}
-    <SignaturePill
-      @piece={{@piece}}
-      @signMarkingActivity={{this.signMarkingActivity}}
-    />
+    <div class="auk-o-flex auk-o-flex--spaced auk-o-flex--vertical-center">
+      <SignaturePill
+        @piece={{@piece}}
+        @signMarkingActivity={{this.signMarkingActivity}}
+      />
+      {{#if (user-may "remove-signatures")}}
+        <AuButton
+          @skin="naked"
+          @alert={{true}}
+          @icon="trash"
+          {{on "click" (toggle "isOpenVerifyDeleteSignFlow" this)}}
+        >
+          {{t "delete-all-sign-flow-data"}}
+        </AuButton>
+      {{/if}}
+    </div>
   {{else if this.agendaitem}}
     {{#if this.loadCanManageSignFlow.isRunning}}
       <Auk::Loader />
@@ -53,3 +65,19 @@
     </AuAlert>
   {{/if}}
 </div>
+
+{{#if this.isOpenVerifyDeleteSignFlow}}
+  {{!-- TODO: vl-refactor --}}
+  {{!-- We can't use AuModal here because said modals get rendered inside a
+        "wormhole" div. The current component is also part of a modal which gets
+        rendered in the same "wormhole", so opening another AuModal here will
+        overwrite the existing page content, and break the route. If AuModals
+        ever support rendering multiple modals over each other, we can use one
+        here, otherwise we might want to make the doc view not be a modal. --}}
+  <WebComponents::VlModalVerify
+    @title={{t "delete-all-sign-flow-data"}}
+    @message={{t "verify-delete-all-sign-flow-data"}}
+    @onCancel={{toggle "isOpenVerifyDeleteSignFlow" this}}
+    @onVerify={{this.verifyDeleteSignFlow}}
+  />
+{{/if}}

--- a/app/components/documents/document-preview/signatures-tab.hbs
+++ b/app/components/documents/document-preview/signatures-tab.hbs
@@ -15,6 +15,9 @@
           {{on "click" (toggle "isOpenVerifyDeleteSignFlow" this)}}
         >
           {{t "delete-all-sign-flow-data"}}
+          <EmberTooltip @side="bottom" @tooltipClass="tooltip-custom">
+            {{t "delete-all-sign-flow-tooltip"}}
+          </EmberTooltip>
         </AuButton>
       {{/if}}
     </div>

--- a/app/components/documents/document-preview/signatures-tab.hbs
+++ b/app/components/documents/document-preview/signatures-tab.hbs
@@ -50,33 +50,29 @@
         </Group>
       </AuToolbar>
     {{else}}
-        <AuAlert
-          @skin="warning"
-          @icon="alert-triangle"
-          @title={{t "cannot-sign"}}
-        >
-          <p>{{t "cannot-create-sign-flow-message"}}</p>
-        </AuAlert>
+      <AuAlert
+        @skin="warning"
+        @icon="alert-triangle"
+        @title={{t "cannot-sign"}}
+      >
+        <p>{{t "cannot-create-sign-flow-message"}}</p>
+      </AuAlert>
     {{/if}}
   {{else}}
-    <AuAlert
-      @skin="warning"
-      @icon="alert-triangle"
-      @title={{t "cannot-sign"}}
-    >
+    <AuAlert @skin="warning" @icon="alert-triangle" @title={{t "cannot-sign"}}>
       <p>{{t "cannot-sign-message"}}</p>
     </AuAlert>
   {{/if}}
 </div>
 
 {{#if this.isOpenVerifyDeleteSignFlow}}
-  {{!-- TODO: vl-refactor --}}
-  {{!-- We can't use AuModal here because said modals get rendered inside a
+  {{! TODO: vl-refactor }}
+  {{! We can't use AuModal here because said modals get rendered inside a
         "wormhole" div. The current component is also part of a modal which gets
         rendered in the same "wormhole", so opening another AuModal here will
         overwrite the existing page content, and break the route. If AuModals
         ever support rendering multiple modals over each other, we can use one
-        here, otherwise we might want to make the doc view not be a modal. --}}
+        here, otherwise we might want to make the doc view not be a modal. }}
   <WebComponents::VlModalVerify
     @title={{t "delete-all-sign-flow-data"}}
     @message={{t "verify-delete-all-sign-flow-data"}}

--- a/app/components/documents/document-preview/signatures-tab.js
+++ b/app/components/documents/document-preview/signatures-tab.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 import { task } from 'ember-concurrency';
 
 export default class DocumentsDocumentPreviewDetailsSignaturesTabComponent extends Component {
@@ -11,6 +12,7 @@ export default class DocumentsDocumentPreviewDetailsSignaturesTabComponent exten
   @tracked agendaitem;
   @tracked decisionActivity;
   @tracked canManageSignFlow = false;
+  @tracked isOpenVerifyDeleteSignFlow = false;
 
   signers = [];
   approvers = [];
@@ -52,4 +54,11 @@ export default class DocumentsDocumentPreviewDetailsSignaturesTabComponent exten
   loadCanManageSignFlow = task(async () => {
     this.canManageSignFlow =  await this.signatureService.canManageSignFlow(this.args.piece);
   });
+
+  @action
+  async verifyDeleteSignFlow() {
+    await this.signatureService.removeSignFlow(this.args.piece);
+    await this.loadSignatureRelatedData.perform();
+    this.isOpenVerifyDeleteSignFlow = false;
+  }
 }

--- a/app/components/documents/document-preview/signatures-tab.js
+++ b/app/components/documents/document-preview/signatures-tab.js
@@ -44,19 +44,21 @@ export default class DocumentsDocumentPreviewDetailsSignaturesTabComponent exten
       this.decisionActivity,
       this.signers,
       this.approvers,
-      this.notificationAddresses,
+      this.notificationAddresses
     );
     await this.args.piece.reload();
     this.signMarkingActivity = await this.args.piece.signMarkingActivity;
   });
 
   loadCanManageSignFlow = task(async () => {
-    this.canManageSignFlow =  await this.signatureService.canManageSignFlow(this.args.piece);
+    this.canManageSignFlow = await this.signatureService.canManageSignFlow(
+      this.args.piece
+    );
   });
 
   verifyDeleteSignFlow = task(async () => {
     await this.signatureService.removeSignFlow(this.args.piece);
     await this.loadSignatureRelatedData.perform();
     this.isOpenVerifyDeleteSignFlow = false;
-  })
+  });
 }

--- a/app/components/documents/document-preview/signatures-tab.js
+++ b/app/components/documents/document-preview/signatures-tab.js
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
-import { action } from '@ember/object';
 import { task } from 'ember-concurrency';
 
 export default class DocumentsDocumentPreviewDetailsSignaturesTabComponent extends Component {
@@ -55,10 +54,9 @@ export default class DocumentsDocumentPreviewDetailsSignaturesTabComponent exten
     this.canManageSignFlow =  await this.signatureService.canManageSignFlow(this.args.piece);
   });
 
-  @action
-  async verifyDeleteSignFlow() {
+  verifyDeleteSignFlow = task(async () => {
     await this.signatureService.removeSignFlow(this.args.piece);
     await this.loadSignatureRelatedData.perform();
     this.isOpenVerifyDeleteSignFlow = false;
-  }
+  })
 }

--- a/app/components/web-components/vl-modal-verify.hbs
+++ b/app/components/web-components/vl-modal-verify.hbs
@@ -6,7 +6,7 @@
   {{! template-lint-disable no-down-event-binding}}
   {{on "keydown" this.keyDown}}
 >
-  <div class="auk-modal auk-modal--small" role="dialog">
+  <div class="auk-modal auk-modal--medium" role="dialog">
     <div class="auk-modal__push"></div>
     <div class="auk-modal__content">
       <div class="auk-modal__header auk-modal__header--bordered">

--- a/app/config/permissions.js
+++ b/app/config/permissions.js
@@ -20,6 +20,7 @@ const {
 // - manage-signatures: currently everything related to digital signing. Will be detailed later
 //     in order to distinguish people that should prepare the flow, effectively sign, etc
 // - manage-only-specific-signatures: allow the profile to only create signing flows for their own mandatee.
+// - remove-signatures: Remove the signed piece and all data of a sign-flow 
 // - search-publication-flows
 // - manage-publication-flows: General viewing and editing of publication flows
 // - manage-documents: modifying document details, uploading new versions, removing.
@@ -50,6 +51,7 @@ const groups = [
     defaultRoute: 'agendas',
     permissions: [
       'manage-signatures',
+      'remove-signatures',
       'manage-agenda-versions',
       'manage-agendaitems',
       'manage-decisions',
@@ -80,6 +82,7 @@ const groups = [
     defaultRoute: 'agendas',
     permissions: [
       'manage-signatures',
+      'remove-signatures',
       'manage-agenda-versions',
       'manage-agendaitems',
       'manage-decisions',
@@ -106,6 +109,7 @@ const groups = [
     defaultRoute: 'agendas',
     permissions: [
       'manage-signatures',
+      'remove-signatures',
       'manage-agenda-versions',
       'manage-agendaitems',
       'manage-decisions',

--- a/app/serializers/piece.js
+++ b/app/serializers/piece.js
@@ -5,7 +5,7 @@ const SKIP_SERIALIZED = [
   'submissionActivity',
   'signedPiece',
   'signMarkingActivity',
-  'signCompletionActivity'
+  'signCompletionActivity',
 ];
 
 export default class PieceSerializer extends ApplicationSerializer {

--- a/app/serializers/piece.js
+++ b/app/serializers/piece.js
@@ -4,7 +4,6 @@ const SKIP_SERIALIZED = [
   'agendaitems',
   'submissionActivity',
   'signedPiece',
-  'unsignedPiece',
   'signMarkingActivity',
   'signCompletionActivity'
 ];

--- a/app/serializers/sign-subcase.js
+++ b/app/serializers/sign-subcase.js
@@ -1,0 +1,27 @@
+import ApplicationSerializer from './application';
+
+const SKIP_SERIALIZED = [
+  'signMarkingActivity',
+  'signPreparationActivity',
+  'signCancellationActivity',
+  'signCompletionActivity',
+  'signSigningActivities',
+  'signApprovalActivities',
+  'signRefusalActivities'
+];
+
+export default class PieceSerializer extends ApplicationSerializer {
+  serializeBelongsTo(snapshot, json, relationship) {
+    const key = relationship.key;
+    if (!SKIP_SERIALIZED.includes(key)) {
+      super.serializeBelongsTo(snapshot, json, relationship);
+    }
+  }
+
+  serializeHasMany(snapshot, json, relationship) {
+    const key = relationship.key;
+    if (!SKIP_SERIALIZED.includes(key)) {
+      super.serializeHasMany(snapshot, json, relationship);
+    }
+  }
+}

--- a/app/serializers/sign-subcase.js
+++ b/app/serializers/sign-subcase.js
@@ -5,9 +5,6 @@ const SKIP_SERIALIZED = [
   'signPreparationActivity',
   'signCancellationActivity',
   'signCompletionActivity',
-  'signSigningActivities',
-  'signApprovalActivities',
-  'signRefusalActivities'
 ];
 
 export default class PieceSerializer extends ApplicationSerializer {
@@ -15,13 +12,6 @@ export default class PieceSerializer extends ApplicationSerializer {
     const key = relationship.key;
     if (!SKIP_SERIALIZED.includes(key)) {
       super.serializeBelongsTo(snapshot, json, relationship);
-    }
-  }
-
-  serializeHasMany(snapshot, json, relationship) {
-    const key = relationship.key;
-    if (!SKIP_SERIALIZED.includes(key)) {
-      super.serializeHasMany(snapshot, json, relationship);
     }
   }
 }

--- a/app/serializers/sign-subcase.js
+++ b/app/serializers/sign-subcase.js
@@ -5,6 +5,9 @@ const SKIP_SERIALIZED = [
   'signPreparationActivity',
   'signCancellationActivity',
   'signCompletionActivity',
+  'signSigningActivities',
+  'signApprovalActivities',
+  'signRefusalActivities'
 ];
 
 export default class PieceSerializer extends ApplicationSerializer {
@@ -12,6 +15,13 @@ export default class PieceSerializer extends ApplicationSerializer {
     const key = relationship.key;
     if (!SKIP_SERIALIZED.includes(key)) {
       super.serializeBelongsTo(snapshot, json, relationship);
+    }
+  }
+
+  serializeHasMany(snapshot, json, relationship) {
+    const key = relationship.key;
+    if (!SKIP_SERIALIZED.includes(key)) {
+      super.serializeHasMany(snapshot, json, relationship);
     }
   }
 }

--- a/app/serializers/sign-subcase.js
+++ b/app/serializers/sign-subcase.js
@@ -7,7 +7,7 @@ const SKIP_SERIALIZED = [
   'signCompletionActivity',
   'signSigningActivities',
   'signApprovalActivities',
-  'signRefusalActivities'
+  'signRefusalActivities',
 ];
 
 export default class PieceSerializer extends ApplicationSerializer {

--- a/app/services/signature-service.js
+++ b/app/services/signature-service.js
@@ -126,4 +126,26 @@ export default class SignatureService extends Service {
     }
     return false;
   }
+
+  async removeSignFlow(piece) {
+    const signMarkingActivity = await piece.signMarkingActivity;
+    if (signMarkingActivity) {
+      const signSubcase = await signMarkingActivity.signSubcase;
+      const signFlow = await signSubcase?.signFlow;
+      // const signPreparationActivity = await signSubcase?.signPreparationActivity;
+      // const signCompletionActivity = await signSubcase?.signCompletionActivity;
+      // const signApprovalActivities = await signSubcase?.signApprovalActivities;
+      // const signSigningActivities = await signSubcase?.signSigningActivities;
+      // const signRefusalActivities = await signSubcase?.signRefusalActivities;
+      const signedPiece = await piece.signedPiece;
+
+      await signedPiece?.destroyRecord();
+      await 
+      await signSubcase?.destroyRecord();
+      await signFlow?.destroyRecord();
+      await signMarkingActivity.destroyRecord();
+      await piece.belongsTo('signedPiece').reload();
+      await piece.belongsTo('signMarkingActivity').reload();
+    }
+  }
 }

--- a/app/services/signature-service.js
+++ b/app/services/signature-service.js
@@ -156,6 +156,8 @@ export default class SignatureService extends Service {
       await signRefusalActivities?.map(async (activity) => {
         await activity.destroyRecord()
       });
+      // destroying signSubcase can throw ember errors. reload fixed that problem.
+      await signSubcase?.reload();
       await signSubcase?.destroyRecord();
       await signFlow?.destroyRecord();
       await signMarkingActivity.destroyRecord();

--- a/app/services/signature-service.js
+++ b/app/services/signature-service.js
@@ -7,30 +7,20 @@ export default class SignatureService extends Service {
   @service intl;
   @service currentSession;
 
-  async createSignFlow(
-    piece,
-    decisionActivity,
-    signers,
-    approvers,
-    notified,
-  ) {
+  async createSignFlow(piece, decisionActivity, signers, approvers, notified) {
     // Create sign flow, sign subcase and marking activity
-    const {
-      signFlow,
-      signSubcase,
-    } = await this.markDocumentForSignature(piece, decisionActivity);
-
+    const { signFlow, signSubcase } = await this.markDocumentForSignature(
+      piece,
+      decisionActivity
+    );
 
     // Attach signers
     await Promise.all(
       signers.map((mandatee) => {
-        const record = this.store.createRecord(
-          'sign-signing-activity',
-          {
-            signSubcase,
-            mandatee,
-          }
-        );
+        const record = this.store.createRecord('sign-signing-activity', {
+          signSubcase,
+          mandatee,
+        });
         return record.save();
       })
     );
@@ -38,13 +28,10 @@ export default class SignatureService extends Service {
     // Attach approvers
     await Promise.all(
       approvers.map((approver) => {
-        const record = this.store.createRecord(
-          'sign-approval-activity',
-          {
-            approver,
-            signSubcase,
-          }
-        );
+        const record = this.store.createRecord('sign-approval-activity', {
+          approver,
+          signSubcase,
+        });
         return record.save();
       })
     );
@@ -94,27 +81,33 @@ export default class SignatureService extends Service {
       return {
         signFlow,
         signSubcase,
-      }
+      };
     }
   }
 
   async canManageSignFlow(piece) {
     // the base permission 'manage-signatures' does not cover cabinet specific requirements
     if (this.currentSession.may('manage-only-specific-signatures')) {
-      const submissionActivity = await this.store.queryOne('submission-activity', {
-        filter: {
-          pieces: {
-            ':id:': piece?.id,
+      const submissionActivity = await this.store.queryOne(
+        'submission-activity',
+        {
+          filter: {
+            pieces: {
+              ':id:': piece?.id,
+            },
           },
-        },
-      });
+        }
+      );
       const subcase = await submissionActivity.subcase;
       if (subcase) {
         const mandatee = await subcase.requestedBy;
         if (mandatee) {
-          const currentUserOrganization = await this.currentSession.organization;
-          const currentUserOrganizationMandatees = await currentUserOrganization.mandatees;
-          const currentUserOrganizationMandateesUris = currentUserOrganizationMandatees?.map((mandatee) => mandatee.uri);
+          const currentUserOrganization = await this.currentSession
+            .organization;
+          const currentUserOrganizationMandatees =
+            await currentUserOrganization.mandatees;
+          const currentUserOrganizationMandateesUris =
+            currentUserOrganizationMandatees?.map((mandatee) => mandatee.uri);
           if (currentUserOrganizationMandateesUris?.includes(mandatee.uri)) {
             return true;
           }
@@ -134,12 +127,24 @@ export default class SignatureService extends Service {
       const signFlow = await signSubcase?.signFlow;
       const signedPiece = await piece.signedPiece;
       const signedFile = await signedPiece?.file;
-      const signPreparationActivity = await signSubcase?.belongsTo('signPreparationActivity').reload();
-      const signCompletionActivity = await signSubcase?.belongsTo('signCompletionActivity').reload();
-      const signCancellationActivity = await signSubcase?.belongsTo('signCancellationActivity').reload();
-      const signApprovalActivities = await signSubcase?.hasMany('signApprovalActivities').reload();
-      const signSigningActivities = await signSubcase?.hasMany('signSigningActivities').reload();
-      const signRefusalActivities = await signSubcase?.hasMany('signRefusalActivities').reload();
+      const signPreparationActivity = await signSubcase
+        ?.belongsTo('signPreparationActivity')
+        .reload();
+      const signCompletionActivity = await signSubcase
+        ?.belongsTo('signCompletionActivity')
+        .reload();
+      const signCancellationActivity = await signSubcase
+        ?.belongsTo('signCancellationActivity')
+        .reload();
+      const signApprovalActivities = await signSubcase
+        ?.hasMany('signApprovalActivities')
+        .reload();
+      const signSigningActivities = await signSubcase
+        ?.hasMany('signSigningActivities')
+        .reload();
+      const signRefusalActivities = await signSubcase
+        ?.hasMany('signRefusalActivities')
+        .reload();
 
       // delete in reverse order of creation
       await signedFile?.destroyRecord();
@@ -148,13 +153,13 @@ export default class SignatureService extends Service {
       await signCompletionActivity?.destroyRecord();
       await signCancellationActivity?.destroyRecord();
       await signApprovalActivities?.map(async (activity) => {
-        await activity.destroyRecord()
+        await activity.destroyRecord();
       });
       await signSigningActivities?.map(async (activity) => {
-        await activity.destroyRecord()
+        await activity.destroyRecord();
       });
       await signRefusalActivities?.map(async (activity) => {
-        await activity.destroyRecord()
+        await activity.destroyRecord();
       });
       // destroying signSubcase can throw ember errors. reload fixed that problem.
       await signSubcase?.reload();

--- a/app/services/signature-service.js
+++ b/app/services/signature-service.js
@@ -132,15 +132,30 @@ export default class SignatureService extends Service {
     if (signMarkingActivity) {
       const signSubcase = await signMarkingActivity.signSubcase;
       const signFlow = await signSubcase?.signFlow;
-      // const signPreparationActivity = await signSubcase?.signPreparationActivity;
-      // const signCompletionActivity = await signSubcase?.signCompletionActivity;
-      // const signApprovalActivities = await signSubcase?.signApprovalActivities;
-      // const signSigningActivities = await signSubcase?.signSigningActivities;
-      // const signRefusalActivities = await signSubcase?.signRefusalActivities;
       const signedPiece = await piece.signedPiece;
+      const signedFile = await signedPiece?.file;
+      const signPreparationActivity = await signSubcase?.signPreparationActivity;
+      const signCompletionActivity = await signSubcase?.signCompletionActivity;
+      const signCancellationActivity = await signSubcase?.signCancellationActivity;
+      const signApprovalActivities = await signSubcase?.signApprovalActivities;
+      const signSigningActivities = await signSubcase?.signSigningActivities;
+      const signRefusalActivities = await signSubcase?.signRefusalActivities;
 
+      // delete in reverse order of creation
+      await signedFile?.destroyRecord();
       await signedPiece?.destroyRecord();
-      await 
+      await signPreparationActivity?.destroyRecord();
+      await signCompletionActivity?.destroyRecord();
+      await signCancellationActivity?.destroyRecord();
+      await signApprovalActivities?.map(async (activity) => {
+        await activity.destroyRecord
+      })
+      await signSigningActivities?.map(async (activity) => {
+        await activity.destroyRecord
+      })
+      await signRefusalActivities?.map(async (activity) => {
+        await activity.destroyRecord
+      })
       await signSubcase?.destroyRecord();
       await signFlow?.destroyRecord();
       await signMarkingActivity.destroyRecord();

--- a/app/services/signature-service.js
+++ b/app/services/signature-service.js
@@ -134,12 +134,12 @@ export default class SignatureService extends Service {
       const signFlow = await signSubcase?.signFlow;
       const signedPiece = await piece.signedPiece;
       const signedFile = await signedPiece?.file;
-      const signPreparationActivity = await signSubcase?.signPreparationActivity;
-      const signCompletionActivity = await signSubcase?.signCompletionActivity;
-      const signCancellationActivity = await signSubcase?.signCancellationActivity;
-      const signApprovalActivities = await signSubcase?.signApprovalActivities;
-      const signSigningActivities = await signSubcase?.signSigningActivities;
-      const signRefusalActivities = await signSubcase?.signRefusalActivities;
+      const signPreparationActivity = await signSubcase?.belongsTo('signPreparationActivity').reload();
+      const signCompletionActivity = await signSubcase?.belongsTo('signCompletionActivity').reload();
+      const signCancellationActivity = await signSubcase?.belongsTo('signCancellationActivity').reload();
+      const signApprovalActivities = await signSubcase?.hasMany('signApprovalActivities').reload();
+      const signSigningActivities = await signSubcase?.hasMany('signSigningActivities').reload();
+      const signRefusalActivities = await signSubcase?.hasMany('signRefusalActivities').reload();
 
       // delete in reverse order of creation
       await signedFile?.destroyRecord();
@@ -149,13 +149,13 @@ export default class SignatureService extends Service {
       await signCancellationActivity?.destroyRecord();
       await signApprovalActivities?.map(async (activity) => {
         await activity.destroyRecord()
-      })
+      });
       await signSigningActivities?.map(async (activity) => {
         await activity.destroyRecord()
-      })
+      });
       await signRefusalActivities?.map(async (activity) => {
         await activity.destroyRecord()
-      })
+      });
       await signSubcase?.destroyRecord();
       await signFlow?.destroyRecord();
       await signMarkingActivity.destroyRecord();

--- a/app/services/signature-service.js
+++ b/app/services/signature-service.js
@@ -148,13 +148,13 @@ export default class SignatureService extends Service {
       await signCompletionActivity?.destroyRecord();
       await signCancellationActivity?.destroyRecord();
       await signApprovalActivities?.map(async (activity) => {
-        await activity.destroyRecord
+        await activity.destroyRecord()
       })
       await signSigningActivities?.map(async (activity) => {
-        await activity.destroyRecord
+        await activity.destroyRecord()
       })
       await signRefusalActivities?.map(async (activity) => {
-        await activity.destroyRecord
+        await activity.destroyRecord()
       })
       await signSubcase?.destroyRecord();
       await signFlow?.destroyRecord();

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1217,7 +1217,8 @@
   "creating-sign-flows-message": "Handtekenstromen worden aangemaakt. Dit kan even duren.",
   "ongoing": "In verwerking",
   "delete-signed-piece": "Getekend document verwijderen",
-  "verify-delete-signed-piece": "Bent u zeker dat u het getekend document wilt verwijderen? Deze actie kan niet meer ongedaan gemaakt worden. Het volledige handtekenprocess in Kaleidos voor dit document zal mee verwijderd worden. In Signinghub zal het proces blijven bestaan tenzij dit manueel verwijderd wordt.",
+  "verify-delete-signed-piece": "Bent u zeker dat u het getekend document wilt verwijderen? Deze actie kan niet meer ongedaan gemaakt worden. Het volledige handtekenprocess voor dit document zal mee verwijderd worden uit Kaleidos. In Signinghub zal het proces blijven bestaan tenzij dit manueel verwijderd wordt.",
   "delete-all-sign-flow-data": "Verwijder volledig handtekeningproces",
-  "verify-delete-all-sign-flow-data": "Bent u zeker dat u het handtekenproces in Kaleidos volledig wilt verwijderen? Deze actie kan niet meer ongedaan gemaakt worden. In Signinghub zal het proces blijven bestaan tenzij dit manueel verwijderd wordt."
+  "verify-delete-all-sign-flow-data": "Bent u zeker dat u het handtekenproces volledig wilt verwijderen uit Kaleidos? Deze actie kan niet meer ongedaan gemaakt worden. In Signinghub zal het proces blijven bestaan tenzij dit manueel verwijderd wordt.",
+  "delete-all-sign-flow-tooltip": "Verwijder het volledige handtekenproces uit Kaleidos, zodat het document opnieuw ondertekend kan worden"
 }

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1217,7 +1217,7 @@
   "creating-sign-flows-message": "Handtekenstromen worden aangemaakt. Dit kan even duren.",
   "ongoing": "In verwerking",
   "delete-signed-piece": "Getekend document verwijderen",
-  "verify-delete-signed-piece": "Bent u zeker dat u het getekend document wilt verwijderen? Deze actie kan niet meer ongedaan gemaakt worden. Het volledige handtekenprocess voor dit document zal mee verwijderd worden.",
+  "verify-delete-signed-piece": "Bent u zeker dat u het getekend document wilt verwijderen? Deze actie kan niet meer ongedaan gemaakt worden. Het volledige handtekenprocess in Kaleidos voor dit document zal mee verwijderd worden. In Signinghub zal het proces blijven bestaan tenzij dit manueel verwijderd wordt.",
   "delete-all-sign-flow-data": "Verwijder volledig handtekeningproces",
-  "verify-delete-all-sign-flow-data": "Bent u zeker dat u het handtekenproces volledig wilt verwijderen? Deze actie kan niet meer ongedaan gemaakt worden."
+  "verify-delete-all-sign-flow-data": "Bent u zeker dat u het handtekenproces in Kaleidos volledig wilt verwijderen? Deze actie kan niet meer ongedaan gemaakt worden. In Signinghub zal het proces blijven bestaan tenzij dit manueel verwijderd wordt."
 }

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1134,7 +1134,7 @@
   "last-seen": "Laatst gezien",
   "filter-on-rights": "Filteren op rechtengroep",
   "filter-on-last-seen": "Filteren op laatst gezien",
-  "blocked-on": "Geblokkeerd op",Admin should be able to do it
+  "blocked-on": "Geblokkeerd op",
   "filter-on-organization": "Filteren op organisatie",
   "id-or-organization": "Organisatie ID of naam",
   "list-of-ovo-codes": "Lijst met OVO codes",

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1215,5 +1215,7 @@
   "create-sign-flow-conflicting-signers-title": "Ondertekenaars zijn niet automatisch ingevuld",
   "create-sign-flow-conflicting-signers-message": "De gekozen bestanden zijn geagendeerd door verschillende ministers waardoor Kaleidos de ondertekenaars niet automatisch kan bepalen.",
   "creating-sign-flows-message": "Handtekenstromen worden aangemaakt. Dit kan even duren.",
-  "ongoing": "In verwerking"
+  "ongoing": "In verwerking",
+  "delete-signed-piece": "Getekend document verwijderen",
+  "verify-delete-signed-piece": "Bent u zeker dat u het getekend document wilt verwijderen? Deze actie kan niet meer ongedaan gemaakt worden. Het volledige handtekenprocess voor dit document zal mee verwijderd worden."
 }

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1217,5 +1217,7 @@
   "creating-sign-flows-message": "Handtekenstromen worden aangemaakt. Dit kan even duren.",
   "ongoing": "In verwerking",
   "delete-signed-piece": "Getekend document verwijderen",
-  "verify-delete-signed-piece": "Bent u zeker dat u het getekend document wilt verwijderen? Deze actie kan niet meer ongedaan gemaakt worden. Het volledige handtekenprocess voor dit document zal mee verwijderd worden."
+  "verify-delete-signed-piece": "Bent u zeker dat u het getekend document wilt verwijderen? Deze actie kan niet meer ongedaan gemaakt worden. Het volledige handtekenprocess voor dit document zal mee verwijderd worden.",
+  "delete-all-sign-flow-data": "Verwijder volledig handtekeningproces",
+  "verify-delete-all-sign-flow-data": "Bent u zeker dat u het handtekenproces volledig wilt verwijderen? Deze actie kan niet meer ongedaan gemaakt worden."
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4099
https://kanselarij.atlassian.net/browse/KAS-2793

Original PR: https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1751
This branch contains fixes to the signature-service method to completely remove all data models.
- Added a new permission to remove signflow related data
- Added a service call to clean up everything related to a sign flow.
- Added dropdown and action in document details panel in doc viewer (with permission)
- Added verify modal for this destructive action in document details panel 
- Added action with tooltip in signature tab
- Added verify modal for this destructive action in signature tab

Added serializer because we set some `belongsTo` relations inversely (activity knows sign-subcase)
Some data might be added by the digital-signing service.
Saving signSubcase after loading all relations may result in overwriting lists with stale data (no reload before save).

Also added the `hasMany` to serialize.
Even though Ember should not serialize it (saving sign-subcase does not save the list (This used to happen in earlier ember versions)) > deleting sign-subcase after deleting all hasMany activities yields an error in console.
![image](https://github.com/kanselarij-vlaanderen/frontend-kaleidos/assets/22245223/4d54b95e-bd16-4459-97a0-138d025cb6e8)

This error is not present when reloading the `signsubcase` model before deleting.
