### PR TITLE
KAS-4210 manage marking on retract and postpone

### DIFF
--- a/app/components/agenda/agendaitem/agendaitem-controls.js
+++ b/app/components/agenda/agendaitem/agendaitem-controls.js
@@ -18,6 +18,7 @@ export default class AgendaitemControls extends Component {
   @service agendaService;
   @service currentSession;
   @service pieceAccessLevelService;
+  @service signatureService;
 
   @tracked isVerifying = false;
   @tracked showLoader = false;
@@ -140,6 +141,9 @@ export default class AgendaitemControls extends Component {
       const pieces = yield this.args.agendaitem.pieces;
       for (const piece of pieces.toArray()) {
         yield this.pieceAccessLevelService.strengthenAccessLevelToInternRegering(piece);
+        if (decisionResultCodeUri === CONSTANTS.DECISION_RESULT_CODE_URIS.INGETROKKEN) {
+          yield this.signatureService.removeSignFlowForPiece(piece);
+        }
       }
     }
   }

--- a/app/components/agenda/agendaitem/agendaitem-decision.hbs
+++ b/app/components/agenda/agendaitem/agendaitem-decision.hbs
@@ -82,7 +82,7 @@
           {{else}}
             <Agenda::Agendaitem::AgendaitemDecisionEdit
               @decisionActivity={{@decisionActivity}}
-              @onSave={{perform this.updateAgendaitemPiecesAccessLevels}}
+              @onSave={{perform this.onDecisionEdit}}
               @onCancel={{this.toggleEditPill}}
             />
           {{/if}}

--- a/app/components/agenda/agendaitem/agendaitem-decision.js
+++ b/app/components/agenda/agendaitem/agendaitem-decision.js
@@ -29,6 +29,7 @@ export default class AgendaitemDecisionComponent extends Component {
   @service fileConversionService;
   @service intl;
   @service pieceAccessLevelService;
+  @service signatureService;
   @service store;
   @service toaster;
 
@@ -134,6 +135,11 @@ export default class AgendaitemDecisionComponent extends Component {
     }
   });
 
+  onDecisionEdit = task(async () => {
+    await this.updateAgendaitemPiecesAccessLevels.perform();
+    await this.updatePiecesSignFlows.perform();
+  });
+
   updateAgendaitemPiecesAccessLevels = task(async () => {
     const decisionResultCode = await this.args.decisionActivity
       .decisionResultCode;
@@ -143,7 +149,7 @@ export default class AgendaitemDecisionComponent extends Component {
         CONSTANTS.DECISION_RESULT_CODE_URIS.INGETROKKEN,
       ].includes(decisionResultCode.uri)
     ) {
-      const pieces = this.args.agendaitem.pieces;
+      const pieces = await this.args.agendaitem.pieces;
       for (const piece of pieces.toArray()) {
         await this.pieceAccessLevelService.strengthenAccessLevelToInternRegering(
           piece
@@ -151,6 +157,17 @@ export default class AgendaitemDecisionComponent extends Component {
       }
     }
     this.toggleEditPill();
+  });
+
+  updatePiecesSignFlows = task(async () => {
+    const decisionResultCode = await this.args.decisionActivity
+      .decisionResultCode;
+    if (decisionResultCode.uri === CONSTANTS.DECISION_RESULT_CODE_URIS.INGETROKKEN) {
+      const pieces = await this.args.agendaitem.pieces;
+      for (const piece of pieces.toArray()) {
+        await this.signatureService.removeSignFlowForPiece(piece);
+      }
+    }
   });
 
   @action

--- a/app/components/documents/document-card.hbs
+++ b/app/components/documents/document-card.hbs
@@ -156,7 +156,7 @@
             {{/unless}}
           </Group.Item>
           {{#if this.signaturesEnabled}}
-            {{#if this.loadSignatureRelatedData.isRunning}}
+            {{#if this.showSignatureLoader}}
               <Group.Item>
                 <div
                   class="auk-loader au-u-margin-left-small"

--- a/app/components/documents/document-card.hbs
+++ b/app/components/documents/document-card.hbs
@@ -216,7 +216,7 @@
                 {{#if this.mayCreateSignMarkingActivity}}
                   <AuButton
                     @skin="link"
-                    {{on "click" this.markDocumentForSigning}}
+                    {{on "click" this.markDocumentForSigning.perform}}
                     role="menuitem"
                   >
                     {{t "present-for-signing"}}

--- a/app/components/documents/document-card.js
+++ b/app/components/documents/document-card.js
@@ -82,6 +82,8 @@ export default class DocumentsDocumentCardComponent extends Component {
     return (
       this.args.isEditable
       && this.currentSession.may('manage-documents')
+      && this.markDocumentForSigning.isIdle
+      && this.deleteMarkedSignFlow.isIdle
       && this.loadSignatureRelatedData.isIdle
       && this.loadSignatureRelatedData.performCount > 0
       && (!this.hasSignFlow || this.hasMarkedSignFlow)
@@ -335,6 +337,12 @@ export default class DocumentsDocumentCardComponent extends Component {
     yield this.loadPieceRelatedData.perform();
   }
 
+  @task
+  *markDocumentForSigning() {
+    yield this.signatureService.markDocumentForSignature(this.piece, this.args.decisionActivity);
+    yield this.loadPieceRelatedData.perform();
+  }
+
   @action
   changeAccessLevel(accessLevel) {
     this.piece.accessLevel = accessLevel;
@@ -361,12 +369,6 @@ export default class DocumentsDocumentCardComponent extends Component {
 
   @action
   async reloadAccessLevel() {
-    await this.loadPieceRelatedData.perform();
-  }
-
-  @action
-  async markDocumentForSigning() {
-    await this.signatureService.markDocumentForSignature(this.piece, this.args.decisionActivity);
     await this.loadPieceRelatedData.perform();
   }
 

--- a/app/components/documents/document-card.js
+++ b/app/components/documents/document-card.js
@@ -98,6 +98,12 @@ export default class DocumentsDocumentCardComponent extends Component {
     );
   }
 
+  get showSignatureLoader() {
+    return this.loadSignatureRelatedData.isRunning ||
+           this.markDocumentForSigning.isRunning ||
+           this.deleteMarkedSignFlow.isRunning;
+  }
+
   get showSignaturePill() {
     const isEnabled = !isEmpty(ENV.APP.ENABLE_SIGNATURES);
     const hasPermission = this.currentSession.may('manage-signatures');

--- a/app/services/agenda-service.js
+++ b/app/services/agenda-service.js
@@ -10,6 +10,7 @@ export default class AgendaService extends Service {
   @service intl;
   @service currentSession;
   @service newsletterService;
+  @service signatureService;
 
   @tracked addedPieces = null;
   @tracked addedAgendaitems = null;
@@ -151,6 +152,12 @@ export default class AgendaService extends Service {
       });
       submittedPieces = submittedPieces.concat((await submissionActivity2.pieces).toArray());
     }
+
+    // signFlows
+    for (const piece of submittedPieces) {
+      await this.signatureService.replaceDecisionActivity(piece, decisionActivity);
+    }
+
     const agendaitem = await this.store.createRecord('agendaitem', {
       created: now,
       number: numberToAssign,

--- a/app/services/signature-service.js
+++ b/app/services/signature-service.js
@@ -203,6 +203,16 @@ export default class SignatureService extends Service {
     }
   }
 
+  async removeSignFlowForPiece(piece) {
+    const signMarkingActivity = await piece.belongsTo('signMarkingActivity').reload();;
+    const signSubcase = await signMarkingActivity?.signSubcase;
+    const signFlow = await signSubcase?.signFlow;
+    const status = await signFlow?.status;
+    if (signFlow && status.uri === MARKED) {
+      await this.removeSignFlow(signFlow);
+    }
+  }
+
   async replaceDecisionActivity(piece, decisionActivity) {
     const signMarkingActivity = await piece.belongsTo('signMarkingActivity').reload();;
     const signSubcase = await signMarkingActivity?.signSubcase;

--- a/app/services/signature-service.js
+++ b/app/services/signature-service.js
@@ -203,6 +203,17 @@ export default class SignatureService extends Service {
     }
   }
 
+  async replaceDecisionActivity(piece, decisionActivity) {
+    const signMarkingActivity = await piece.belongsTo('signMarkingActivity').reload();;
+    const signSubcase = await signMarkingActivity?.signSubcase;
+    const signFlow = await signSubcase?.signFlow;
+    const status = await signFlow?.status;
+    if (signFlow && status.uri === MARKED) {
+      signFlow.decisionActivity = decisionActivity;
+      await signFlow.save();
+    }
+  }
+
   async hasSignFlow(piece) {
     const signaturesEnabled = !!ENV.APP.ENABLE_SIGNATURES;
     if (signaturesEnabled) {
@@ -224,7 +235,6 @@ export default class SignatureService extends Service {
       const signSubcase = await signMarkingActivity?.signSubcase;
       const signFlow = await signSubcase?.signFlow;
       const status = await signFlow?.belongsTo('status').reload();
-      console.log('status', status)
       return status?.uri === MARKED;
     }
     return false;


### PR DESCRIPTION
In this PR:
- re-submitting a postponed `agendaitem` will add the new `decisionActivity` to all `signFlows` of that `agendaitem`'s `pieces`
- retracting an `agendaitem` (via the `agendaitem-decision-edit` pill or via the `agendaitem-controls` dropdown) will cause all `signFlows` on that agendaitem to be removed

Also in this PR but not in the ticket:
- hide the actions dropdown in the document card when marking/demarking a document for signature, because this bugged the cr*p out of me when testing.