### PR TITLE
KAS-4333 Added editing field for Annotatie to decision editor

### DIFF
--- a/app/components/agenda/agendaitem/agendaitem-decision.hbs
+++ b/app/components/agenda/agendaitem/agendaitem-decision.hbs
@@ -237,7 +237,6 @@
              <Auk::Toolbar::Group @position="right">
                <Auk::Toolbar::Item>
                  <AuButton
-                   data-test-agendaitem-decision-save
                    @disabled={{this.disableSaveAnnotationButton}}
                    @skin="primary"
                    @loading={{this.onUpdateAnnotation.isRunning}}
@@ -267,7 +266,6 @@
                  }}
                    <Group.Item>
                      <AuButton
-                       data-test-agendaitem-decision-create
                        @skin="naked"
                        @icon="pencil"
                        @iconAlignment="left"

--- a/app/components/agenda/agendaitem/agendaitem-decision.hbs
+++ b/app/components/agenda/agendaitem/agendaitem-decision.hbs
@@ -96,7 +96,14 @@
       <Auk::Panel::Body
         class="au-o-flow {{if this.isEditing 'au-u-background-gray-100'}}"
       >
-        <h4 class="auk-h4">{{t "concerns"}}</h4>
+        <h4 class="auk-h4">{{t "annotation"}}</h4>
+        <AuInput
+          @width="block"
+          @value={{mut this.editorValueAnnotatie}}
+          id="decisionAnnotation"
+        />
+
+        <h4 class="auk-h4 au-u-padding-top">{{t "concerns"}}</h4>
         <SayEditor
           @size="small"
           @allowFullscreen={{true}}
@@ -209,6 +216,75 @@
           class="au-o-flow {{if this.isEditing 'au-u-background-gray-100'}}"
         >
           <AuContent @size="small">
+        {{#if (and this.isEditingAnnotation this.enableDigitalAgenda)}}
+           <h4 class="auk-h4">{{t "annotation"}}</h4>
+           <AuInput
+             @width="block"
+             @value={{mut this.editorValueAnnotatie}}
+             id="decisionAnnotation"
+           />
+           <Auk::Toolbar>
+             <Auk::Toolbar::Group @position="left">
+               <Auk::Toolbar::Item>
+                 <AuButton
+                   @skin="naked"
+                   {{on "click" (set this "isEditingAnnotation" false)}}
+                 >
+                   {{t "cancel"}}
+                 </AuButton>
+               </Auk::Toolbar::Item>
+             </Auk::Toolbar::Group>
+             <Auk::Toolbar::Group @position="right">
+               <Auk::Toolbar::Item>
+                 <AuButton
+                   data-test-agendaitem-decision-save
+                   @disabled={{this.disableSaveAnnotationButton}}
+                   @skin="primary"
+                   @loading={{this.onUpdateAnnotation.isRunning}}
+                   {{on "click" (perform this.onUpdateAnnotation)}}
+                 >
+                   {{t "update"}}
+                 </AuButton>
+               </Auk::Toolbar::Item>
+             </Auk::Toolbar::Group>
+           </Auk::Toolbar>
+           {{else}}
+           <Auk::Toolbar @auto={{true}} as |Toolbar|>
+             <Toolbar.Group @position="left">
+               <h4 class="auk-toolbar__title">
+                   {{t "annotation"}}:
+               </h4>
+             </Toolbar.Group>
+             <Toolbar.Group @position="right" as |Group|>
+               {{#if
+                   (and
+                     this.loadReport.isIdle
+                     (user-may "manage-decisions")
+                     (not this.isEditingAnnotation)
+                     (or this.pieceParts (not this.report))
+                     this.enableDigitalAgenda
+                   )
+                 }}
+                   <Group.Item>
+                     <AuButton
+                       data-test-agendaitem-decision-create
+                       @skin="naked"
+                       @icon="pencil"
+                       @iconAlignment="left"
+                       @disabled={{this.saveReport.isRunning}}
+                       {{on "click" this.startEditingAnnotation}}
+                     >
+                       {{t "edit"}}
+                     </AuButton>
+                   </Group.Item>
+                 {{/if}}
+             </Toolbar.Group>
+           </Auk::Toolbar>
+         <SanitizeHtml
+           @raw={{true}}
+           @value={{this.annotatiePiecePart.htmlContent}}
+         />
+        {{/if}}
         {{#if (and this.isEditingConcern this.enableDigitalAgenda)}}
            <h4 class="auk-h4">{{t "concerns"}}</h4>
         <SayEditor

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1178,6 +1178,7 @@
   "news-items": "Kort bestek berichten",
   "document-not-on-agendaitem": "Niet geüpload in agendapunt",
   "export-as-pdf": "Exporteren als PDF",
+  "annotation": "Annotatie",
   "concerns": "Betreft",
   "update-thing": "{thing} updaten",
   "current-version": "Huidige versie",


### PR DESCRIPTION
Added a field to edit the Annotatie `piecePart` of a decision.

Notes: I did implement it to always generate a `piecePart` for this, even when the Annotatie is empty.
Additionally, even though we don't have to implement versioning for this (yet), I kept it consistent with the other piece parts, and always generate a new `piecePart` version.

RELATED PR: https://github.com/kanselarij-vlaanderen/decision-report-generation-service/pull/10