### PR TITLE
add Timezone to jenkins testing

### DIFF
--- a/Jenkinsfile.ci
+++ b/Jenkinsfile.ci
@@ -98,7 +98,7 @@ pipeline {
       steps {
         // sh "npx cypress run"
         sh "export HOST_UID_GID=\$(id -u):\$(id -g)"
-        sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p  ${projectName} exec -T e2e-electron cypress run"
+        sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p  ${projectName} exec -T e2e-electron TZ=Europe/Brussels cypress run"
         // run specific specs example
         // sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p  ${projectName} exec -T e2e-electron cypress run --spec '**/all-flaky-tests/*.spec.js'"
       }

--- a/Jenkinsfile.ci
+++ b/Jenkinsfile.ci
@@ -98,9 +98,9 @@ pipeline {
       steps {
         // sh "npx cypress run"
         sh "export HOST_UID_GID=\$(id -u):\$(id -g)"
-        sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p  ${projectName} exec -T e2e-electron TZ=Europe/Brussels cypress run"
+        sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p  ${projectName} exec -T e2e-electron cypress run"
         // run specific specs example
-        // sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p  ${projectName} exec -T e2e-electron cypress run --spec '**/all-flaky-tests/*.spec.js'"
+        // sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p  ${projectName} exec -T e2e-electron cypress run --spec '**/all-flaky-tests/*.cy.js'"
       }
     }
   }

--- a/app/utils/date-format.js
+++ b/app/utils/date-format.js
@@ -1,4 +1,7 @@
-import { format } from 'date-fns';
+// import { format } from 'date-fns';
+import { formatInTimeZone as format } from 'date-fns-tz';
+
+const timezone = 'Europe/Brussels';
 
 export function dateFormat(dateOrString, formatString) {
   if (formatString) {
@@ -6,7 +9,7 @@ export function dateFormat(dateOrString, formatString) {
     // This is undesired, we actually want an invalid date in that case
     const dateObject = new Date(dateOrString ?? NaN);
     if (!isNaN(dateObject.valueOf())) {
-      return format(dateObject, formatString);
+      return format(dateObject, timezone, formatString);
     }
   }
 }

--- a/app/utils/date-format.js
+++ b/app/utils/date-format.js
@@ -1,5 +1,6 @@
 // import { format } from 'date-fns';
 import { formatInTimeZone as format } from 'date-fns-tz';
+import { nlBE } from 'date-fns/locale';
 
 const timezone = 'Europe/Brussels';
 
@@ -9,7 +10,9 @@ export function dateFormat(dateOrString, formatString) {
     // This is undesired, we actually want an invalid date in that case
     const dateObject = new Date(dateOrString ?? NaN);
     if (!isNaN(dateObject.valueOf())) {
-      return format(dateObject, timezone, formatString);
+      return format(dateObject, timezone, formatString, {
+        locale: nlBE,
+      });
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "broccoli-funnel": "^3.0.8",
     "cypress": "^12.14.0",
     "date-fns": "^2.29.3",
+    "date-fns-tz": "^2.0.0",
     "dayjs": "^1.11.7",
     "ember-auto-import": "^2.5.0",
     "ember-cli": "~4.8.0",


### PR DESCRIPTION
No ticket.
The mandatee dates are off in jenkins testing but are ok locally.
Checking if this is timezone related and if we can run the tests in our own timezone (Europe/Brussels) on the server.
