### PR TITLE
KAS-4206 Added keepMarkingActivity argument to removeSignflow

### DIFF
--- a/app/services/signature-service.js
+++ b/app/services/signature-service.js
@@ -175,9 +175,9 @@ export default class SignatureService extends Service {
       await signRefusalActivities?.map(async (activity) => {
         await activity.destroyRecord();
       });
+      // destroying signSubcase can throw ember errors. reload fixed that problem.
+      await signSubcase?.reload();
       if (!keepMarkingActivity) {
-        // destroying signSubcase can throw ember errors. reload fixed that problem.
-        await signSubcase?.reload();
         await signSubcase?.destroyRecord();
         await signFlow?.destroyRecord();
         await signMarkingActivity.destroyRecord();


### PR DESCRIPTION
HOTFIX

Keep the marking activity after trying to send a signFlow to SigningHub. Right now, in case of an error on their end, our signFlow gets totally removed, which is confusing for the users. This fix keeps it in the list by removing all the `activities` and `creator`, and keeping the `signFlow`, `signSubcase`, `signMarkingActivity` & resetting the `status`.