### PR TITLE
Feature KAS-4359: Add next meeting text at the end of minutes

### DIFF
--- a/app/controllers/agenda/minutes.js
+++ b/app/controllers/agenda/minutes.js
@@ -12,6 +12,7 @@ import VrNotulenName,
 { compareFunction as compareNotulen } from 'frontend-kaleidos/utils/vr-notulen-name';
 import { generateBetreft } from 'frontend-kaleidos/utils/decision-minutes-formatting';
 import generateReportName from 'frontend-kaleidos/utils/generate-report-name';
+import { addWeeks } from 'date-fns';
 
 function renderAttendees(attendees) {
   const { primeMinister, viceMinisters, ministers, secretary } = attendees;
@@ -131,14 +132,38 @@ function renderAbsentees() {
   `;
 }
 
+function renderNextMeeting(meeting, intl) {
+  const currentPlannedStart = meeting.plannedStart;
+  const nextPlannedStart = addWeeks(currentPlannedStart, 1);
+  const date = dateFormat(nextPlannedStart, 'EEEE d MMMM yyyy');
+  const time = dateFormat(nextPlannedStart, 'HH:mm');
+  return `<p><span id="next-meeting">${intl.t("minutes-next-meeting", { date, time })}</span><p/>`;
+}
+
 async function renderMinutes(data, intl, store) {
-  const { meeting, attendees, notas, announcements } = data;
-  return `
-    ${renderAttendees(attendees)}
-    ${renderAbsentees()}
-    ${notas ? await renderNotas(meeting, notas, intl, store) : ''}
-    ${announcements ? await renderAnnouncements(meeting, announcements, intl, store) : ''}
-  `;
+  const { meeting, attendees, notas, announcements, editorContent } = data;
+
+  let newMinutesContent = `${renderAttendees(attendees)}
+${renderAbsentees()}
+${notas ? await renderNotas(meeting, notas, intl, store) : ''}
+${announcements ? await renderAnnouncements(meeting, announcements, intl, store) : ''}
+${renderNextMeeting(meeting, intl)}`;
+
+  if (editorContent) {
+    const contentElement = document.createElement('template');
+    contentElement.innerHTML = editorContent;
+
+    const newContentElement = document.createElement('template');
+    newContentElement.innerHTML = newMinutesContent;
+
+    const nextMeetingText = contentElement.content.querySelector('#next-meeting')?.innerHTML;
+    if (nextMeetingText) {
+      newContentElement.content.querySelector('#next-meeting').innerHTML = nextMeetingText;
+    }
+
+    newMinutesContent = newContentElement.innerHTML;
+  }
+  return newMinutesContent;
 }
 
 function mandateeName(mandatee) {
@@ -368,6 +393,7 @@ export default class AgendaMinutesController extends Controller {
       attendees: await this.getAttendees(),
       notas: this.model.notas,
       announcements: this.model.announcements,
+      editorContent: this.editor.htmlContent,
     };
   }
 }

--- a/app/controllers/agenda/minutes.js
+++ b/app/controllers/agenda/minutes.js
@@ -19,7 +19,7 @@ function renderAttendees(attendees) {
   let secretaryTitle = secretary?.title.toLowerCase() || 'secretaris';
   return `
     <p><u>AANWEZIG</u></p>
-    <table>
+    <table id="attendees">
       <tbody>
         <tr>
           <td>De minister-president</td>
@@ -121,7 +121,7 @@ function capitalizeFirstLetter(string) {
 function renderAbsentees() {
   return `
     <p><u>AFWEZIG MET KENNISGEVING</u></p>
-    <table>
+    <table id="absentees">
       <tbody>
         <tr>
           <td></td>
@@ -155,6 +155,16 @@ ${renderNextMeeting(meeting, intl)}`;
 
     const newContentElement = document.createElement('template');
     newContentElement.innerHTML = newMinutesContent;
+
+    const attendeesText = contentElement.content.querySelector('#attendees')?.innerHTML;
+    if (attendeesText) {
+      newContentElement.content.querySelector('#attendees').innerHTML = attendeesText;
+    }
+
+    const absenteesText = contentElement.content.querySelector('#absentees')?.innerHTML;
+    if (absenteesText) {
+      newContentElement.content.querySelector('#absentees').innerHTML = absenteesText;
+    }
 
     const nextMeetingText = contentElement.content.querySelector('#next-meeting')?.innerHTML;
     if (nextMeetingText) {

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1254,6 +1254,7 @@
   "minutes-retracted": "{mededelingOrNota} wordt ingetrokken.",
   "minutes-acknowledged": "De Vlaamse Regering neemt akte van {mededelingOrNota}.",
   "minutes-postponed": "{mededelingOrNota} wordt uitgesteld tot de volgende vergadering.",
+  "minutes-next-meeting": "De volgende vergadering van de Vlaamse Regering heeft plaats op {date} om {time} op het kabinet van de minister-president van de Vlaamse Regering, Martelaarsplein 19 - 1000 Brussel.",
   "postponed-item-decision": "Dit punt wordt uitgesteld tot de volgende vergadering.",
   "retracted-item-decision": "Dit punt wordt ingetrokken.",
   "decision-report-generation--toast-generating--message": "{total} beslissingen zullen worden aangepast.",


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4359

When updating the editor content, we first copy the text blurb before replacing content, in case a user has already updated it so their edits don't get lost.