### PR TITLE
KAS-4382: Error toast kan in specifiek geval niet weggeklikt worden

### DIFF
--- a/app/components/utils/toaster/copy-error-to-clipboard-toast.hbs
+++ b/app/components/utils/toaster/copy-error-to-clipboard-toast.hbs
@@ -6,7 +6,7 @@
 >
   <div class="auk-u-text-capitalize">
     <p>{{@options.message}}</p>
-    <div class="au-u-margin-top-small au-o-box--small au-u-background-gray-100">
+    <div class="au-u-margin-top-small au-o-box--small au-u-background-gray-100 au-u-word-break">
       <Utils::ClipboardableContent @content={{@options.errorContent}} />
     </div>
   </div>

--- a/app/components/utils/toaster/copy-error-to-clipboard-toast.hbs
+++ b/app/components/utils/toaster/copy-error-to-clipboard-toast.hbs
@@ -2,6 +2,7 @@
   @title={{@options.title}}
   @skin="error"
   @icon="alert-triangle"
+  @size="small"
   @closable={{true}}
 >
   <div class="auk-u-text-capitalize">


### PR DESCRIPTION
**Tickets binnen Jira:** 
- https://kanselarij.atlassian.net/browse/KAS-4382

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.