### PR TITLE
Feature/KAS-4353: Digital Agenda start time flags

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,10 @@ module.exports = {
   },
   rules: {
     'prettier/prettier': 'off',
+    'no-unused-vars': [
+      'error',
+      { argsIgnorePattern: '^_' },
+    ],
   },
   overrides: [
     // node files

--- a/app/components/agenda/agenda-header/agenda-tabs.hbs
+++ b/app/components/agenda/agenda-header/agenda-tabs.hbs
@@ -22,7 +22,7 @@
   <Auk::Tab @route="agenda.documents">
     {{t "documents"}}
   </Auk::Tab>
-  {{#if this.enableDigitalMinutes}}
+  {{#if (and (not @currentMeeting.isPreDigitalMinutes) this.enableDigitalMinutes)}}
     <Auk::Tab @route="agenda.minutes">
       {{t "minutes"}}
     </Auk::Tab>

--- a/app/components/agenda/agendaitem/agendaitem-decision.js
+++ b/app/components/agenda/agendaitem/agendaitem-decision.js
@@ -744,8 +744,9 @@ export default class AgendaitemDecisionComponent extends Component {
 
   get enableDigitalAgenda() {
     return (
-      ENV.APP.ENABLE_DIGITAL_AGENDA === 'true' ||
-      ENV.APP.ENABLE_DIGITAL_AGENDA === true
+      (ENV.APP.ENABLE_DIGITAL_AGENDA === 'true' ||
+        ENV.APP.ENABLE_DIGITAL_AGENDA === true) &&
+      !this.args.agendaContext.meeting.isPreDigitalDecisions
     );
   }
 

--- a/app/config/config.js
+++ b/app/config/config.js
@@ -24,6 +24,8 @@ export const PUBLICATION_EMAIL = {
 
 export const KALEIDOS_START_DATE = new Date(2019, 9 /* October */, 1);
 export const PUBLICATIONS_IN_KALEIDOS_START_DATE = new Date(2022, 2 /* March */, 2);
+export const DIGITAL_DECISIONS_IN_KALEIDOS_START_DATE = new Date(2023, 10 /* November */, 1);
+export const DIGITAL_MINUTES_IN_KALEIDOS_START_DATE = new Date(2023, 10 /* November */, 1);
 
 // Number of milliseconds it takes to release a publication via Yggdrasil/Themis
 export const ESTIMATED_PUBLICATION_DURATION = 30 * 60 * 1000;

--- a/app/models/meeting.js
+++ b/app/models/meeting.js
@@ -1,6 +1,10 @@
 import Model, { belongsTo, hasMany, attr } from '@ember-data/model';
 import { inject as service } from '@ember/service';
-import { KALEIDOS_START_DATE } from 'frontend-kaleidos/config/config';
+import {
+  KALEIDOS_START_DATE,
+  DIGITAL_MINUTES_IN_KALEIDOS_START_DATE,
+  DIGITAL_DECISIONS_IN_KALEIDOS_START_DATE,
+} from 'frontend-kaleidos/config/config';
 
 export default class Meeting extends Model {
   @service intl;
@@ -49,5 +53,13 @@ export default class Meeting extends Model {
 
   get isPreKaleidos() {
     return this.plannedStart < KALEIDOS_START_DATE;
+  }
+
+  get isPreDigitalMinutes() {
+    return this.plannedStart < DIGITAL_MINUTES_IN_KALEIDOS_START_DATE;
+  }
+
+  get isPreDigitalDecisions() {
+    return this.plannedStart < DIGITAL_DECISIONS_IN_KALEIDOS_START_DATE;
   }
 }

--- a/app/routes/agenda/minutes.js
+++ b/app/routes/agenda/minutes.js
@@ -49,13 +49,14 @@ export default class AgendaMinutesRoute extends Route {
       }
     }
     const minutes = await meeting.minutes;
-    return { minutes, mandatees, notas, announcements, meeting };
+    return { minutes, mandatees, notas, announcements, meeting, agenda };
   }
 
   async afterModel(model, _transition) {
     const meeting = model.meeting;
+    const agenda = model.agenda;
     if (meeting?.isPreDigitalMinutes) {
-      await this.router.transitionTo('route-not-found', 404);
+      this.router.transitionTo('agenda.agendaitems', meeting.id, agenda.id);
     }
   }
 

--- a/app/routes/agenda/minutes.js
+++ b/app/routes/agenda/minutes.js
@@ -5,6 +5,7 @@ import CONSTANTS from 'frontend-kaleidos/config/constants';
 import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 
 export default class AgendaMinutesRoute extends Route {
+  @service router;
   @service store;
   @service mandatees;
 
@@ -48,6 +49,13 @@ export default class AgendaMinutesRoute extends Route {
     }
     const minutes = await meeting.minutes;
     return { minutes, mandatees, notas, announcements, meeting };
+  }
+
+  async afterModel(model, _transition) {
+    const meeting = model.meeting;
+    if (meeting?.isPreDigitalMinutes) {
+      await this.router.transitionTo('route-not-found', 404);
+    }
   }
 
   setupController(controller) {


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4353

Adds start dates for the digital agenda features that we use in the frontend to determine whether we will show the new digital agenda features on particular agenda.

For agendas before the flags' start date:
- the "Notulen" tab will be hidden on the agenda and the route will redirect to a 404 page
- the "Beslissing" tab on the agenda item will only show the old-style decision document card

The flags are set to the 1st of November and are separate (one for decisions and one for minutes), but both can be merged into one if they're being enabled at the same time (presumably the case).