### PR TITLE
chore: don't make a count call in queryAll, get count from first call

### DIFF
--- a/app/services/store.js
+++ b/app/services/store.js
@@ -19,11 +19,19 @@ export default class ExtendedStoreService extends Store {
 
   async queryAll(modelName, query, options) {
     query = query || {}; // eslint-disable-line no-param-reassign
-    const count = await this.count(modelName, query, options);
     const batchSize = query.page?.size || 100;
+
+    const firstBatch = this.query(modelName, Object.assign({}, query, {
+      'page[size]': batchSize,
+      'page[number]': 0,
+    }));
+
+    const batches = [firstBatch];
+    const result = await firstBatch;
+    const count = result.meta.count;
+
     const nbOfBatches = Math.ceil(count / batchSize);
-    const batches = [];
-    for (let i = 0; i < nbOfBatches; i++) {
+    for (let i = 1; i < nbOfBatches; i++) {
       const queryForBatch = Object.assign({}, query, {
         'page[size]': batchSize,
         'page[number]': i,


### PR DESCRIPTION
Store#count is really just requesting a single record from mu-cl-resources and using the returned metadata to know how many records there are in total. While this is fine if you only care about the count, since we're going to start fetching the actual records in Store#queryAll, we're better off doing an initial call for the first batch, checking the total count and then deciding if we need to fetch further batches.

While this isn't a giant amount of performance gain, for e.g. the government fields, the uncached count call takes ~200ms, which isn't nothing.