### PR TITLE
fix: filter out the prime minister

### DIFF
--- a/app/components/signatures/create-sign-flow.js
+++ b/app/components/signatures/create-sign-flow.js
@@ -85,11 +85,26 @@ export default class SignaturesCreateSignFlowComponent extends Component {
     if (hasConflictingSigners) {
       this.signers = new TrackedArray([]);
     } else {
-      this.signers = new TrackedArray([...new Set([
-        this.primeMinister,
-        submitter,
-        ...cosigners,
-      ].filter(m => m))]);
+      const signersSet = new Set([this.primeMinister]);
+      const primeMinisterPerson = await this.primeMinister.person;
+
+      if (submitter) {
+        const submitterPerson = await submitter.person;
+        if (primeMinisterPerson.id !== submitterPerson.id) {
+          signersSet.add(submitter);
+        }
+      }
+
+      for (let cosigner of cosigners) {
+        if (cosigner) {
+          const cosignerPerson = await cosigner.person;
+          if (primeMinisterPerson.id !== cosignerPerson.id) {
+            signersSet.add(cosigner);
+          }
+        }
+      }
+
+      this.signers = new TrackedArray([...signersSet]);
     }
     this.args.onChangeSigners?.(this.signers);
   });


### PR DESCRIPTION
When we refactored this to a trackedFunction to deal with multiple sign flows & the sidebar that stayed open but whose arguments changed, we forgot to filter out the PM as submitter/cosigner.