### PR TITLE
chore: redirect to /mock-login when unauthenticated in dev mode

### DIFF
--- a/app/routes/agenda.js
+++ b/app/routes/agenda.js
@@ -8,7 +8,7 @@ export default class AgendaRoute extends Route {
   @service store;
 
   beforeModel(transition) {
-    this.simpleAuthSession.requireAuthentication(transition, 'login');
+    this.simpleAuthSession.requireAuthentication(transition, this.simpleAuthSession.unauthenticatedRouteName);
   }
 
   async model(params) {

--- a/app/routes/agendas.js
+++ b/app/routes/agendas.js
@@ -25,7 +25,7 @@ export default class AgendasRoute extends Route {
   };
 
   beforeModel(transition) {
-    this.simpleAuthSession.requireAuthentication(transition, 'login');
+    this.simpleAuthSession.requireAuthentication(transition, this.simpleAuthSession.unauthenticatedRouteName);
   }
 
   async model(params) {

--- a/app/routes/cases.js
+++ b/app/routes/cases.js
@@ -5,6 +5,6 @@ export default class CasesRoute extends Route {
   @service('session') simpleAuthSession;
 
   beforeModel(transition) {
-    this.simpleAuthSession.requireAuthentication(transition, 'login');
+    this.simpleAuthSession.requireAuthentication(transition, this.simpleAuthSession.unauthenticatedRouteName);
   }
 }

--- a/app/routes/document.js
+++ b/app/routes/document.js
@@ -20,7 +20,7 @@ export default class DocumentRoute extends Route {
   isSigning = false;
 
   beforeModel(transition) {
-    this.simpleAuthSession.requireAuthentication(transition, 'login');
+    this.simpleAuthSession.requireAuthentication(transition, this.simpleAuthSession.unauthenticatedRouteName);
   }
 
   async model(params) {

--- a/app/routes/newsletter.js
+++ b/app/routes/newsletter.js
@@ -6,7 +6,7 @@ export default class NewsletterRoute extends Route {
   @service store;
 
   beforeModel(transition) {
-    this.simpleAuthSession.requireAuthentication(transition, 'login');
+    this.simpleAuthSession.requireAuthentication(transition, this.simpleAuthSession.unauthenticatedRouteName);
   }
 
   async model(params) {

--- a/app/routes/newsletters.js
+++ b/app/routes/newsletters.js
@@ -7,7 +7,7 @@ export default class NewslettersRoute extends Route {
   @service router;
 
   beforeModel(transition) {
-    this.simpleAuthSession.requireAuthentication(transition, 'login');
+    this.simpleAuthSession.requireAuthentication(transition, this.simpleAuthSession.unauthenticatedRouteName);
 
     if (!this.currentSession.may('manage-news-items')) {
       this.router.transitionTo('index');

--- a/app/routes/print-overviews.js
+++ b/app/routes/print-overviews.js
@@ -5,6 +5,6 @@ export default class PrintOverviewsRoute extends Route {
   @service('session') simpleAuthSession;
 
   beforeModel(transition) {
-    this.simpleAuthSession.requireAuthentication(transition, 'login');
+    this.simpleAuthSession.requireAuthentication(transition, this.simpleAuthSession.unauthenticatedRouteName);
   }
 }

--- a/app/routes/publications.js
+++ b/app/routes/publications.js
@@ -11,7 +11,7 @@ export default class PublicationsRoute extends Route {
   @service('session') simpleAuthSession;
 
   beforeModel(transition) {
-    this.simpleAuthSession.requireAuthentication(transition, 'login');
+    this.simpleAuthSession.requireAuthentication(transition, this.simpleAuthSession.unauthenticatedRouteName);
 
     if (!this.currentSession.may('manage-publication-flows')) {
       this.router.transitionTo('index');

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -26,7 +26,7 @@ export default class SearchRoute extends Route {
   };
 
   beforeModel(transition) {
-    this.simpleAuthSession.requireAuthentication(transition, 'login');
+    this.simpleAuthSession.requireAuthentication(transition, this.simpleAuthSession.unauthenticatedRouteName);
   }
 
   /* There is no reset of query parameters here by means of "resetController".

--- a/app/routes/settings.js
+++ b/app/routes/settings.js
@@ -7,7 +7,7 @@ export default class SettingsRoute extends Route {
   @service router;
 
   beforeModel(transition) {
-    this.simpleAuthSession.requireAuthentication(transition, 'login');
+    this.simpleAuthSession.requireAuthentication(transition, this.simpleAuthSession.unauthenticatedRouteName);
 
     if (!this.currentSession.may('manage-settings')) {
       this.router.transitionTo('index');

--- a/app/routes/signatures.js
+++ b/app/routes/signatures.js
@@ -7,7 +7,7 @@ export default class SignaturesRoute extends Route {
   @service router;
 
   beforeModel(transition) {
-    this.simpleAuthSession.requireAuthentication(transition, 'login');
+    this.simpleAuthSession.requireAuthentication(transition, this.simpleAuthSession.unauthenticatedRouteName);
 
     if (!this.currentSession.may('manage-signatures')) {
       this.router.transitionTo('index');

--- a/app/routes/styleguide.js
+++ b/app/routes/styleguide.js
@@ -5,6 +5,6 @@ export default class styleguideRoute extends Route {
   @service('session') simpleAuthSession;
 
   beforeModel(transition) {
-    this.simpleAuthSession.requireAuthentication(transition, 'login');
+    this.simpleAuthSession.requireAuthentication(transition, this.simpleAuthSession.unauthenticatedRouteName);
   }
 }

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -6,6 +6,14 @@ export default class ExtendedSessionService extends SessionService {
   @service currentSession;
   @service router;
 
+  get unauthenticatedRouteName() {
+    if (ENV.environment === 'development') {
+      return 'mock-login';
+    } else {
+      return 'login';
+    }
+  }
+
   async handleAuthentication() {
     try {
       await this.currentSession.load();
@@ -22,7 +30,7 @@ export default class ExtendedSessionService extends SessionService {
       const url = new URL(logoutUrl);
       window.location.replace(url.toString());
     } catch (error) { // eslint-disable-line no-unused-vars
-      this.router.transitionTo('login');
+      this.router.transitionTo(this.unauthenticatedRouteName);
     }
   }
 


### PR DESCRIPTION
When navigating to a page, if you're unauthenticated, our app will redirect you to a page where you can authenticate and after that's done you are sent back to the page you were first going to.

Locally this doesn't work because you're redirected to the login page, which won't work locally, so you "lose" the first page you were navigating to.

This change makes it so you're redirected to the mock-login route when unauthenticated, but only when the environment is set to development.