### PR TITLE
KAS-4130 Provision for status on signflow model and in constants

### DIFF
--- a/app/config/constants.js
+++ b/app/config/constants.js
@@ -97,6 +97,16 @@ export default {
     CONFIRMED: 'http://themis.vlaanderen.be/id/concept/vrijgave-status/5da73f0d-6605-493c-9c1c-0d3a71bf286a',
     RELEASED: 'http://themis.vlaanderen.be/id/concept/vrijgave-status/27bd25d1-72b4-49b2-a0ba-236ca28373e5',
   },
+  // NOT ALL SIGNFLOW STATUSSES ARE SUPPORTED YET. UNCOMMENT WHEN ENABLED
+  SIGNFLOW_STATUSES: {
+    MARKED: 'http://themis.vlaanderen.be/id/handtekenstatus/f6a60072-0537-11ee-bb35-ee395168dcf7',
+    PREPARED: 'http://themis.vlaanderen.be/id/handtekenstatus/1dd296c2-053a-11ee-bb35-ee395168dcf7',
+    // TO_BE_APPROVED: 'http://themis.vlaanderen.be/id/handtekenstatus/2fd72150-0538-11ee-bb35-ee395168dcf7',
+    // TO_BE_SIGNED: 'http://themis.vlaanderen.be/id/handtekenstatus/47508452-0538-11ee-bb35-ee395168dcf7',
+    SIGNED: 'http://themis.vlaanderen.be/id/handtekenstatus/29d4e7d2-0539-11ee-bb35-ee395168dcf7',
+    // REFUSED: 'http://themis.vlaanderen.be/id/handtekenstatus/3128aae6-0539-11ee-bb35-ee395168dcf7',
+    // CANCELED: 'http://themis.vlaanderen.be/id/handtekenstatus/2d043722-053a-11ee-bb35-ee395168dcf7',
+  },
   URGENCY_LEVELS: {
     SPEEDPROCEDURE: 'http://themis.vlaanderen.be/id/concept/urgentieniveau/b2b9c588-e91d-4ce0-a1a1-11b522e8a9bf',
     STANDARD: 'http://themis.vlaanderen.be/id/concept/urgentieniveau/5a48d953-3d88-4eb6-b784-ddb3070c831d',

--- a/app/models/sign-flow.js
+++ b/app/models/sign-flow.js
@@ -13,4 +13,5 @@ export default class SignFlowModel extends Model {
   @belongsTo('decision-activity', { inverse: 'signFlows', async: true })
   decisionActivity;
   @belongsTo('user', { inverse: null, async: true }) creator;
+  @belongsTo('concept', { inverse: null, async: true }) status;
 }


### PR DESCRIPTION
Provisions for status concepts to be linked to sign flows.

Also added them in constants, with the unused ones (for now) commented out.
These can then be used to populate the available statuses in filters, for example, without cluttering the list with unused ones.

Related PR: https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/395