### PR TITLE
fix: don't reload whole agendaitems route when searching

### DIFF
--- a/app/controllers/agenda/agendaitems.js
+++ b/app/controllers/agenda/agendaitems.js
@@ -42,9 +42,10 @@ export default class AgendaAgendaitemsController extends Controller {
   @tracked selectedAgendaitem; // set in setupController of child-route
   @tracked documentLoadCount = 0;
   @tracked totalCount = 0;
+  @tracked isLoading;
   @tracked isEditingOverview = false;
 
-  // @tracked filter; // TODO: don't do tracking on qp's before updating to Ember 3.22+ (https://github.com/emberjs/ember.js/issues/18715)
+  @tracked filter;
   // @tracked showModifiedOnly;
   // @tracked anchor;
 
@@ -69,15 +70,7 @@ export default class AgendaAgendaitemsController extends Controller {
 
   @action
   searchAgendaitems(value) {
-    set(this, 'filter', value);
-    // bug in ember with refreshModel, (more info in loading action in route)
-    this.router.transitionTo(
-      ('agenda.agendaitems',
-      this.meeting.id,
-      this.agenda.id,
-      { queryParams: { filter: value } })
-    );
-    this.router.refresh('agenda.agendaitems');
+    this.filter = value;
   }
 
   @task

--- a/app/templates/agenda/agendaitems.hbs
+++ b/app/templates/agenda/agendaitems.hbs
@@ -23,7 +23,11 @@
     </div>
   </div>
   <div class="auk-panel-layout__main-content">
-    {{outlet}}
+    {{#if this.isLoading}}
+      <Auk::Loader @message={{t "agenda-loading"}} />
+    {{else}}
+      {{outlet}}
+    {{/if}}
   </div>
 {{else}}
   <div
@@ -36,7 +40,9 @@
         @onSearch={{this.searchAgendaitems}}
       />
       <div class="auk-scroll-wrapper__body auk-scroll-wrapper__body--vertical auk-u-hidden@print">
-        {{#if this.loadDocuments.isRunning}}
+        {{#if this.isLoading}}
+          <Auk::Loader @message={{t "agenda-loading"}} />
+        {{else if this.loadDocuments.isRunning}}
           <Auk::Loader @message={{this.documentLoadingMessage}} />
         {{else}}
           <Agenda::AgendaOverview


### PR DESCRIPTION
Full reload (and showing the loading state) means that we de-render the search field and that users can't automatically keep typing.

This commit should still preserve the fix intended in KAS-4129, though without making use of router.transitionTo and just using the refreshModel behaviour of the queryParams again. Setting filter as a tracked field instead of using `set()` seems to fix the behaviour.

https://kanselarij.atlassian.net/browse/KAS-4129

Somewhat undoes https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1796