### PR TITLE
Feature/KAS-4167 Make the signature pills poll their status regularly

### DIFF
--- a/app/components/signature-pill.js
+++ b/app/components/signature-pill.js
@@ -25,7 +25,7 @@ export default class SignaturePillComponent extends Component {
     cancel(this.scheduledRefresh);
   }
 
-  schedulePublicationActivitiesRefresh() {
+  scheduleSignFlowStatusRefresh() {
     if (![REFUSED, SIGNED, CANCELED].includes(this.data?.value?.status?.uri)) {
       this.scheduledRefresh = later(this, async () => {
         this.args.signMarkingActivity.reload();
@@ -69,7 +69,7 @@ export default class SignaturePillComponent extends Component {
       }
     }
 
-    this.schedulePublicationActivitiesRefresh();
+    this.scheduleSignFlowStatusRefresh();
 
     return {
       signingHubUrl,

--- a/app/components/signature-pill.js
+++ b/app/components/signature-pill.js
@@ -1,9 +1,14 @@
 import Component from '@glimmer/component';
+import { later, cancel } from '@ember/runloop';
+import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import fetch from 'fetch';
 import constants from 'frontend-kaleidos/config/constants';
 import { task as trackedTask } from 'ember-resources/util/ember-concurrency';
 import { task } from 'ember-concurrency';
+import { SIGN_FLOW_STATUS_REFRESH_INTERVAL_MS } from 'frontend-kaleidos/config/config';
+
+const { SIGNED, REFUSED, CANCELED, MARKED } = constants.SIGNFLOW_STATUSES;
 
 /**
  * @param signMarkingActivity {SignMarkingActivityModel|Promise<SignMarkingActivityModel>}
@@ -12,8 +17,30 @@ export default class SignaturePillComponent extends Component {
   @service intl;
   @service currentSession;
 
+  scheduledRefresh;
+  @tracked triggerTask;
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+    cancel(this.scheduledRefresh);
+  }
+
+  schedulePublicationActivitiesRefresh() {
+    if (![REFUSED, SIGNED, CANCELED].includes(this.data?.value?.status?.uri)) {
+      this.scheduledRefresh = later(this, async () => {
+        this.args.signMarkingActivity.reload();
+        const signSubcase = await this.args.signMarkingActivity.signSubcase.reload();
+        const signFlow = await signSubcase.signFlow.reload();
+        await signFlow.status.reload();
+        this.triggerTask = new Date();
+      }, SIGN_FLOW_STATUS_REFRESH_INTERVAL_MS);
+    }
+  }
+
   loadData = task(async () => {
-    const { SIGNED, REFUSED, MARKED } = constants.SIGNFLOW_STATUSES;
+    // Cancel the scheduled refresh, in case we're retriggering because
+    // a dependency (marking activity) changed
+    cancel(this.scheduledRefresh);
     const signMarkingActivity = await this.args.signMarkingActivity;
     if (!signMarkingActivity) return;
     const signSubcase = await signMarkingActivity.signSubcase;
@@ -42,13 +69,15 @@ export default class SignaturePillComponent extends Component {
       }
     }
 
+    this.schedulePublicationActivitiesRefresh();
+
     return {
       signingHubUrl,
       status,
     };
   });
 
-  data = trackedTask(this, this.loadData);
+  data = trackedTask(this, this.loadData, () => [this.triggerTask]); // Make the resource dependant on this.triggerTask
 
   get skin() {
     const { REFUSED, CANCELED } = constants.SIGNFLOW_STATUSES;

--- a/app/components/signature-pill.js
+++ b/app/components/signature-pill.js
@@ -28,10 +28,6 @@ export default class SignaturePillComponent extends Component {
   scheduleSignFlowStatusRefresh() {
     if (![REFUSED, SIGNED, CANCELED].includes(this.data?.value?.status?.uri)) {
       this.scheduledRefresh = later(this, async () => {
-        this.args.signMarkingActivity.reload();
-        const signSubcase = await this.args.signMarkingActivity.signSubcase.reload();
-        const signFlow = await signSubcase.signFlow.reload();
-        await signFlow.status.reload();
         this.triggerTask = new Date();
       }, SIGN_FLOW_STATUS_REFRESH_INTERVAL_MS);
     }
@@ -41,11 +37,12 @@ export default class SignaturePillComponent extends Component {
     // Cancel the scheduled refresh, in case we're retriggering because
     // a dependency (marking activity) changed
     cancel(this.scheduledRefresh);
+
     const signMarkingActivity = await this.args.signMarkingActivity;
     if (!signMarkingActivity) return;
-    const signSubcase = await signMarkingActivity.signSubcase;
-    const signFlow = await signSubcase.signFlow;
-    const status = await signFlow.status;
+    const signSubcase = await signMarkingActivity.signSubcase.reload();
+    const signFlow = await signSubcase.signFlow.reload();
+    const status = await signFlow.status.reload();
     let signingHubUrl = null;
 
     if (status.uri !== REFUSED) {

--- a/app/components/signature-pill.js
+++ b/app/components/signature-pill.js
@@ -40,9 +40,9 @@ export default class SignaturePillComponent extends Component {
 
     const signMarkingActivity = await this.args.signMarkingActivity;
     if (!signMarkingActivity) return;
-    const signSubcase = await signMarkingActivity.signSubcase.reload();
-    const signFlow = await signSubcase.signFlow.reload();
-    const status = await signFlow.status.reload();
+    const signSubcase = await signMarkingActivity.signSubcase;
+    const signFlow = await signSubcase.signFlow;
+    const status = await signFlow.belongsTo('status').reload();
     let signingHubUrl = null;
 
     if (status.uri !== REFUSED) {

--- a/app/config/config.js
+++ b/app/config/config.js
@@ -28,6 +28,7 @@ export const PUBLICATIONS_IN_KALEIDOS_START_DATE = new Date(2022, 2 /* March */,
 // Number of milliseconds it takes to release a publication via Yggdrasil/Themis
 export const ESTIMATED_PUBLICATION_DURATION = 30 * 60 * 1000;
 export const PUBLICATION_ACTIVITY_REFRESH_INTERVAL_MS = 60 * 1000;
+export const SIGN_FLOW_STATUS_REFRESH_INTERVAL_MS = 60 * 1000;
 
 export const DOCUMENT_DELETE_UNDO_TIME_MS = 15000;
 


### PR DESCRIPTION
Uses an equivalent construction to what we do in the publication pills to poll the status.

We might want to replace usage of models and relationships (`signMarkingActivity.signSubcase; signSubcase.signFlow; signFlow.status`) with just a query. The query won't be cached, but given that we're explicitly trying to reload data that's probably a good thing in this case (and it means we don't need to do a bunch of manual reloads to make the code work when ran a second time with the same `signMarkingActivity`).
TBD if we want to change this, now, some other time, or never.