### PR TITLE
KAS-4148: Icons binnen badge component worden verkeerd verticaal & horizontaal gealigneerd

### DIFF
--- a/app/styles/au/_au-components.scss
+++ b/app/styles/au/_au-components.scss
@@ -420,6 +420,13 @@ $au-button-height: 3.4rem;
   font-size: 1.5rem;
 }
 
+.au-c-alert--small {
+  .au-c-icon {
+    height: 1.5rem;
+    width: 1.6rem;
+  }
+}
+
 // Toaster
 
 .auk-alert-stack {
@@ -430,8 +437,8 @@ $au-button-height: 3.4rem;
   }
 
   .au-c-icon {
-    height: $au-alert-small-icon-size - 0.1rem; // compensate for visual distortion of perfect circle
-    width: $au-alert-small-icon-size;
+    height: ($au-alert-small-icon-size + 0.1rem) - 0.1rem; // compensate for visual distortion of perfect circle
+    width: $au-alert-small-icon-size + 0.1rem;
   }
 
   .au-c-alert__close {
@@ -445,6 +452,16 @@ $au-button-height: 3.4rem;
 .auk-empty-state {
   .au-c-badge {
     margin-right: 2rem;
+  }
+}
+
+.au-c-badge--small {
+  height: 2.3rem;
+  width: 2.4rem;
+
+  .au-c-icon {
+    height: 1.5rem;
+    width: 1.6rem;
   }
 }
 


### PR DESCRIPTION
**Tickets binnen Jira:** 
- https://kanselarij.atlassian.net/browse/KAS-4148

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.