### PR TITLE
fix: don't send users to SH when they click on a cancelled sign flow

### DIFF
--- a/app/controllers/signatures/ongoing.js
+++ b/app/controllers/signatures/ongoing.js
@@ -56,7 +56,10 @@ export default class SignaturesOngoingController extends Controller {
     const status = await signFlow.status;
 
     if (piece) {
-      if (status.uri === CONSTANTS.SIGNFLOW_STATUSES.MARKED || status.uri === CONSTANTS.SIGNFLOW_STATUSES.SIGNED) {
+      if (status.uri === CONSTANTS.SIGNFLOW_STATUSES.MARKED
+          || status.uri === CONSTANTS.SIGNFLOW_STATUSES.SIGNED
+          || status.uri === CONSTANTS.SIGNFLOW_STATUSES.REFUSED
+          || status.uri === CONSTANTS.SIGNFLOW_STATUSES.CANCELED) {
         window.open(`/document/${piece.id}`, '_blank');
       } else {
         const signingHubUrl = await this.signatureService.getSigningHubUrl(signFlow, piece);


### PR DESCRIPTION
can be released as a hotfix