### PR TITLE
Feature/kas 4129 agenda detail constant refresh

### DIFF
--- a/app/components/agenda/agenda-header/agenda-tabs.hbs
+++ b/app/components/agenda/agenda-header/agenda-tabs.hbs
@@ -13,6 +13,7 @@
   {{#if this.firstAgendaitem}}
     <Auk::Tab
       @route="agenda.agendaitems.agendaitem"
+      @current-when="agenda.agendaitems.agendaitem"
       @models={{this.modelsForDetailRoute}}
     >
       {{t "detail"}}

--- a/app/controllers/agenda/agendaitems.js
+++ b/app/controllers/agenda/agendaitems.js
@@ -42,7 +42,6 @@ export default class AgendaAgendaitemsController extends Controller {
   @tracked selectedAgendaitem; // set in setupController of child-route
   @tracked documentLoadCount = 0;
   @tracked totalCount = 0;
-  @tracked isLoading;
   @tracked isEditingOverview = false;
 
   // @tracked filter; // TODO: don't do tracking on qp's before updating to Ember 3.22+ (https://github.com/emberjs/ember.js/issues/18715)
@@ -71,6 +70,9 @@ export default class AgendaAgendaitemsController extends Controller {
   @action
   searchAgendaitems(value) {
     set(this,'filter', value);
+    // bug in ember with refreshModel, (more info in loading action in route)
+    this.router.transitionTo(('agenda.agendaitems', this.meeting.id, this.agenda.id, {queryParams: {filter: value}}));
+    this.router.refresh('agenda.agendaitems');
   }
 
   @task

--- a/app/controllers/agenda/agendaitems.js
+++ b/app/controllers/agenda/agendaitems.js
@@ -69,9 +69,14 @@ export default class AgendaAgendaitemsController extends Controller {
 
   @action
   searchAgendaitems(value) {
-    set(this,'filter', value);
+    set(this, 'filter', value);
     // bug in ember with refreshModel, (more info in loading action in route)
-    this.router.transitionTo(('agenda.agendaitems', this.meeting.id, this.agenda.id, {queryParams: {filter: value}}));
+    this.router.transitionTo(
+      ('agenda.agendaitems',
+      this.meeting.id,
+      this.agenda.id,
+      { queryParams: { filter: value } })
+    );
     this.router.refresh('agenda.agendaitems');
   }
 

--- a/app/routes/agenda/agendaitems.js
+++ b/app/routes/agenda/agendaitems.js
@@ -10,7 +10,8 @@ import CONSTANTS from 'frontend-kaleidos/config/constants';
 export default class AgendaAgendaitemsRoute extends Route {
   queryParams = {
     filter: {
-      refreshModel: true,
+      // bug in ember with refreshModel, keep this false (more info in loading action)
+      refreshModel: false, 
     },
     showModifiedOnly: {
       refreshModel: true,
@@ -130,21 +131,26 @@ export default class AgendaAgendaitemsRoute extends Route {
   }
 
   @action
+  // eslint-disable-next-line no-unused-vars
   loading(transition) {
-    // eslint-disable-next-line ember/no-controller-access-in-routes
-    const controller = this.controllerFor(this.routeName);
-    controller.isLoadingModel = true;
-    transition.promise.finally(() => {
-      controller.isLoadingModel = false;
-    });
+    // Currently there is a bug in ember with refreshModel where the model keeps refresing even though it there is no need.
+    // This is causing many visual refreshes in our code in cetain situations.
+    // https://github.com/emberjs/ember.js/issues/19497
+    // In order to fix this: When searching we do a transitionTo from the controller and a manual model refresh instead
+    // In that case, we can just rely on the default behavior of ember and not block the transition.    
 
-    // If only the filter queryParam changed, we don't want to bubble
-    // the loading event so we can handle it ourselves with an inline loader.
-    // When changing routes, e.g. when switching tabs, or when other queryParams
-    // change we do want to display the loading page.
-    if (transition.queryParamsOnly && transition.from && transition.to) {
-      return transition.from.queryParams?.filter === transition.to.queryParams?.filter;
-    }
+    // When should we show the loader on this level:
+    // - when searching the model should reload (manual refresh from controller)
+    // - when filtering on modifiedOnly the model should reload (ember default behavior with refreshModel, this one is not broken)
+    // - when entering the route the first time (ember default behavior building top down)
+    // - when switching subroutes on 'agenda' route (ex. agenda.documents to agenda.agendaitem, ember default behavior)
+
+    // When should we NOT show the loader on this level:
+    // - when switching between agendaitems (agenda.agendaitems.agendaitem.* subroutes with id to a different id)
+    // - when switching between agendaitem tabs (agenda.agendaitems.agendaitem.* subroutes with same id)
+    // in both those cases ember default behavior will trigger 'agenda.agendaitems.agendaitem.loading' to show
+
+    // so for all of those cases, we can just bubble and let ember handle it.
     return true;
   }
 }

--- a/app/routes/agenda/agendaitems.js
+++ b/app/routes/agenda/agendaitems.js
@@ -137,7 +137,7 @@ export default class AgendaAgendaitemsRoute extends Route {
     // This is causing many visual refreshes in our code in cetain situations.
     // https://github.com/emberjs/ember.js/issues/19497
     // In order to fix this: When searching we do a transitionTo from the controller and a manual model refresh instead
-    // In that case, we can just rely on the default behavior of ember and not block the transition.    
+    // In that case, we can just rely on the default behavior of ember and not block the transition.
 
     // When should we show the loader on this level:
     // - when searching the model should reload (manual refresh from controller)

--- a/app/templates/agenda/agendaitems.hbs
+++ b/app/templates/agenda/agendaitems.hbs
@@ -1,8 +1,4 @@
-{{#if this.isLoading}}
-  <div class="auk-panel-layout__main-content auk-u-bg-alt">
-    <Auk::Loader @message={{t "agenda-loading"}} />
-  </div>
-{{else if this.isAgendaitemDetailRoute}}
+{{#if this.isAgendaitemDetailRoute}}
   <div class="auk-panel-layout__agenda-items">
     <div class="auk-sidebar auk-sidebar--gray-100 auk-sidebar--left auk-u-maximize-width">
       <div class="auk-scroll-wrapper">


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4129

Took awhile to find this one.
There is an active bug in Ember where the "transitionTo incorrectly re-runs the model hook when query params do not change".
Linked the issue in JIRA ticket.
In some cases (fe. when going from agenda.documents to agenda.agendaitems) we did not change query params, but the model kept refreshing to due to "refreshModel" begin true on the filter QP. Even though there was no change in QP.

This had some side-effects:
Switching to a subroute of 1 agendaitem (agenda.agendaitem.agendaitem.**) refreshed the entire parent route (agenda.agendaitems)
The links in the sidebar were always pointing to the "index" route, even if we were on the "documents" route at the time.
We were reloading some views multiple times (users did report the agenda seemed slower, could this be part of it?)


In order to fix this:
- refreshModel has to be false for the filter not to force the model reload.
- in order to refresh the model when we change the filter I added a manual transition and a model reload with the new filter.
- have default ember loading behavior take care of the transitions to loading pages on all levels

I tested this through and all the loaders seemed to be shown in the correct places.
I could no longer reproduce a situation where the parent loader was shown when the child routes were traversed
Running this through Jenkins.