### PR TITLE
show signaturepill in documentPreviewModal when there is a signflow that doesnt have status MARKED for users that can't start signflows

### DIFF
--- a/app/components/documents/document-preview/signatures-tab.hbs
+++ b/app/components/documents/document-preview/signatures-tab.hbs
@@ -32,6 +32,11 @@
         @onChange={{fn this.markForSignFlow.perform}}
         @disabled={{this.markForSignFlow.isRunning}}
       />
+    {{else if (and this.signMarkingActivity (not this.hasMarkedSignFlow))}}
+      <SignaturePill 
+        @piece={{@piece}} 
+        @signMarkingActivity={{this.signMarkingActivity}} 
+      />
     {{else}}
       <AuAlert
         @skin="warning"


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4213