### PR TITLE
KAS-4366: Regenerate reports when re-ordering agendaitems

### DIFF
--- a/app/controllers/agenda/agendaitems.js
+++ b/app/controllers/agenda/agendaitems.js
@@ -15,6 +15,7 @@ import {
   all,
   animationFrame
 } from 'ember-concurrency';
+import generateReportName from 'frontend-kaleidos/utils/generate-report-name';
 
 export default class AgendaAgendaitemsController extends Controller {
   queryParams = [
@@ -31,8 +32,10 @@ export default class AgendaAgendaitemsController extends Controller {
     },
   ];
   
+  @service store;
   @service router;
   @service intl;
+  @service decisionReportGeneration;
   @service throttledLoadingService;
 
   @lastValue('groupNotasOnGroupName') notaGroups = [];
@@ -75,6 +78,7 @@ export default class AgendaAgendaitemsController extends Controller {
 
   @task
   *assignNewPriorities(reorderedAgendaitems, draggedAgendaItem) {
+    const draggedAgendaItemNumber = draggedAgendaItem.number;
     const draggedAgendaItemType = yield draggedAgendaItem.type;
     // reorderedAgendaitems includes all items on the whole page. We only want to re-order within one category (nota/announcement/...)
     const reorderedAgendaitemsOfCategory =  [];
@@ -85,6 +89,26 @@ export default class AgendaAgendaitemsController extends Controller {
       }
     }
     yield setAgendaitemsNumber(reorderedAgendaitemsOfCategory, true, true); // permissions guarded in template (and backend)
+    const newDraggedAgendaItemNumber = draggedAgendaItem.number;
+
+    const needNewReports = reorderedAgendaitemsOfCategory.slice(
+      Math.min(draggedAgendaItemNumber, newDraggedAgendaItemNumber) - 1, // number is 1-indexed
+      Math.max(draggedAgendaItemNumber, newDraggedAgendaItemNumber), // slice does not include end index
+    );
+    if (needNewReports) {
+      const reports = [];
+      yield Promise.all(needNewReports.map(async (agendaitem) => {
+        const report = await this.store.queryOne('report', {
+          'filter[:has-no:next-piece]': true,
+          'filter[:has:piece-parts]': true,
+          'filter[decision-activity][treatment][agendaitems][:id:]': agendaitem.id,
+        });
+        reports.push(report);
+        report.name = await generateReportName(agendaitem, this.meeting);
+        return report.save();
+      }));
+      this.decisionReportGeneration.generateReplacementReports.perform(reports);
+    }
     this.router.refresh('agenda.agendaitems');
   }
 

--- a/app/controllers/agenda/agendaitems/agendaitem/index.js
+++ b/app/controllers/agenda/agendaitems/agendaitem/index.js
@@ -10,6 +10,7 @@ import ENV from 'frontend-kaleidos/config/environment';
 export default class IndexAgendaitemAgendaitemsAgendaController extends Controller {
   @service store;
   @service currentSession;
+  @service decisionReportGeneration;
   @service router;
   @service agendaitemAndSubcasePropertiesSync;
   @service decisionReportGeneration;
@@ -66,7 +67,12 @@ export default class IndexAgendaitemAgendaitemsAgendaController extends Controll
   }
 
   async reassignNumbersForAgendaitems() {
-    await reorderAgendaitemsOnAgenda(this.agenda, this.currentSession.may('manage-agendaitems'));
+    await reorderAgendaitemsOnAgenda(
+      this.agenda,
+      this.store,
+      this.decisionReportGeneration,
+      this.currentSession.may('manage-agendaitems'),
+    );
   }
 
   @action

--- a/app/utils/agendaitem-utils.js
+++ b/app/utils/agendaitem-utils.js
@@ -1,6 +1,7 @@
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 import EmberObject from '@ember/object';
 import { A } from '@ember/array';
+import generateReportName from './generate-report-name';
 
 /**
  * @description Zet een agendaitem of subcase naar nog niet formeel ok
@@ -84,22 +85,42 @@ export const sortByNumber = (groupedAgendaitems, allowEmptyGroups) => {
 /**
  * Given a set of agendaitems, set their number
  * @name setAgendaitemsNumber
- * @param  {Array<agendaitem>}   agendaitems  Array of agendaitem objects to set number on.
- * @param  {Boolean} isEditor     When true, the user is allowed to edit the trigger a recalculation of the number.
- * @param {Boolean} isDesignAgenda  When true, the agenda is a designagenda.
+ * @param  {Array<Agendaitem>} agendaitems  Array of agendaitem objects to set number on.
+ * @param {Meeting} meeting The meeting the agendaitems belong to
+ * @param {Store} store The store service
+ * @param {DecisionReportGeneration} decisionReportGeneration The decisionReportGeneration service
+ * @param {Boolean} isEditor When true, the user is allowed to edit the trigger a recalculation of the number.
+ * @param {Boolean} isDesignAgenda When true, the agenda is a designagenda.
  */
-export const setAgendaitemsNumber = async(agendaitems, isEditor, isDesignAgenda) => {
+export const setAgendaitemsNumber = async(agendaitems, meeting, store, decisionReportGeneration, isEditor, isDesignAgenda) => {
   if (isEditor && isDesignAgenda) {
-    return await Promise.all(agendaitems.map(async(agendaitem, index) => {
+    const reports = [];
+    const promises = await Promise.all(agendaitems.map(async(agendaitem, index) => {
       if (agendaitem.number !== index + 1) {
-        agendaitem.set('number', index + 1);
-        return agendaitem.save();
+        agendaitem.number = index + 1;
+        const agendaitemSave = await agendaitem.save();
+
+        const report = await store.queryOne('report', {
+          'filter[:has-no:next-piece]': true,
+          'filter[:has:piece-parts]': true,
+          'filter[decision-activity][treatment][agendaitems][:id:]': agendaitem.id,
+        });
+        if (report) {
+          reports.push(report);
+          report.name = await generateReportName(agendaitem, meeting);
+          await report.save();
+        }
+        return agendaitemSave;
       }
     }));
+    if (reports.length) {
+      await decisionReportGeneration.generateReplacementReports.perform(reports);
+    }
+    return promises;
   }
 };
 
-export const reorderAgendaitemsOnAgenda = async(agenda, isEditor) => {
+export const reorderAgendaitemsOnAgenda = async(agenda, store, decisionReportGeneration, isEditor) => {
   await agenda.hasMany('agendaitems').reload();
   const agendaitems = await agenda.get('agendaitems');
   const actualAgendaitems = [];
@@ -114,8 +135,9 @@ export const reorderAgendaitemsOnAgenda = async(agenda, isEditor) => {
       }
     }
   }
-  await setAgendaitemsNumber(actualAgendaitems, isEditor, true);
-  await setAgendaitemsNumber(actualAnnouncements, isEditor, true);
+  const meeting = await agenda.createdFor;
+  await setAgendaitemsNumber(actualAgendaitems, meeting, store, decisionReportGeneration, isEditor, true);
+  await setAgendaitemsNumber(actualAnnouncements, meeting, store, decisionReportGeneration, isEditor, true);
 };
 
 /**

--- a/app/utils/agendaitem-utils.js
+++ b/app/utils/agendaitem-utils.js
@@ -107,7 +107,9 @@ export const setAgendaitemsNumber = async(agendaitems, meeting, store, decisionR
         });
         if (report) {
           reports.push(report);
-          report.name = await generateReportName(agendaitem, meeting);
+          const documentContainer = await report.documentContainer;
+          const pieces = await documentContainer.pieces;
+          report.name = await generateReportName(agendaitem, meeting, pieces.length);
           await report.save();
         }
         return agendaitemSave;

--- a/app/utils/generate-report-name.js
+++ b/app/utils/generate-report-name.js
@@ -1,5 +1,6 @@
 import addLeadingZeros from 'frontend-kaleidos/utils/add-leading-zeros';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
+import CONFIG from 'frontend-kaleidos/utils/config';
 
 /**
  * Generates a report name like "VR PV 2023/01 - punt 0001" based on the meeting
@@ -7,16 +8,22 @@ import CONSTANTS from 'frontend-kaleidos/config/constants';
  *
  * @param {Agendaitem} agendaitem The agendaitem whose number and type will be
  * used to generate the report name.
- * @param {Meeting} [meeting] The meeting whose number will be
+ * @param {Meeting} meeting The meeting whose number will be
  * used to generate the report name.
+ * @param {Number} [reportNr=1] The version number of the report, used to
+ * determine the suffix (BIS, TER, etc.).
  */
-export default async function generateReportName(agendaitem, meeting) {
+export default async function generateReportName(agendaitem, meeting, reportNr=1) {
   // *note: any changes made here should also be made in the decision-report-generation service
   const meetingNumber = meeting.numberRepresentation;
   const type = await agendaitem.type;
   const agendaitemType = type.uri === CONSTANTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT
         ? 'mededeling' : 'punt';
   const agendaitemNumber = addLeadingZeros(agendaitem.number, 4);
+  let versionSuffix = '';
+  if (reportNr >= 1 && reportNr < Object.keys(CONFIG.latinAdverbialNumberals).length) {
+    versionSuffix = CONFIG.latinAdverbialNumberals[reportNr].toUpperCase();
+  }
 
-  return `${meetingNumber} - ${agendaitemType} ${agendaitemNumber}`;
+  return `${meetingNumber} - ${agendaitemType} ${agendaitemNumber}${versionSuffix}`;
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4366

Regenerates report (so new PDF) and changes name of piece.

:warning: We also need to change the name of the piece when changing a meeting! In my opinion this should go in the `DecisionReportGenerationService`, but I think those changes should occur after the "job generate reports" PR gets merged, to prevent conflicts.