### PR TITLE
fix: filter out sign flows w/o piece and do cache busting in a silly way

### DIFF
--- a/app/components/signatures/create-sign-flow.js
+++ b/app/components/signatures/create-sign-flow.js
@@ -62,7 +62,7 @@ export default class SignaturesCreateSignFlowComponent extends Component {
         cosigners: _cosigners,
       } = await getSubmitterAndCosigners(decisionActivity);
 
-      if (submitter.id !== _submitter.id) {
+      if (submitter?.id !== _submitter?.id) {
         hasConflictingSigners = true;
         break;
       }

--- a/app/controllers/signatures/index.js
+++ b/app/controllers/signatures/index.js
@@ -35,9 +35,9 @@ export default class SignaturesIndexController extends Controller {
 
   @tracked selectedSignFlows = new TrackedArray([]);
 
-  @tracked size = PAGINATION_SIZES[1];
-  @tracked page = 0;
-  @tracked sort = DEFAULT_SORT_OPTIONS.join(',');
+  @tracked sizeSignaturesIndex = PAGINATION_SIZES[1];
+  @tracked pageSignaturesIndex = 0;
+  @tracked sortSignaturesIndex = DEFAULT_SORT_OPTIONS.join(',');
   @tracked sortField;
 
   signers = [];
@@ -45,9 +45,9 @@ export default class SignaturesIndexController extends Controller {
   notificationAddresses = [];
 
   queryParams = [
-    { size: { type: 'number' } },
-    { page: { type: 'number' } },
-    { sort: { type: 'string' } },
+    { sizeSignaturesIndex: { type: 'number' } },
+    { pageSignaturesIndex: { type: 'number' } },
+    { sortSignaturesIndex: { type: 'string' } },
   ];
 
   localStorageKey = 'signatures.shortlist.minister-filter';
@@ -112,9 +112,9 @@ export default class SignaturesIndexController extends Controller {
       } else {
         newSortOptions = [this.sortField, ...DEFAULT_SORT_OPTIONS];
       }
-      this.sort = newSortOptions.join(',');
+      this.sortSignaturesIndex = newSortOptions.join(',');
     } else {
-      this.sort = DEFAULT_SORT_OPTIONS.join(',');
+      this.sortSignaturesIndex = DEFAULT_SORT_OPTIONS.join(',');
     }
   }
 

--- a/app/controllers/signatures/index.js
+++ b/app/controllers/signatures/index.js
@@ -285,4 +285,16 @@ export default class SignaturesIndexController extends Controller {
       );
     }
   });
+
+  removeSignFlow = task(async () => {
+    if (this.selectedSignFlows.length) {
+      for (let signFlow of this.selectedSignFlows) {
+        await this.signatureService.removeSignFlow(signFlow);
+      }
+    } else if (this.signFlow) {
+      await this.signatureService.removeSignFlow(this.signFlow);
+    }
+    this.closeSidebar();
+    this.router.refresh(this.router.routeName);
+  });
 }

--- a/app/routes/signatures/index.js
+++ b/app/routes/signatures/index.js
@@ -76,10 +76,10 @@ export default class SignaturesIndexRoute extends Route {
         'sign-subcase.sign-marking-activity.piece.document-container.type'
       ].join(','),
       page: {
-        number: params.page,
-        size: params.size,
+        number: params.pageSignaturesIndex,
+        size: params.sizeSignaturesIndex,
       },
-      sort: params.sort,
+      sort: params.sortSignaturesIndex,
     });
   }
 

--- a/app/routes/signatures/index.js
+++ b/app/routes/signatures/index.js
@@ -40,15 +40,19 @@ export default class SignaturesIndexRoute extends Route {
 
   async model(params) {
     const filter = {
+      'sign-subcase': {
+        'sign-marking-activity': {
+          ':has:piece': 'yes',
+        }
+      },
       status: {
         ':uri:': CONSTANTS.SIGNFLOW_STATUSES.MARKED,
       },
       'decision-activity': {
-        ':lte:start-date': (new Date()).toISOString().slice(0, 10), // Cache-busting
         treatment: {
           agendaitems: {
             agenda: {
-              ':has:meeting': true,
+              ':has:meeting': `ye-date-added-for-cache-busting-${(new Date()).toISOString()}`,
             }
           }
         }

--- a/app/routes/signatures/index.js
+++ b/app/routes/signatures/index.js
@@ -7,15 +7,15 @@ export default class SignaturesIndexRoute extends Route {
   @service currentSession;
 
   queryParams = {
-    page: {
+    pageSignaturesIndex: {
       refreshModel: true,
       as: 'pagina',
     },
-    size: {
+    sizeSignaturesIndex: {
       refreshModel: true,
       as: 'aantal',
     },
-    sort: {
+    sortSignaturesIndex: {
       refreshModel: true,
       as: 'sorteer',
     }

--- a/app/templates/signatures/index.hbs
+++ b/app/templates/signatures/index.hbs
@@ -36,12 +36,12 @@
     @clickable={{false}}
     @asideVisible={{this.showSidebar}}
     @content={{@model}}
-    @page={{this.page}}
-    @size={{this.size}}
+    @page={{this.pageSignaturesIndex}}
+    @size={{this.sizeSignaturesIndex}}
     @numberOfItems={{@model.length}}
     @totalNumberOfItems={{@model.meta.count}}
-    @onChangeSize={{fn (mut this.size)}}
-    @onChangePage={{fn (mut this.page)}}
+    @onChangeSize={{fn (mut this.sizeSignaturesIndex)}}
+    @onChangePage={{fn (mut this.pageSignaturesIndex)}}
   >
     <:header>
       <th>

--- a/app/templates/signatures/index.hbs
+++ b/app/templates/signatures/index.hbs
@@ -1,256 +1,270 @@
 {{page-title (t "to-start-up")}}
 
-{{#in-element this.customNavbarButtonsElement}}
-  {{#unless (user-may "manage-only-specific-signatures")}}
-    {{#if this.filteredMinisters}}
-      <AuButton @skin="naked" {{on "click" this.clearFilter}}>
-        {{t "clear-filter"}}
+{{#if this.removeSignFlow.isRunning}}
+  <WebComponents::LoadingPage />
+{{else}}
+  {{#in-element this.customNavbarButtonsElement}}
+    {{#unless (user-may "manage-only-specific-signatures")}}
+      {{#if this.filteredMinisters}}
+        <AuButton @skin="naked" {{on "click" this.clearFilter}}>
+          {{t "clear-filter"}}
+        </AuButton>
+      {{/if}}
+      <AuButton
+        data-test-route-signatures-open-minister-filter
+        @skin="secondary"
+        @icon="filter"
+        {{on "click" this.openFilterModal}}
+      >
+        {{t "filter-on-signer"}}
+      </AuButton>
+    {{/unless}}
+    {{#if this.selectedSignFlows.length}}
+      <AuButton
+        @icon="sign"
+        {{on "click" this.openSidebarMultiItem}}
+      >
+        {{t "start-signing-for-n-selected-documents" n=this.selectedSignFlows.length}}
       </AuButton>
     {{/if}}
-    <AuButton
-      data-test-route-signatures-open-minister-filter
-      @skin="secondary"
-      @icon="filter"
-      {{on "click" this.openFilterModal}}
-    >
-      {{t "filter-on-signer"}}
-    </AuButton>
-  {{/unless}}
-  {{#if this.selectedSignFlows.length}}
-    <AuButton
-      @icon="sign"
-      {{on "click" this.openSidebarMultiItem}}
-    >
-      {{t "start-signing-for-n-selected-documents" n=this.selectedSignFlows.length}}
-    </AuButton>
-  {{/if}}
-{{/in-element}}
+  {{/in-element}}
 
-<KDataTable
-  data-test-route-signatures-data-table
-  @scrollable={{true}}
-  @stickyHeader={{true}}
-  @clickable={{false}}
-  @asideVisible={{this.showSidebar}}
-  @content={{@model}}
-  @page={{this.page}}
-  @size={{this.size}}
-  @numberOfItems={{@model.length}}
-  @totalNumberOfItems={{@model.meta.count}}
-  @onChangeSize={{fn (mut this.size)}}
-  @onChangePage={{fn (mut this.page)}}
->
-  <:header>
-    <th>
-      <AuCheckbox
-        @checked={{this.isSelectedAllItems}}
-        @indeterminate={{and (not this.isSelectedAllItems) this.isSelectedSomeItems}}
-        @onChange={{this.selectAll}}
-      >
-        <span class="auk-u-sr-only">
-          {{t "select"}}
-        </span>
-      </AuCheckbox>
-    </th>
-    <Utils::ThSortable
-      @currentSorting={{this.sortField}}
-      @field={{"sign-subcase.sign-marking-activity.piece.name"}}
-      @onChange={{this.changeSort}}
-      @label={{t "document-name"}}
-    />
-    <th>{{t "document-type"}}</th>
-    <Utils::ThSortable
-      @currentSorting={{this.sortField}}
-      @field={{"decision-activity.treatment.agendaitems.short-title"}}
-      @onChange={{this.changeSort}}
-      @label={{capitalize (t "agendaitem")}}
-    />
-    <th>{{t "ministers"}}</th>
-    <Utils::ThSortable
-      @currentSorting={{this.sortField}}
-      @field={{"decision-activity.start-date"}}
-      @onChange={{this.changeSort}}
-      @label={{t "decision-date"}}
-    />
-    <th></th>
-  </:header>
-  <:body as |signFlow|>
-    {{#let signFlow.signSubcase.signMarkingActivity as |signMarkingActivity|}}
-      {{#let signMarkingActivity.piece as |piece|}}
-        <td>
-          <AuCheckbox
-            @checked={{includes signFlow this.selectedSignFlows}}
-            @onChange={{fn this.toggleItem signFlow}}
-          >
-            <span class="auk-u-sr-only">
-              {{t "select"}}
-            </span>
-          </AuCheckbox>
-        </td>
-        <td data-test-route-signatures-row-name>
-          <AuLink @route="document" @model={{piece.id}}>
-            {{piece.name}}
-          </AuLink>
-        </td>
-        <td>
-          <AuPill @size="small">
-            {{#let piece.documentContainer.type as |type|}}
-              {{#if type}}
-                {{type.label}}
+  <KDataTable
+    data-test-route-signatures-data-table
+    @scrollable={{true}}
+    @stickyHeader={{true}}
+    @clickable={{false}}
+    @asideVisible={{this.showSidebar}}
+    @content={{@model}}
+    @page={{this.page}}
+    @size={{this.size}}
+    @numberOfItems={{@model.length}}
+    @totalNumberOfItems={{@model.meta.count}}
+    @onChangeSize={{fn (mut this.size)}}
+    @onChangePage={{fn (mut this.page)}}
+  >
+    <:header>
+      <th>
+        <AuCheckbox
+          @checked={{this.isSelectedAllItems}}
+          @indeterminate={{and (not this.isSelectedAllItems) this.isSelectedSomeItems}}
+          @onChange={{this.selectAll}}
+        >
+          <span class="auk-u-sr-only">
+            {{t "select"}}
+          </span>
+        </AuCheckbox>
+      </th>
+      <Utils::ThSortable
+        @currentSorting={{this.sortField}}
+        @field={{"sign-subcase.sign-marking-activity.piece.name"}}
+        @onChange={{this.changeSort}}
+        @label={{t "document-name"}}
+      />
+      <th>{{t "document-type"}}</th>
+      <Utils::ThSortable
+        @currentSorting={{this.sortField}}
+        @field={{"decision-activity.treatment.agendaitems.short-title"}}
+        @onChange={{this.changeSort}}
+        @label={{capitalize (t "agendaitem")}}
+      />
+      <th>{{t "ministers"}}</th>
+      <Utils::ThSortable
+        @currentSorting={{this.sortField}}
+        @field={{"decision-activity.start-date"}}
+        @onChange={{this.changeSort}}
+        @label={{t "decision-date"}}
+      />
+      <th></th>
+    </:header>
+    <:body as |signFlow|>
+      {{#let signFlow.signSubcase.signMarkingActivity as |signMarkingActivity|}}
+        {{#let signMarkingActivity.piece as |piece|}}
+          <td>
+            <AuCheckbox
+              @checked={{includes signFlow this.selectedSignFlows}}
+              @onChange={{fn this.toggleItem signFlow}}
+            >
+              <span class="auk-u-sr-only">
+                {{t "select"}}
+              </span>
+            </AuCheckbox>
+          </td>
+          <td data-test-route-signatures-row-name>
+            <AuLink @route="document" @model={{piece.id}}>
+              {{piece.name}}
+            </AuLink>
+          </td>
+          <td>
+            <AuPill @size="small">
+              {{#let piece.documentContainer.type as |type|}}
+                {{#if type}}
+                  {{type.label}}
+                {{else}}
+                  {{t "no-document-type"}}
+                {{/if}}
+              {{/let}}
+            </AuPill>
+          </td>
+          <td>
+            {{#let (await (this.getAgendaitem piece)) as |agendaitem|}}
+              {{agendaitem.shortTitle}}
+            {{/let}}
+          </td>
+          <td data-test-route-signatures-row-mandatee>
+            {{#let (await (this.getMandateeNames signFlow)) as |names|}}
+              {{#if names}}
+                {{join ", " names}}
               {{else}}
-                {{t "no-document-type"}}
+                -
               {{/if}}
             {{/let}}
-          </AuPill>
-        </td>
-        <td>
-          {{#let (await (this.getAgendaitem piece)) as |agendaitem|}}
-            {{agendaitem.shortTitle}}
-          {{/let}}
-        </td>
-        <td data-test-route-signatures-row-mandatee>
-          {{#let (await (this.getMandateeNames signFlow)) as |names|}}
-            {{#if names}}
-              {{join ", " names}}
-            {{else}}
-              -
-            {{/if}}
-          {{/let}}
-        </td>
-        <td>{{date signFlow.decisionActivity.startDate}}</td>
-        <td>
-          <AuButton
-            data-test-route-signatures-row-open-sidebar
-            @skin="naked"
-            @icon="sign"
-            {{on "click" (fn this.openSidebarSingleItem signFlow piece)}}
-          >
-            {{t "start-signing"}}
-          </AuButton>
-        </td>
-      {{/let}}
-    {{/let}}
-  </:body>
-  <:aside>
-    <div class="auk-sidebar">
-      <div class="auk-sidebar__header">
-        <h4 class="auk-toolbar-complex__title">
-          {{t "start-signing"}}
-        </h4>
-        <Auk::Button
-          data-test-route-signatures-sidebar-close
-          @icon="x"
-          @skin="borderless"
-          @layout="icon-only"
-          {{on "click" this.closeSidebar}}
-        />
-      </div>
-      <div data-test-route-signatures-sidebar-info class="auk-sidebar__body">
-        {{#unless this.selectedSignFlows.length}}
-          <p class="au-u-muted auk-u-mt-2">
-            {{or this.piece.documentContainer.type.label (t "no-document-type")}}
-            -
-            {{date this.decisionActivity.startDate}}
-          </p>
-          <h5 class="auk-h4">{{this.piece.name}}</h5>
-          <div class="auk-o-flex auk-o-flex--spaced-wide auk-u-mt-1">
-            <AuLink
-              data-test-route-signatures-sidebar-preview
-              @skin="naked"
-              @icon="book"
-              @route="document"
-              @model={{this.piece.id}}
-            >
-              {{t "preview"}}
-            </AuLink>
-            <AuLink
-              data-test-route-signatures-sidebar-last-agendaitem
-              @skin="naked"
-              @icon="document"
-              @route="agenda.agendaitems.agendaitem"
-              @models={{array this.meeting.id this.agenda.id this.agendaitem.id}}
-            >
-              {{t "consult-agendaitem-decision"}}
-            </AuLink>
-          </div>
-        {{/unless}}
-        {{#if this.decisionActivity}}
-          <Signatures::CreateSignFlow
-            @decisionActivities={{array this.decisionActivity}}
-            @onChangeSigners={{fn (mut this.signers)}}
-            @onChangeApprovers={{fn (mut this.approvers)}}
-            @onChangeNotificationAddresses={{fn (mut this.notificationAddresses)}}
-          />
-        {{else if this.selectedSignFlows.length}}
-          <Signatures::CreateSignFlow
-            @decisionActivities={{this.selectedDecisionActivities.value}}
-            @onChangeSigners={{fn (mut this.signers)}}
-            @onChangeApprovers={{fn (mut this.approvers)}}
-            @onChangeNotificationAddresses={{fn (mut this.notificationAddresses)}}
-          />
-        {{/if}}
-      </div>
-      <div class="auk-sidebar__footer">
-        <AuToolbar as |Group|>
-          <Group>
+          </td>
+          <td>{{date signFlow.decisionActivity.startDate}}</td>
+          <td>
             <AuButton
-              data-test-route-signatures-sidebar-start-signflow
-              @loading={{this.createSignFlow.isRunning}}
-              @disabled={{not this.signers.length}}
-              {{on "click" this.createSignFlow.perform}}
+              data-test-route-signatures-row-open-sidebar
+              @skin="naked"
+              @icon="sign"
+              {{on "click" (fn this.openSidebarSingleItem signFlow piece)}}
             >
               {{t "start-signing"}}
             </AuButton>
-          </Group>
-        </AuToolbar>
+          </td>
+        {{/let}}
+      {{/let}}
+    </:body>
+    <:aside>
+      <div class="auk-sidebar">
+        <div class="auk-sidebar__header">
+          <h4 class="auk-toolbar-complex__title">
+            {{t "start-signing"}}
+          </h4>
+          <Auk::Button
+            data-test-route-signatures-sidebar-close
+            @icon="x"
+            @skin="borderless"
+            @layout="icon-only"
+            {{on "click" this.closeSidebar}}
+          />
+        </div>
+        <div data-test-route-signatures-sidebar-info class="auk-sidebar__body">
+          {{#unless this.selectedSignFlows.length}}
+            <p class="au-u-muted auk-u-mt-2">
+              {{or this.piece.documentContainer.type.label (t "no-document-type")}}
+              -
+              {{date this.decisionActivity.startDate}}
+            </p>
+            <h5 class="auk-h4">{{this.piece.name}}</h5>
+            <div class="auk-o-flex auk-o-flex--spaced-wide auk-u-mt-1">
+              <AuLink
+                data-test-route-signatures-sidebar-preview
+                @skin="naked"
+                @icon="book"
+                @route="document"
+                @model={{this.piece.id}}
+              >
+                {{t "preview"}}
+              </AuLink>
+              <AuLink
+                data-test-route-signatures-sidebar-last-agendaitem
+                @skin="naked"
+                @icon="document"
+                @route="agenda.agendaitems.agendaitem"
+                @models={{array this.meeting.id this.agenda.id this.agendaitem.id}}
+              >
+                {{t "consult-agendaitem-decision"}}
+              </AuLink>
+            </div>
+          {{/unless}}
+          {{#if this.decisionActivity}}
+            <Signatures::CreateSignFlow
+              @decisionActivities={{array this.decisionActivity}}
+              @onChangeSigners={{fn (mut this.signers)}}
+              @onChangeApprovers={{fn (mut this.approvers)}}
+              @onChangeNotificationAddresses={{fn (mut this.notificationAddresses)}}
+            />
+          {{else if this.selectedSignFlows.length}}
+            <Signatures::CreateSignFlow
+              @decisionActivities={{this.selectedDecisionActivities.value}}
+              @onChangeSigners={{fn (mut this.signers)}}
+              @onChangeApprovers={{fn (mut this.approvers)}}
+              @onChangeNotificationAddresses={{fn (mut this.notificationAddresses)}}
+            />
+          {{/if}}
+        </div>
+        <div class="auk-sidebar__footer">
+          <AuToolbar as |Group|>
+            <Group>
+              <AuButton
+                data-test-route-signatures-sidebar-start-signflow
+                @loading={{or this.createSignFlow.isRunning this.removeSignFlow.isRunning}}
+                @disabled={{not this.signers.length}}
+                {{on "click" this.createSignFlow.perform}}
+              >
+                {{t "start-signing"}}
+              </AuButton>
+            </Group>
+            <Group>
+              <AuButton
+                @alert={{true}}
+                @skin="naked"
+                @loading={{or this.createSignFlow.isRunning this.removeSignFlow.isRunning}}
+                {{on "click" this.removeSignFlow.perform}}
+              >
+                {{t "stop-sign-flow"}}
+              </AuButton>
+            </Group>
+          </AuToolbar>
+        </div>
       </div>
-    </div>
-  </:aside>
-</KDataTable>
+    </:aside>
+  </KDataTable>
 
-<ConfirmationModal
-  @modalOpen={{this.showFilterModal}}
-  @title={{t "filter-content"}}
-  @onCancel={{this.closeFilterModal}}
->
-  <:body>
-    <Mandatees::CheckboxList
-      @selected={{this.selectedMinisters}}
-      @onChange={{fn (mut this.selectedMinisters)}}
-    />
-  </:body>
-  <:footer>
-    <AuToolbar
-      as |Group|
-    >
-      <Group>
-        <AuButton @skin="naked" {{on "click" this.closeFilterModal}}>
-          {{t "cancel"}}
-        </AuButton>
-      </Group>
-      <Group>
-        {{#if this.filteredMinisters}}
-          <AuButton @skin="secondary" {{on "click" this.clearFilter}}>
-            {{t "clear-filter"}}
-          </AuButton>
-        {{/if}}
-        <AuButton data-test-route-signatures-apply-filter @icon="filter" {{on "click" this.applyFilter}}>
-          {{t "filter-content"}}
-        </AuButton>
-      </Group>
-    </AuToolbar>
-  </:footer>
-</ConfirmationModal>
-
-{{#if this.createSignFlow.isRunning}}
-  <Auk::Modal @size="medium">
-    <Auk::Modal::Header @title={{t "loading-text"}} @closeable={{false}} />
-    <Auk::Modal::Body>
-      <Auk::Loader @message={{concat
-                              (t "creating-sign-flows-message")
-                              " "
-                              (t "please-be-patient")}}
+  <ConfirmationModal
+    @modalOpen={{this.showFilterModal}}
+    @title={{t "filter-content"}}
+    @onCancel={{this.closeFilterModal}}
+  >
+    <:body>
+      <Mandatees::CheckboxList
+        @selected={{this.selectedMinisters}}
+        @onChange={{fn (mut this.selectedMinisters)}}
       />
-    </Auk::Modal::Body>
-  </Auk::Modal>
+    </:body>
+    <:footer>
+      <AuToolbar
+        as |Group|
+      >
+        <Group>
+          <AuButton @skin="naked" {{on "click" this.closeFilterModal}}>
+            {{t "cancel"}}
+          </AuButton>
+        </Group>
+        <Group>
+          {{#if this.filteredMinisters}}
+            <AuButton @skin="secondary" {{on "click" this.clearFilter}}>
+              {{t "clear-filter"}}
+            </AuButton>
+          {{/if}}
+          <AuButton data-test-route-signatures-apply-filter @icon="filter" {{on "click" this.applyFilter}}>
+            {{t "filter-content"}}
+          </AuButton>
+        </Group>
+      </AuToolbar>
+    </:footer>
+  </ConfirmationModal>
+
+  {{#if this.createSignFlow.isRunning}}
+    <Auk::Modal @size="medium">
+      <Auk::Modal::Header @title={{t "loading-text"}} @closeable={{false}} />
+      <Auk::Modal::Body>
+        <Auk::Loader @message={{concat
+                                (t "creating-sign-flows-message")
+                                " "
+                                (t "please-be-patient")}}
+        />
+      </Auk::Modal::Body>
+    </Auk::Modal>
+  {{/if}}
 {{/if}}

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1246,5 +1246,6 @@
   "verify-delete-all-sign-flow-data": "Bent u zeker dat u het handtekenproces volledig wilt verwijderen uit Kaleidos? Deze actie kan niet meer ongedaan gemaakt worden. In Signinghub zal het proces blijven bestaan tenzij dit manueel verwijderd wordt.",
   "delete-all-sign-flow-tooltip": "Verwijder het volledige handtekenproces uit Kaleidos, zodat het document opnieuw ondertekend kan worden",
   "to-start-up": "Op te starten",
-  "to-follow-up": "Op te volgen"
+  "to-follow-up": "Op te volgen",
+  "stop-sign-flow": "Tekenen stopzetten"
 }


### PR DESCRIPTION
cache-busting: when an agenda/meeting is finalised the changes don't invalidate the calls to the sign flows that we make in this route. to always get a fresh call we just add timestamp to the call. we do this in the `:has:meeting` because the value of a `:has:` filter is never used, mu-cl-resources just checks if it's set to *something*.