### PR TITLE
Feature KAS-4387: Correct filename download in PDF viewer

### DIFF
--- a/app/models/file.js
+++ b/app/models/file.js
@@ -31,7 +31,7 @@ export default class File extends Model {
   }
 
   get inlineViewLink() {
-    return `/files/${this.id}/download?content-disposition=inline`;
+    return `${this.namedDownloadLink}&content-disposition=inline`;
   }
 
   get namedDownloadLink() {


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4387
https://kanselarij.atlassian.net/browse/KAS-4388

This way when users download the file inside the pdf-viewer it should also have the correct name.