### PR TITLE
Fix/BS thread ID

### DIFF
--- a/app/components/publications/publication/case/info/publication-case-info-panel.hbs
+++ b/app/components/publications/publication/case/info/publication-case-info-panel.hbs
@@ -113,7 +113,7 @@
               </div>
 
               {{! BS Thread ID}}
-              <div class="auk-o-grid-col-2">
+              <div class="auk-o-grid-col-3">
                 <div
                   class="auk-form-group"
                 >
@@ -128,7 +128,7 @@
 
 
               {{! wijze van publicatie }}
-              <div class="auk-o-grid-col-1">
+              <div class="auk-o-grid-col-3">
                 <div
                   data-test-publication-case-info-panel-edit-publication-mode
                   class="auk-form-group"
@@ -275,7 +275,7 @@
           </div>
 
           {{! BS Thread Id}}
-          <div class="auk-o-grid-col-2">
+          <div class="auk-o-grid-col-3">
             <div class="auk-content">
               <h4 class="auk-u-m-0">{{t "publication-flow-thread-id"}}</h4>
               <p
@@ -291,7 +291,7 @@
           </div>
 
           {{! Wijze publicatie }}
-          <div class="auk-o-grid-col-1">
+          <div class="auk-o-grid-col-3">
             <div class="auk-content">
               <h4 class="auk-u-m-0">{{t "kind-of-publication"}}</h4>
               <p

--- a/app/components/publications/publication/case/info/publication-case-info-panel.hbs
+++ b/app/components/publications/publication/case/info/publication-case-info-panel.hbs
@@ -281,9 +281,8 @@
               <p
                 class="auk-u-m-0"
               >
-                {{log @publicationFlow.threadId.idName}}
                 {{#if @publicationFlow.threadId.idName}}
-                  {{@publicationFlow.threadId.idName}}
+                  <p class="auk-u-text-uncapitalize">thread::{{@publicationFlow.threadId.idName}}::</p>
                 {{else}}
                   {{t "dash"}}
                 {{/if}}

--- a/app/components/publications/publication/case/info/publication-case-info-panel.hbs
+++ b/app/components/publications/publication/case/info/publication-case-info-panel.hbs
@@ -112,8 +112,23 @@
                 </div>
               </div>
 
+              {{! BS Thread ID}}
+              <div class="auk-o-grid-col-2">
+                <div
+                  class="auk-form-group"
+                >
+                  <Auk::Label>
+                    {{t "publication-flow-thread-id"}}
+                  </Auk::Label>
+                  <AuInput
+                    @value={{mut this.threadId}}
+                  />
+                </div>
+              </div>
+
+
               {{! wijze van publicatie }}
-              <div class="auk-o-grid-col-3">
+              <div class="auk-o-grid-col-1">
                 <div
                   data-test-publication-case-info-panel-edit-publication-mode
                   class="auk-form-group"
@@ -259,8 +274,25 @@
             </div>
           </div>
 
+          {{! BS Thread Id}}
+          <div class="auk-o-grid-col-2">
+            <div class="auk-content">
+              <h4 class="auk-u-m-0">{{t "publication-flow-thread-id"}}</h4>
+              <p
+                class="auk-u-m-0"
+              >
+                {{log @publicationFlow.threadId.idName}}
+                {{#if @publicationFlow.threadId.idName}}
+                  {{@publicationFlow.threadId.idName}}
+                {{else}}
+                  {{t "dash"}}
+                {{/if}}
+              </p>
+            </div>
+          </div>
+
           {{! Wijze publicatie }}
-          <div class="auk-o-grid-col-3">
+          <div class="auk-o-grid-col-1">
             <div class="auk-content">
               <h4 class="auk-u-m-0">{{t "kind-of-publication"}}</h4>
               <p

--- a/app/components/publications/publication/case/info/publication-case-info-panel.js
+++ b/app/components/publications/publication/case/info/publication-case-info-panel.js
@@ -20,6 +20,7 @@ export default class PublicationsPublicationCaseInfoPanelComponent extends Compo
   @tracked numberIsAlreadyUsed = false;
   @tracked numberIsRequired = false;
 
+  @tracked threadId;
   numacNumbersToDelete;
 
   constructor() {
@@ -43,6 +44,8 @@ export default class PublicationsPublicationCaseInfoPanelComponent extends Compo
     this.publicationNumberSuffix = this.structuredIdentifier.versionIdentifier;
     // Numac-nummers
     this.numacNumbers = yield this.args.publicationFlow.numacNumbers;
+    // Thread ID
+    this.threadId = (yield this.args.publicationFlow.threadId)?.idName;
     // Datum beslissing
     this.decisionActivity = yield this.args.publicationFlow
       .decisionActivity;
@@ -153,11 +156,35 @@ export default class PublicationsPublicationCaseInfoPanelComponent extends Compo
     this.args.publicationFlow.mode = publicationMode;
   }
 
+  async saveThreadId() {
+    this.threadId = this.threadId?.trim()
+    const existingThreadId = await this.args.publicationFlow.threadId;
+    if (existingThreadId) {
+      if (!this.threadId) {
+        return existingThreadId.destroyRecord();
+      } else if (existingThreadId.idName !== this.threadId) {
+        existingThreadId.idName = this.threadId;
+        return existingThreadId.save();
+      }
+    } else {
+      if (this.threadId) {
+        const threadIdIdentification = this.store.createRecord('identification', {
+          idName: this.threadId,
+          agency: CONSTANTS.SCHEMA_AGENCIES.NUMAC,
+          publicationFlowForThreadId: this.args.publicationFlow,
+        });
+        return threadIdIdentification.save();
+      }
+    }
+  }
+
   @task
   *closeEditingPanel() {
     // Remove locally created numac-numbers that are not yet persisted in the backend
     const newNumacNumbers = this.numacNumbers.filter((number) => number.isNew);
     newNumacNumbers.forEach((number) => number.deleteRecord());
+    // Reset thread ID
+    this.threadId = (yield this.args.publicationFlow.threadId)?.idName;
 
     const reloads = [
       this.args.publicationFlow.belongsTo('urgencyLevel').reload(),
@@ -203,6 +230,9 @@ export default class PublicationsPublicationCaseInfoPanelComponent extends Compo
         saves.push(numacNumber.save());
       }
     }
+
+    // Thread ID
+    saves.push(this.saveThreadId());
 
     // Datum beslissing
     if (!this.isViaCouncilOfMinisters) {

--- a/app/components/publications/publication/proofs/proof-request-modal.js
+++ b/app/components/publications/publication/proofs/proof-request-modal.js
@@ -137,6 +137,7 @@ export default class PublicationsPublicationProofsProofRequestModalComponent ext
     const publicationFlow = this.args.publicationFlow;
     const identification = yield publicationFlow.identification;
     const urgencyLevel = yield publicationFlow.urgencyLevel;
+    const threadId = yield publicationFlow.threadId;
     const mailParams = {
       identifier: identification.idName,
       shortTitle: publicationFlow.shortTitle,
@@ -144,6 +145,7 @@ export default class PublicationsPublicationProofsProofRequestModalComponent ext
       longTitle: publicationFlow.longTitle
         ? publicationFlow.longTitle
         : publicationFlow.shortTitle,
+      threadId: threadId?.idName,
     };
 
     const mailTemplate = proofRequestEmail(mailParams);

--- a/app/components/publications/publication/publication-activities/publication-request-modal.js
+++ b/app/components/publications/publication/publication-activities/publication-request-modal.js
@@ -108,6 +108,7 @@ export default class PublicationsPublicationPublicationActivitiesPublicationRequ
   @task
   *setEmailFields() {
     const publicationFlow = this.args.publicationFlow;
+    const threadId = yield publicationFlow.threadId;
     const [identification, numacNumbers, publicationSubcase, urgencyLevel] =
       yield Promise.all([
         publicationFlow.identification,
@@ -121,6 +122,7 @@ export default class PublicationsPublicationPublicationActivitiesPublicationRequ
       isUrgent: urgencyLevel?.isUrgent,
       targetEndDate: publicationSubcase.targetEndDate,
       numacNumbers: numacNumbers,
+      threadId: threadId?.idName,
     };
 
     const mailTemplate = publicationRequestEmail(mailParams);

--- a/app/models/identification.js
+++ b/app/models/identification.js
@@ -14,6 +14,11 @@ export default class Identification extends Model {
     async: true,
   })
   publicationFlowForNumac;
+  @belongsTo('publication-flow', {
+    inverse: 'threadId',
+    async: true,
+  })
+  publicationFlowForThreadId;
   @belongsTo('structured-identifier', {
     inverse: 'identification',
     async: true,

--- a/app/models/publication-flow.js
+++ b/app/models/publication-flow.js
@@ -33,6 +33,8 @@ export default class PublicationFlow extends Model {
   translationSubcase;
   @belongsTo('decision-activity', { inverse: 'publicationFlows', async: true })
   decisionActivity;
+  @belongsTo('identification', { invserse: 'publicationFlowForThreadId', async: true})
+  threadId; // Not serialized on pub-flow side to prevent errors when deleting
 
   @hasMany('identification', {
     inverse: 'publicationFlowForNumac',

--- a/app/models/publication-flow.js
+++ b/app/models/publication-flow.js
@@ -33,7 +33,10 @@ export default class PublicationFlow extends Model {
   translationSubcase;
   @belongsTo('decision-activity', { inverse: 'publicationFlows', async: true })
   decisionActivity;
-  @belongsTo('identification', { invserse: 'publicationFlowForThreadId', async: true})
+  @belongsTo('identification', {
+    invserse: 'publicationFlowForThreadId',
+    async: true,
+  })
   threadId; // Not serialized on pub-flow side to prevent errors when deleting
 
   @hasMany('identification', {

--- a/app/serializers/publication-flow.js
+++ b/app/serializers/publication-flow.js
@@ -1,6 +1,6 @@
 import ApplicationSerializer from './application';
 
-const SKIP_SERIALIZED = ['publicationStatusChange'];
+const SKIP_SERIALIZED = ['publicationStatusChange', 'threadId'];
 
 export default class PublicationFlowSerializer extends ApplicationSerializer {
   serializeBelongsTo(snapshot, json, relationship) {

--- a/app/styles/auk/_auk-additions.scss
+++ b/app/styles/auk/_auk-additions.scss
@@ -411,3 +411,9 @@ table tr.lt-expanded-row {
 .auk-loadable-content__content {
   min-width: 0;
 }
+
+.auk-u-text-uncapitalize {
+  &::first-letter {
+    text-transform: lowercase !important;
+  }
+}

--- a/app/utils/publication-email.js
+++ b/app/utils/publication-email.js
@@ -75,15 +75,17 @@ function proofRequestEmail(params) {
 
   subject += `Drukproefaanvraag VO-dossier: ${params.identifier} - ${params.shortTitle}`;
 
-   const message = 'Beste,\n'
-      + '\n'
-      + 'In bijlage voor drukproef:\n'
-      + '\n'
-      + `Titel: ${params.longTitle}\t\n`
-      + '\n'
-      + `VO-dossier: ${params.identifier}\n`
-      + '\n'
-      + 'Vragen bij dit dossier kunnen met vermelding van publicatienummer gericht worden aan onderstaand emailadres.\t\n';
+  const threadIdSection = params.threadId ? `thread::${params.threadId}::\t\n` : '';
+  const message = 'Beste,\n'
+        + '\n'
+        + 'In bijlage voor drukproef:\n'
+        + '\n'
+        + `Titel: ${params.longTitle}\t\n`
+        + '\n'
+        + `VO-dossier: ${params.identifier}\n`
+        + threadIdSection
+        + '\n'
+        + 'Vragen bij dit dossier kunnen met vermelding van publicatienummer gericht worden aan onderstaand emailadres.\t\n';
   return {
     subject: subject,
     message: [message, footer].join('\n\n'),
@@ -101,12 +103,15 @@ function publicationRequestEmail(params) {
     subject +=  `DRINGEND: `;
   }
   subject += `Publicatieaanvraag BS-werknr: ${numacNumbers} VO-dossier: ${params.identifier}`;
+
+  const threadIdSection = params.threadId ? `thread::${params.threadId}::\t\n` : '';
   const message = 'Beste,\n'
     + '\n'
     + 'Hierbij de verbeterde drukproef :\n'
     + '\n'
     + `BS-werknummer: ${numacNumbers}\n`
     + `VO-dossier: ${params.identifier}\n`
+    + threadIdSection
     + '\n'
     + `De gewenste datum van publicatie is: ${targetEndDate}\t\n`
     + '\t\n'

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -777,6 +777,7 @@
   "publication-flow-opening-date": "Datum ontvangst",
   "kind-of-publication": "Wijze van publicatie",
   "publication-flow-numac-number": "Numac",
+  "publication-flow-thread-id": "Thread ID",
   "publication-flow-number-of-extracts": "Aantal uittreksels",
   "not-known": "Niet gekend",
   "requests": "Aanvragen",


### PR DESCRIPTION
>**Warning**
> Both this and the backend PR branch off from production. But we want to merge and deploy it on ACC before deploying the hotfix on PROD

Adds a field to input the thread ID used by BS and inserts this ID in the email form.

We take the inputted thread ID as-is, we only trim surrounding whitespace. I.e. we also don't do any kinds of checks in case users input `thread::ACTUAL-ID::` instead of just `ACTUAL-ID`.

The field input expects just the ID/token part (i.e. `JAJ3Z_4cFV2IyiB72fpRriQ` from `thread::JAJ3Z_4cFV2IyiB72fpRriQ::`) but in the display (panel) we show the full string (with `thread::`) so that users can easily copy it.

Related PR:
- [ ] https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/408

JIRA: https://kanselarij.atlassian.net/browse/KAS-4168