### PR TITLE
Feature/kas 4143 bundled signing

### DIFF
--- a/app/components/documents/document-card-list.hbs
+++ b/app/components/documents/document-card-list.hbs
@@ -9,6 +9,7 @@
         @hideNewerVersions={{false}}
         @didDeleteContainer={{@didDeleteContainer}}
         @onOpenUploadModal={{@onOpenUploadModal}}
+        @markForSignature={{@markForSignature}}
         @onAddPiece={{@onAddPiece}}
         @isGenerated={{false}}
       />

--- a/app/components/documents/document-card.hbs
+++ b/app/components/documents/document-card.hbs
@@ -156,7 +156,7 @@
             {{/unless}}
           </Group.Item>
           {{#if this.signaturesEnabled}}
-            {{#if this.loadSignatureRelatedData.isRunning}}
+            {{#if (or this.markForSignature.isRunning this.loadSignatureRelatedData.isRunning)}}
               <Group.Item>
                 <div
                   class="auk-loader au-u-margin-left-small"
@@ -216,18 +216,14 @@
                   </AuButton>
                 {{/if}}
                 {{#if this.mayCreateSignMarkingActivity}}
-                  {{#let (t "signatures") as |signTab| }}
-                    <AuLink
-                      @skin="link"
-                      @route="document"
-                      @model={{this.piece.id}}
-                      @query={{hash tab=signTab}}
-                      role="menuitem"
-                    >
-                      {{t "present-for-signing"}}
-                    </AuLink>
-                    <AuHr />
-                  {{/let}}
+                  <AuButton
+                    @skin="link"
+                    {{on "click" this.markForSignature.perform}}
+                    role="menuitem"
+                  >
+                    {{t "present-for-signing"}}
+                  </AuButton>
+                  <AuHr />
                 {{/if}}
                 {{#if (not @hideDelete)}}
                   <AuHr />

--- a/app/components/documents/document-card.js
+++ b/app/components/documents/document-card.js
@@ -152,6 +152,11 @@ export default class DocumentsDocumentCardComponent extends Component {
     }
   }
 
+  markForSignature = task(async () => {
+    await this.args.markForSignature?.(this.piece);
+    await this.loadSignatureRelatedData.perform();
+  });
+
   get sortedPieces() {
     return A(sortPieces(this.pieces.toArray()).reverse());
   }

--- a/app/components/documents/document-preview/signatures-tab.hbs
+++ b/app/components/documents/document-preview/signatures-tab.hbs
@@ -1,7 +1,8 @@
 <div class="auk-u-m-4">
   {{#if this.loadSignatureRelatedData.isRunning}}
     <Auk::Loader />
-  {{else if this.signMarkingActivity}}
+  {{! {else if this.signMarkingActivity}}
+  {{else if this.signPreparationActivity}}
     <div class="auk-o-flex auk-o-flex--spaced auk-o-flex--vertical-center">
       <SignaturePill
         @piece={{@piece}}

--- a/app/components/documents/document-preview/signatures-tab.js
+++ b/app/components/documents/document-preview/signatures-tab.js
@@ -9,7 +9,9 @@ export default class DocumentsDocumentPreviewDetailsSignaturesTabComponent exten
   @service signatureService;
   @service toaster;
 
+  @tracked signSubcase;
   @tracked signMarkingActivity;
+  @tracked signPreparationActivity;
   @tracked agendaitem;
   @tracked decisionActivity;
   @tracked canManageSignFlow = false;
@@ -27,6 +29,8 @@ export default class DocumentsDocumentPreviewDetailsSignaturesTabComponent exten
 
   loadSignatureRelatedData = task(async () => {
     this.signMarkingActivity = await this.args.piece.signMarkingActivity;
+    this.signSubcase = await this.signMarkingActivity?.signSubcase;
+    this.signPreparationActivity = await this.signSubcase?.signPreparationActivity;
     // we want to get the agendaitem this piece is linked to so we can use a treatment of it later
     // it should be the latest version, although any version should yield the same treatment if they are all versions on 1 agenda
     // There are situations where 1 piece is linked to different versions of agendaitems on multiple agendas (postponed)
@@ -45,17 +49,20 @@ export default class DocumentsDocumentPreviewDetailsSignaturesTabComponent exten
       await this.signatureService.createSignFlow(
         this.args.piece,
         this.decisionActivity,
+        this.signSubcase,
         this.signers,
         this.approvers,
         this.notificationAddresses,
       );
       await this.args.piece.reload();
       this.signMarkingActivity = await this.args.piece.signMarkingActivity;
+      this.signPreparationActivity = await this.args.piece.signPreparationActivity;
       this.toaster.success(
         this.intl.t('document-was-sent-to-signinghub'),
         this.intl.t('successfully-started-sign-flow')
       )
-    } catch {
+    } catch (e) {
+      console.error(e);
       this.toaster.error(
         this.intl.t('create-sign-flow-error-message'),
         this.intl.t('warning-title')

--- a/app/components/signature-pill.js
+++ b/app/components/signature-pill.js
@@ -50,7 +50,7 @@ export default class SignaturePillComponent extends Component {
     } else if (this.isPrepared) {
       return this.intl.t('sent');
     } else if (this.isMarked) {
-      return this.intl.t('to-sign');
+      return this.intl.t('marked-for-signing');
     }
     return "";
   }
@@ -74,7 +74,7 @@ export default class SignaturePillComponent extends Component {
       this.isRefused = signRefusalActivities?.length;
       this.isCancelled = !!signCancellationActivity;
 
-      if (!this.isRefused) {
+      if (this.isPrepared && !this.isRefused && !this.isCancelled) {
         const piece = await this.args.piece;
         const signFlow = await signSubcase.signFlow;
         const signFlowCreator = await signFlow.creator;

--- a/app/controllers/agenda/agendaitems/agendaitem/documents.js
+++ b/app/controllers/agenda/agendaitems/agendaitem/documents.js
@@ -20,6 +20,7 @@ export default class DocumentsAgendaitemsAgendaController extends Controller {
   @service agendaService;
   @service fileConversionService;
   @service router;
+  @service signatureService;
 
   documentsAreVisible;
   defaultAccessLevel;
@@ -324,6 +325,14 @@ export default class DocumentsAgendaitemsAgendaController extends Controller {
   @action
   closePublicationModal() {
     this.isOpenPublicationModal = false;
+  }
+
+  @action
+  async markForSignature(piece) {
+    // Placed the getting of these variables here to lessen loading time in router
+    const agendaItemTreatment = await this.agendaitem.treatment;
+    const decisionActivity = await agendaItemTreatment.decisionActivity;
+    await this.signatureService.markDocumentForSignature(piece, decisionActivity);
   }
 
   @action

--- a/app/services/signature-service.js
+++ b/app/services/signature-service.js
@@ -1,5 +1,4 @@
 import Service, { inject as service } from '@ember/service';
-import { uploadPiecesToSigninghub } from 'frontend-kaleidos/utils/digital-signing';
 
 export default class SignatureService extends Service {
   @service store;
@@ -7,12 +6,12 @@ export default class SignatureService extends Service {
   @service intl;
   @service currentSession;
 
-  async createSignFlow(piece, decisionActivity, signers, approvers, notified) {
+  async createSignFlow(piece, decisionActivity, signSubcase, signers, approvers, notified) {
     // Create sign flow, sign subcase and marking activity
-    const { signFlow, signSubcase } = await this.markDocumentForSignature(
-      piece,
-      decisionActivity
-    );
+    // const { signFlow, signSubcase } = await this.markDocumentForSignature(
+    //   piece,
+    //   decisionActivity
+    // );
 
     // Attach signers
     await Promise.all(
@@ -41,11 +40,11 @@ export default class SignatureService extends Service {
     await signSubcase.save();
 
     // Prepare sign flow: create preparation activity and send to SH
-    const response = await uploadPiecesToSigninghub(signFlow, [piece]);
-    if (!response.ok) {
-      await this.removeSignFlow(piece);
-      throw new Error('Failed to upload piece to Signing Hub');
-    }
+    // const response = await uploadPiecesToSigninghub(signFlow, [piece]);
+    // if (!response.ok) {
+    //   await this.removeSignFlow(piece);
+    //   throw new Error('Failed to upload piece to Signing Hub');
+    // }
   }
 
   async markDocumentForSignature(piece, decisionActivity) {

--- a/app/templates/agenda/agendaitems/agendaitem/documents.hbs
+++ b/app/templates/agenda/agendaitems/agendaitem/documents.hbs
@@ -43,6 +43,7 @@
       @onOpenUploadModal={{this.openUploadModalForNewPiece}}
       @onAddPiece={{perform this.addPiece}}
       @didDeleteContainer={{this.refresh}}
+      @markForSignature={{this.markForSignature}}
       @isEditable={{true}}
     />
   {{else}}


### PR DESCRIPTION
# :warning: DO NOT MERGE THIS!
This frontend PR only exists to make testing the backend changes somewhat less annoying.

Related PRs (these *should* be merged!):
- https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/401
- https://github.com/kanselarij-vlaanderen/digital-signing-service/pull/26

## How to test the changes

The `Aanbieden voor handteken` button in the three dots menu of the document card now only creates the sign flow and marking activity of that piece. As soon as you click it the status should be reflected as a new `Gemarkeerd voor handtekenen` pill appears. 

To properly test this you will want to mark a number of documents of multiple agenda items, e.g. 2 documents in 2 agendaitems. Once this is done, open these documents in the preview modal and go to the `Handtekenen` tab. Use the same data for all the sign flows (signers/approvers/notifiers) and "create" the sign flow. Notice that once you've created them the "form" is still there and the signature pill isn't shown in the sigatures tab. This is normal.
Now find the sign flow IDs of the documents you've marked, you can use Ember inspect for this, and make the following call to the backend from inside a JS console in a logged in Kaleidos tab:

```js
body = { data: [
{ id: '649697817C2C7149DDFFCA0E' }, 
{ id: '649697807C2C7149DDFFCA0B' },
{ id: '649697787C2C7149DDFFCA05' },
{ id: '6496977A7C2C7149DDFFCA08' }
]};

await fetch("/signing-flows/upload-to-signinghub", {
  method: 'POST',
  headers: {
    'content-type': 'application/vnd.api+json',
  },
  body: JSON.stringify(body)
});
```

You should see the sign preparation activities being created in the digital-signing-service logs and after the call is done refresh Kaleidos. The signature pills should now say `Verstuurd` and if you click through to SH you should see one package/bundle of documents per decision activity.