### PR TITLE
chore: redirect bare agenda route to agenda.agendaitems

### DIFF
--- a/app/routes/agenda.js
+++ b/app/routes/agenda.js
@@ -5,6 +5,7 @@ import { set } from '@ember/object';
 export default class AgendaRoute extends Route {
   @service('session') simpleAuthSession;
   @service agendaService;
+  @service router;
   @service store;
 
   beforeModel(transition) {
@@ -35,6 +36,12 @@ export default class AgendaRoute extends Route {
 
   async afterModel(model) {
     await this.loadChangesToAgenda(model.agenda);
+  }
+
+  redirect(_model, transition) {
+    if (transition.to.name === 'agenda.index') {
+      this.router.transitionTo('agenda.agendaitems')
+    }
   }
 
   async loadChangesToAgenda(agenda) {


### PR DESCRIPTION
The bare agenda route is empty. Although nothing in our app links to it, users might arrive there by (accidentally) removing /agendapunten or /documenten from the agenda route. Or users might expect a working view when manually navigating to /vergadering/:id/agenda/:id, which we currently don't offer.

In any case instead of having a barren route that users might stumble upon, it's better to redirect to a route we actually have populated.

This is a small change that we should slowly start adding to other routes, just to rub off some of the rough edges on Kaleidos.

Another small QoL improvement would be to properly redirect users to the 404/route-not-found page when a model fails to find a resource (e.g. http://localhost:4200/vergadering/this-id-does-not-exist/agenda/and-neither-does-this-one/agendapunten), currently we just show the red toasts when resources doesn't return results.