### PR TITLE
Feature/KAS-4169 move fetching SH url to service

### DIFF
--- a/app/components/signature-pill.js
+++ b/app/components/signature-pill.js
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { later, cancel } from '@ember/runloop';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
-import fetch from 'fetch';
 import constants from 'frontend-kaleidos/config/constants';
 import { task as trackedTask } from 'ember-resources/util/ember-concurrency';
 import { task } from 'ember-concurrency';
@@ -16,6 +15,7 @@ const { SIGNED, REFUSED, CANCELED, MARKED } = constants.SIGNFLOW_STATUSES;
 export default class SignaturePillComponent extends Component {
   @service intl;
   @service currentSession;
+  @service signatureService;
 
   scheduledRefresh;
   @tracked triggerTask;
@@ -56,13 +56,7 @@ export default class SignaturePillComponent extends Component {
         status.uri !== SIGNED &&
         status.uri !== MARKED
       ) {
-        const response = await fetch(
-          `/signing-flows/${signFlow.id}/pieces/${piece.id}/signinghub-url?collapse_panels=false`
-        );
-        if (response.ok) {
-          const result = await response.json();
-          signingHubUrl = result.url;
-        }
+        signingHubUrl = await this.signatureService.getSigningHubUrl(signFlow, piece);
       }
     }
 

--- a/app/controllers/signatures/ongoing.js
+++ b/app/controllers/signatures/ongoing.js
@@ -1,6 +1,5 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
-import fetch from 'fetch';
 import { PAGINATION_SIZES } from 'frontend-kaleidos/config/config';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 import { action } from '@ember/object';
@@ -11,6 +10,7 @@ export default class SignaturesOngoingController extends Controller {
   @service mandatees;
   @service intl;
   @service currentSession;
+  @service signatureService;
 
   queryParams = [
     {
@@ -61,12 +61,9 @@ export default class SignaturesOngoingController extends Controller {
           piece.id
         );
       } else {
-        const response = await fetch(
-          `/signing-flows/${signFlow.id}/pieces/${piece.id}/signinghub-url?collapse_panels=false`
-        );
-        if (response.ok) {
-          const result = await response.json();
-          window.location.href = result.url;
+        const signingHubUrl = await this.signatureService.getSigningHubUrl(signFlow, piece);
+        if (signingHubUrl) {
+          window.location.href = signingHubUrl;
         } else {
           this.router.transitionTo(
             'document',

--- a/app/services/signature-service.js
+++ b/app/services/signature-service.js
@@ -1,6 +1,7 @@
 import Service, { inject as service } from '@ember/service';
 import { uploadPiecesToSigninghub } from 'frontend-kaleidos/utils/digital-signing';
 import ENV from 'frontend-kaleidos/config/environment';
+import fetch from 'fetch';
 
 export default class SignatureService extends Service {
   @service store;
@@ -187,5 +188,15 @@ export default class SignatureService extends Service {
       }
     }
     return false;
+  }
+
+  async getSigningHubUrl(signFlow, piece) {
+    const response = await fetch(
+      `/signing-flows/${signFlow.id}/pieces/${piece.id}/signinghub-url?collapse_panels=false`
+    );
+    if (response.ok && response.status === 200) {
+      const result = await response.json();
+      return result.url;
+    }
   }
 }


### PR DESCRIPTION
https://github.com/kanselarij-vlaanderen/digital-signing-service/pull/28

URL fetching code is now inside the signature service and with the backend changes we no longer get error logs in the console due to 404 responses.