### PR TITLE
KAS-4057: gebruik van backspace/delete toets verdubbelt een letter binnen rdfa-editor

### DIFF
--- a/app/styles/auk/_auk-additions.scss
+++ b/app/styles/auk/_auk-additions.scss
@@ -339,14 +339,6 @@ table tr.lt-expanded-row {
   }
 }
 
-// Override default capitalization of first letter in paragraphs
-.au-c-content,
-.say-editor {
-  p::first-letter {
-    text-transform: none;
-  };
-}
-
 .auk-alert-stack {
   z-index: 10000;
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@ember/test-helpers": "^2.9.3",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
-    "@kanselarij-vlaanderen/au-kaleidos-css": "3.7.0",
+    "@kanselarij-vlaanderen/au-kaleidos-css": "3.7.1",
     "@kanselarij-vlaanderen/au-kaleidos-icons": "3.0.1",
     "@lblod/ember-acmidm-login": "git+https://github.com/ValenberghsSven/ember-acmidm-login.git#75d8aab5839585201a68df4701a15bcfda42b32d",
     "@lblod/ember-mock-login": "^0.7.0",


### PR DESCRIPTION
**Tickets binnen Jira:** 
- https://kanselarij.atlassian.net/browse/KAS-4057

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.