### PR TITLE
Feature/kas 4183 pill unclickable in list

### DIFF
--- a/app/components/signature-pill.hbs
+++ b/app/components/signature-pill.hbs
@@ -5,7 +5,7 @@
     <AuPill
       @icon="sign"
       @skin={{this.skin}}
-      @href={{this.data.value.signingHubUrl}}
+      @href={{if this.isClickable this.data.value.signingHubUrl}}
       target="_blank"
     >
       {{this.data.value.status.label}}

--- a/app/components/signature-pill.js
+++ b/app/components/signature-pill.js
@@ -11,6 +11,8 @@ const { SIGNED, REFUSED, CANCELED, MARKED } = constants.SIGNFLOW_STATUSES;
 
 /**
  * @param signMarkingActivity {SignMarkingActivityModel|Promise<SignMarkingActivityModel>}
+ * @param piece {Piece|Promise<Piece>}
+ * @param isClickable {boolean} Defaults to true, can be used to disable the click behaviour
  */
 export default class SignaturePillComponent extends Component {
   @service intl;
@@ -20,6 +22,11 @@ export default class SignaturePillComponent extends Component {
 
   scheduledRefresh;
   @tracked triggerTask;
+
+  get isClickable() {
+    // use passed in argument, otherwise default to true
+    return this.args.isClickable ?? true;
+  }
 
   willDestroy() {
     super.willDestroy(...arguments);

--- a/app/controllers/signatures/ongoing.js
+++ b/app/controllers/signatures/ongoing.js
@@ -63,7 +63,7 @@ export default class SignaturesOngoingController extends Controller {
       } else {
         const signingHubUrl = await this.signatureService.getSigningHubUrl(signFlow, piece);
         if (signingHubUrl) {
-          window.location.href = signingHubUrl;
+          window.open(signingHubUrl, '_blank');
         } else {
           this.router.transitionTo(
             'document',

--- a/app/templates/signatures/ongoing.hbs
+++ b/app/templates/signatures/ongoing.hbs
@@ -94,6 +94,7 @@
             <SignaturePill
               @piece={{signMarkingActivity.piece}}
               @signMarkingActivity={{signMarkingActivity}}
+              @isClickable={{false}}
             />
           </td>
         {{/let}}


### PR DESCRIPTION
Make the signature pill unclickable in the ongoing signatures list and make the row click open SH in a new tab.