### PR TITLE
KAS-4377: Tweaken van default & max breedte van toaster items uit ember-appuniversum

### DIFF
--- a/app/styles/au/_au-components.scss
+++ b/app/styles/au/_au-components.scss
@@ -453,7 +453,15 @@ $au-label-color: var(--au-gray-700);
 // Toaster
 
 .au-c-toaster {
-  width: 420px;
+  width: auto;
+  align-items: flex-end;
+}
+
+.au-c-toaster {
+  .au-c-alert {
+    min-width: 420px;
+    max-width: 580px;
+  }
 }
 
 // Additions


### PR DESCRIPTION
**Tickets binnen Jira:** 
- https://kanselarij.atlassian.net/browse/KAS-4377

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.