### PR TITLE
Feature/kas 4379 bundle BFs and minutes

### DIFF
--- a/app/components/agenda/agendaitem/agendaitem-decision.hbs
+++ b/app/components/agenda/agendaitem/agendaitem-decision.hbs
@@ -54,7 +54,6 @@
           @hideNewerVersions={{true}}
           @hideEdit={{true}}
           @hideUpload={{true}}
-          @hideSign={{true}}
           @showCreateNewVersion={{true}}
           @onCreateNewVersion={{perform this.onCreateNewVersion}}
           @bordered={{true}}

--- a/app/components/agenda/agendaitem/agendaitem-decision.hbs
+++ b/app/components/agenda/agendaitem/agendaitem-decision.hbs
@@ -49,6 +49,7 @@
         <Documents::DocumentCard
           @piece={{this.report}}
           @decisionActivity={{@decisionActivity}}
+          @meeting={{@agendaContext.meeting}}
           @isEditable={{true}}
           @agendaContext={{@agendaContext}}
           @hideNewerVersions={{true}}
@@ -184,6 +185,7 @@
           <Documents::DocumentCard
             @piece={{this.report}}
             @decisionActivity={{@decisionActivity}}
+            @meeting={{@agendaContent.meeting}}
             @isEditable={{true}}
             @agendaContext={{@agendaContext}}
             @hideNewerVersions={{true}}

--- a/app/components/agenda/agendaitem/agendaitem-decision.js
+++ b/app/components/agenda/agendaitem/agendaitem-decision.js
@@ -539,7 +539,6 @@ export default class AgendaitemDecisionComponent extends Component {
   async createNewReport(documentContainer) {
     const now = new Date();
     const report = this.store.createRecord('report', {
-      isReportOrMinutes: true,
       created: now,
       modified: now,
       name: await generateReportName(
@@ -577,7 +576,6 @@ export default class AgendaitemDecisionComponent extends Component {
       newName = previousReport.name;
     }
     const report = this.store.createRecord('report', {
-      isReportOrMinutes: true,
       name: newName,
       created: now,
       modified: now,

--- a/app/components/documents/document-card.hbs
+++ b/app/components/documents/document-card.hbs
@@ -217,7 +217,7 @@
                   <AuButton
                     data-test-document-card-sign-marking
                     @skin="link"
-                    @disabled={{this.agendaitemIsRetracted}}
+                    @disabled={{this.markingForSigningIsDisabled}}
                     {{on "click" this.markDocumentForSigning.perform}}
                     role="menuitem"
                   >

--- a/app/components/documents/document-preview/signatures-tab.hbs
+++ b/app/components/documents/document-preview/signatures-tab.hbs
@@ -1,7 +1,12 @@
 <div class="auk-u-m-4">
-  {{#if (or this.loadSignatureRelatedData.isRunning this.markForSignFlow.isRunning)}}
+  {{#if (or
+       this.loadSignatureRelatedData.isRunning
+       this.loadCanManageSignFlow.isRunning
+       this.markForSignFlow.isRunning)
+  }}
     <Auk::Loader />
   {{else if (and this.signMarkingActivity (not this.hasMarkedSignFlow))}}
+    {{! There's an ongoing sign flow and it's further along than being marked }}
     <div class="auk-o-flex auk-o-flex--spaced auk-o-flex--vertical-center">
       <SignaturePill
         @piece={{@piece}}
@@ -21,48 +26,37 @@
         </AuButton>
       {{/if}}
     </div>
-  {{else if (or this.agendaitem @piece.isReportOrMinutes)}}
-    {{! TODO KAS-111 this is not feature flag friendly yet}}
-    {{#if this.loadCanManageSignFlow.isRunning}}
-      <Auk::Loader />
-    {{else if this.canManageSignFlow}}
-      {{#if (or this.decisionActivity @piece.isReportOrMinutes)}}
-        {{#if (or @piece.isReportOrMinutes (not this.agendaitemIsRetracted))}}
-          <AuToggleSwitch
-            @skin="primary"
-            @label={{t "present-for-signing"}}
-            @checked={{this.hasMarkedSignFlow}}
-            @onChange={{fn this.markForSignFlow.perform}}
-            @disabled={{this.markForSignFlow.isRunning}}
-          />
-        {{else}}
-          <AuAlert @skin="warning" @icon="alert-triangle" @title={{t "cannot-sign"}}>
-          <p>{{t "cannot-sign-because-agendaitem-retracted"}}</p>
-        </AuAlert>
-        {{/if}}
-      {{else}}
-        <AuAlert @skin="warning" @icon="alert-triangle" @title={{t "cannot-sign"}}>
-          <p>{{t "cannot-sign-because-no-decision-activity"}}</p>
-        </AuAlert>
-      {{/if}}
-    {{else if (and this.signMarkingActivity (not this.hasMarkedSignFlow))}}
-      <SignaturePill 
-        @piece={{@piece}} 
-        @signMarkingActivity={{this.signMarkingActivity}} 
-      />
-    {{else}}
-      <AuAlert
-        @skin="warning"
-        @icon="alert-triangle"
-        @title={{t "cannot-sign"}}
-      >
-        <p>{{t "cannot-create-sign-flow-message"}}</p>
-      </AuAlert>
-    {{/if}}
-  {{else}}
+  {{! TODO KAS-111 this is not feature flag friendly yet}}
+  {{else if (not this.agendaitem this.decisionActivity this.meeting)}}
+    {{! The piece is not linked to an agendaitem/meeting and cannot be signed }}
     <AuAlert @skin="warning" @icon="alert-triangle" @title={{t "cannot-sign"}}>
       <p>{{t "cannot-sign-message"}}</p>
     </AuAlert>
+  {{else if (not this.canManageSignFlow)}}
+    {{! A kabinetsmedewerker is trying to sign someone else's document }}
+    <AuAlert @skin="warning" @icon="alert-triangle" @title={{t "cannot-sign"}}>
+      <p>{{t "cannot-create-sign-flow-message"}}</p>
+    </AuAlert>
+  {{else if (and this.agendaitem (not this.decisionActivity))}}
+    {{! The piece is not linked to a decision activty (possibly due to
+        propagation) and cannot be signed }}
+    <AuAlert @skin="warning" @icon="alert-triangle" @title={{t "cannot-sign"}}>
+      <p>{{t "cannot-sign-because-no-decision-activity"}}</p>
+    </AuAlert>
+  {{else if (and this.agendaitem this.agendaitemIsRetracted)}}
+    <AuAlert @skin="warning" @icon="alert-triangle" @title={{t "cannot-sign"}}>
+      <p>{{t "cannot-sign-because-agendaitem-retracted"}}</p>
+    </AuAlert>
+  {{else}}
+    {{! All the necessary data to create a sign flow is available and valid and
+        the current user can create/manage a sign flow for the current piece }}
+    <AuToggleSwitch
+      @skin="primary"
+      @label={{t "present-for-signing"}}
+      @checked={{this.hasMarkedSignFlow}}
+      @onChange={{fn this.markForSignFlow.perform}}
+      @disabled={{this.markForSignFlow.isRunning}}
+    />
   {{/if}}
 </div>
 

--- a/app/components/documents/document-preview/signatures-tab.js
+++ b/app/components/documents/document-preview/signatures-tab.js
@@ -12,6 +12,7 @@ export default class DocumentsDocumentPreviewDetailsSignaturesTabComponent exten
   @tracked signMarkingActivity;
   @tracked hasMarkedSignFlow;
 
+  @tracked meeting;
   @tracked agendaitem;
   @tracked decisionActivity;
   @tracked canManageSignFlow = false;
@@ -45,6 +46,30 @@ export default class DocumentsDocumentPreviewDetailsSignaturesTabComponent exten
     });
     const treatment = await this.agendaitem?.treatment;
     this.decisionActivity = await treatment?.decisionActivity;
+
+    if (!this.agendaitem) {
+      // If the current piece is not linked to an agendaitem, try to find if
+      // it's linked to a decision activity (in case it's the report) or a
+      // meeting (in case it's the minutes), in which case it can be signed
+      this.decisionActivity = await this.store.queryOne('decision-activity', {
+        'filter[report][:id:]': this.args.piece.id,
+      });
+      let meetingFilter = {};
+      if (this.decisionActivity) {
+        // The current piece is the report of a decision activity, we still need
+        // the meeting
+        meetingFilter = {
+          'filter[agendas][agendaitems][treatment][decision-activity][:id:]': this.decisionActivity.id,
+        };
+      } else {
+        // The current piece could be the minutes of a meeting
+        meetingFilter = {
+          'filter[minutes][:id:]': this.args.piece.id,
+        };
+      }
+      this.meeting = await this.store.queryOne('meeting', meetingFilter);
+    }
+
     await this.decisionActivity?.decisionResultCode;
   });
 
@@ -54,6 +79,7 @@ export default class DocumentsDocumentPreviewDetailsSignaturesTabComponent exten
         await this.signatureService.markDocumentForSignature(
           this.args.piece,
           this.decisionActivity,
+          this.meeting,
         );
       } else {
         const signSubcase = await this.signMarkingActivity.signSubcase;

--- a/app/components/signature-pill.js
+++ b/app/components/signature-pill.js
@@ -57,8 +57,8 @@ export default class SignaturePillComponent extends Component {
     let route = null;
     if (status) {
       if (status.uri === MARKED) {
-        const piece = await this.args.piece;
-        route = piece?.isReportOrMinutes
+        const meeting = await signFlow.meeting;
+        route = meeting
           ? 'signatures.decisions'
           : 'signatures.index';
       }

--- a/app/components/signatures/create-sign-flow.hbs
+++ b/app/components/signatures/create-sign-flow.hbs
@@ -1,4 +1,4 @@
-{{#if @isReportOrMinute}}
+{{#if @isReportOrMinutes}}
   <Signatures::CreateSignFlow::ReportOrMinutes
     @decisionActivities={{@decisionActivities}}
     @onChangeSigners={{@onChangeSigners}}

--- a/app/controllers/agenda/minutes.js
+++ b/app/controllers/agenda/minutes.js
@@ -203,7 +203,6 @@ export default class AgendaMinutesController extends Controller {
         minutesForMeeting: this.meeting,
         accessLevel: defaultAccessLevel,
         documentContainer,
-        isReportOrMinutes: true,
       });
       await minutes.save();
     } else {
@@ -248,7 +247,6 @@ export default class AgendaMinutesController extends Controller {
       previousPiece: minutes,
       documentContainer: minutes.documentContainer,
       accessLevel: minutes.accessLevel,
-      isReportOrMinutes: true,
     });
 
     await newVersion.save();

--- a/app/models/meeting.js
+++ b/app/models/meeting.js
@@ -46,6 +46,8 @@ export default class Meeting extends Model {
   @hasMany('agenda', { inverse: 'createdFor', async: true }) agendas; // All agendas for this meeting, includes the final agenda
   @hasMany('piece', { inverse: 'meeting', async: true, polymorphic: true })
   pieces;
+  @hasMany('sign-flow', { inverse: 'meeting', async: true })
+  signFlows;
 
   get isPreKaleidos() {
     return this.plannedStart < KALEIDOS_START_DATE;

--- a/app/models/piece.js
+++ b/app/models/piece.js
@@ -3,7 +3,6 @@ import sanitize from 'sanitize-filename';
 
 export default class Piece extends Model {
   @attr('string') name;
-  @attr('boolean') isReportOrMinutes;
   @attr('number') numberOfPages;
   @attr('number') numberOfWords;
   @attr('datetime') created;

--- a/app/models/sign-flow.js
+++ b/app/models/sign-flow.js
@@ -12,6 +12,8 @@ export default class SignFlowModel extends Model {
   @belongsTo('case', { inverse: 'signFlows', async: true }) case;
   @belongsTo('decision-activity', { inverse: 'signFlows', async: true })
   decisionActivity;
+  @belongsTo('meeting', { inverse: 'signFlows', async: true })
+  meeting;
   @belongsTo('user', { inverse: null, async: true }) creator;
   @belongsTo('concept', { inverse: null, async: true }) status;
 }

--- a/app/routes/signatures/decisions.js
+++ b/app/routes/signatures/decisions.js
@@ -46,10 +46,10 @@ export default class SignaturesDecisionsRoute extends Route {
     }
 
     const filter = {
+      ':has:meeting': true,
       'sign-subcase': {
         'sign-marking-activity': {
           piece: {
-            'is-report-or-minutes': true,
             ':has-no:next-piece': true
           }
         },

--- a/app/routes/signatures/index.js
+++ b/app/routes/signatures/index.js
@@ -58,6 +58,7 @@ export default class SignaturesIndexRoute extends Route {
     }
 
     const filter = {
+      ':has-no:meeting': true,
       'sign-subcase': {
         'sign-marking-activity': {
           piece: {

--- a/app/routes/signatures/ongoing-decisions.js
+++ b/app/routes/signatures/ongoing-decisions.js
@@ -54,14 +54,8 @@ export default class SignaturesOngoingRoute extends Route {
 
     const filter = {
       ':has:creator': true,
-      'sign-subcase': {
-        'sign-marking-activity': {
-          piece: {
-            'is-report-or-minutes': true,
-          }
-        }
-      }
-    }
+      ':has:meeting': true,
+    };
     if (params.statuses?.length > 0) {
       filter['status'] = {
         ':id:': params.statuses.join(','),

--- a/app/routes/signatures/ongoing.js
+++ b/app/routes/signatures/ongoing.js
@@ -46,15 +46,7 @@ export default class SignaturesOngoingRoute extends Route {
       params.page = 0;
     }
 
-    const filter = {
-      'sign-subcase': {
-        'sign-marking-activity': {
-          piece: {
-            'is-report-or-minutes': false,
-          }
-        }
-      }
-    };
+    const filter = { ':has-no:meeting': true };
     if (this.currentSession.may('view-all-ongoing-signatures')) {
       filter[':has:creator'] = 't';
     } else {

--- a/app/services/signature-service.js
+++ b/app/services/signature-service.js
@@ -81,8 +81,20 @@ export default class SignatureService extends Service {
     }
   }
 
-  // return results are currently not used by any caller
-  async markDocumentForSignature(piece, decisionActivity) {
+  /**
+   * Marks a piece for signature by creating a sign flow, sign subcase and sign
+   * marking activity. The sign subcase and sign flow are returned.
+   *
+   * Note: The return values are currently unused by any caller.
+   *
+   * @param {Piece} piece The piece that will be marked for signing
+   * @param {DecisionActivity} decisionActivity The decision activity
+   *   related to the piece being marked for signing, this should only be passed
+   * for regular pieces and reports, not minutes
+   * @param {Meeting} meeting The meeting related to the piece being
+   *   marked for signing, this should only be be passed for minutes
+   */
+  async markDocumentForSignature(piece, decisionActivity, meeting) {
     const existingSignMarking = await piece.belongsTo('signMarkingActivity').reload();
     if (existingSignMarking) {
       // someone else may have made a signflow, returning that one instead
@@ -106,6 +118,7 @@ export default class SignatureService extends Service {
       longTitle: _case?.title,
       case: _case,
       decisionActivity,
+      meeting,
       status: status,
     });
     await signFlow.save();

--- a/app/templates/agenda/minutes.hbs
+++ b/app/templates/agenda/minutes.hbs
@@ -98,6 +98,7 @@
                 @onCreateNewVersion={{perform this.onCreateNewVersion}}
                 @bordered={{true}}
                 @didDeleteContainer={{this.didDeleteMinutes}}
+                @meeting={{this.meeting}}
               />
             {{else if (user-may "manage-minutes")}}
               <AuAlert

--- a/app/templates/agenda/minutes.hbs
+++ b/app/templates/agenda/minutes.hbs
@@ -94,7 +94,6 @@
                 @hideNewerVersions={{true}}
                 @hideEdit={{true}}
                 @hideUpload={{true}}
-                @hideSign={{true}}
                 @showCreateNewVersion={{true}}
                 @onCreateNewVersion={{perform this.onCreateNewVersion}}
                 @bordered={{true}}

--- a/app/templates/signatures/decisions.hbs
+++ b/app/templates/signatures/decisions.hbs
@@ -162,13 +162,13 @@
             <Signatures::CreateSignFlow
               @decisionActivities={{array this.decisionActivityOrMeeting}}
               @onChangeSigners={{fn (mut this.signers)}}
-              @isReportOrMinute={{true}}
+              @isReportOrMinutes={{true}}
             />
           {{else if this.selectedSignFlows.length}}
             <Signatures::CreateSignFlow
               @decisionActivities={{this.selectedDecisionActivitiesOrMeetings.value}}
               @onChangeSigners={{fn (mut this.signers)}}
-              @isReportOrMinute={{true}}
+              @isReportOrMinutes={{true}}
             />
           {{/if}}
         </div>


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4379

Now that meetings are linked to sign flow and the `is-report-or-minutes` attribute has been removed from piece, all the logic that checked whether a sign flow was for a regular piece or for a report/minutes has been replaced to be based on the existence of the link between sign-flow and meeting.

When a document is marked for signing, the meeting is provided in the case of report and minutes to ensure this new behaviour works. Regular pieces should not get linked to their meeting.

Related PRs:
- [x] https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/428
- [x] https://github.com/kanselarij-vlaanderen/digital-signing-service/pull/37