### PR TITLE
fix: approvers + signature pill shouldn't be clickable in ongoing list

### DIFF
--- a/app/components/signature-pill.js
+++ b/app/components/signature-pill.js
@@ -23,9 +23,11 @@ export default class SignaturePillComponent extends Component {
   @tracked triggerTask;
 
   get isClickable() {
+    // Use the passed in argument if it exists but default to true
+    const isClickable = this.args.isClickable ?? true;
     const signingHubUrl = this.data?.value?.signingHubUrl;
     const route = this.data?.value?.route;
-    return !!signingHubUrl || !!route;
+    return isClickable && (!!signingHubUrl || !!route);
   }
 
   willDestroy() {

--- a/app/services/signature-service.js
+++ b/app/services/signature-service.js
@@ -31,7 +31,7 @@ export default class SignatureService extends Service {
         approvers.map((approver) => {
           const approverLowerCase = approver.toLowerCase();
           const record = this.store.createRecord('sign-approval-activity', {
-            approverLowerCase,
+            approver: approverLowerCase,
             signSubcase,
           });
           return record.save();

--- a/app/templates/signatures/ongoing.hbs
+++ b/app/templates/signatures/ongoing.hbs
@@ -95,6 +95,7 @@
             <SignaturePill
               @piece={{signMarkingActivity.piece}}
               @signMarkingActivity={{signMarkingActivity}}
+              @isClickable={{false}}
             />
           </td>
         {{/let}}


### PR DESCRIPTION
Approver's address was being passed incorrectly to the createRecord call, as the property is called `approver` but (implicitly) `approverLowerCase` was being passed. This caused the sign flow to have no approver in SH.

The built-in procedure to check if a signature pill is clickable is fine but we still need to be able to override it (and disable it) in certain cases, specifically in the ongoing signatures list.