### PR TITLE
KAS-2468: Disable sign marking toggle if decision activity doesn't exist

### DIFF
--- a/app/components/documents/document-preview/signatures-tab.hbs
+++ b/app/components/documents/document-preview/signatures-tab.hbs
@@ -25,13 +25,19 @@
     {{#if this.loadCanManageSignFlow.isRunning}}
       <Auk::Loader />
     {{else if this.canManageSignFlow}}
-      <AuToggleSwitch
-        @skin="primary"
-        @label={{t "present-for-signing"}}
-        @checked={{this.hasMarkedSignFlow}}
-        @onChange={{fn this.markForSignFlow.perform}}
-        @disabled={{this.markForSignFlow.isRunning}}
-      />
+      {{#if this.decisionActivity}}
+        <AuToggleSwitch
+          @skin="primary"
+          @label={{t "present-for-signing"}}
+          @checked={{this.hasMarkedSignFlow}}
+          @onChange={{fn this.markForSignFlow.perform}}
+          @disabled={{this.markForSignFlow.isRunning}}
+        />
+      {{else}}
+        <AuAlert @skin="warning" @icon="alert-triangle" @title={{t "cannot-sign"}}>
+          <p>{{t "cannot-sign-because-no-decision-activity"}}</p>
+        </AuAlert>
+      {{/if}}
     {{else if (and this.signMarkingActivity (not this.hasMarkedSignFlow))}}
       <SignaturePill 
         @piece={{@piece}} 

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1204,6 +1204,7 @@
   "cannot-sign": "Ondertekenen is niet mogelijk",
   "cannot-sign-message": "Dit document is niet gekoppeld aan een agendapunt. Het is niet mogelijk om de ondertekenflow op te starten.",
   "cannot-create-sign-flow-message": "Dit document is niet ingediend door uw minister. U kunt de ondertekenflow niet opstarten.",
+  "cannot-sign-because-no-decision-activity": "De beslissing gekoppeld aan dit document is nog niet vrijgegeven. Het is niet mogelijk om de ondertekenflow op te starten.",
   "signed-document": "Ondertekened document",
   "on": "op",
   "start-signing-for-n-selected-documents": "Ondertekenen opstarten voor {n, plural, =1 {1 geselecteerd document} other { # geselecteerde documenten }}",


### PR DESCRIPTION
For Kabinetdossierbeheerders, the decision activity is only available when Kanselarij has released the decisions, that means that they can't mark a document for signing before that occurs. Here we hide the toggle and show a warning message if that's the case.

![Screenshot from 2023-08-25 10-30-57](https://github.com/kanselarij-vlaanderen/frontend-kaleidos/assets/22411874/a8186774-e841-40a8-9a04-7251c902fee7)

Note: this will not work as expected for Notulen & BFs signing, but that will be tackled in the latter issues to make those elements signable.