### PR TITLE
KAS-4378: Visueel en/of structureel verschil tussen selectielijst van ministers wegwerken

### DIFF
--- a/app/components/agenda/agenda-header/agenda-actions.hbs
+++ b/app/components/agenda/agenda-header/agenda-actions.hbs
@@ -284,29 +284,33 @@
     >
       <p>{{t "download-agenda-decisions-info"}}</p>
     </AuAlert>
-    <Mandatees::CheckboxSelect
-      @selected={{this.selectedMandatees}}
-      @referenceAgenda={{@currentAgenda}}
-      @onChange={{set this "selectedMandatees"}}
-    />
-    <AuFieldset as |Fieldset|>
-      <Fieldset.legend>{{t "file-types"}}</Fieldset.legend>
-      <Fieldset.content>
-        <AuRadioGroup
-          @alignment="inline"
-          @selected={{this.selectedDownloadOption}}
-          @onChange={{this.onChangeDownloadOption}}
-          as |Group|
-        >
-          {{#each this.downloadOptions as |option|}}
-          <Group.Radio
-            @value={{option.value}}
-            >
-            {{option.label}}
-          </Group.Radio>
-          {{/each}}
-        </AuRadioGroup>
-      </Fieldset.content>
-    </AuFieldset>
+    <div class="au-c-form">
+      <AuFormRow>
+        <Mandatees::CheckboxSelect
+          @selected={{this.selectedMandatees}}
+          @referenceAgenda={{@currentAgenda}}
+          @onChange={{set this "selectedMandatees"}}
+        />
+      </AuFormRow>
+      <AuFieldset as |Fieldset|>
+        <Fieldset.legend>{{t "file-types"}}</Fieldset.legend>
+        <Fieldset.content>
+          <AuRadioGroup
+            @alignment="inline"
+            @selected={{this.selectedDownloadOption}}
+            @onChange={{this.onChangeDownloadOption}}
+            as |Group|
+          >
+            {{#each this.downloadOptions as |option|}}
+            <Group.Radio
+              @value={{option.value}}
+              >
+              {{option.label}}
+            </Group.Radio>
+            {{/each}}
+          </AuRadioGroup>
+        </Fieldset.content>
+      </AuFieldset>
+    </div>
   </:body>
 </ConfirmationModal>

--- a/app/components/auk/checkbox-tree.hbs
+++ b/app/components/auk/checkbox-tree.hbs
@@ -1,4 +1,4 @@
-<AuCheckboxGroup> {{!-- Just use the group component here as a styling method as also using the included functionality would unnecessarily overcomplicate things --}}
+<AuCheckboxGroup class="auk-u-maximize-width"> {{!-- Just use the group component here as a styling method as also using the included functionality would unnecessarily overcomplicate things --}}
   <AuCheckbox
     @checked={{this.isSelectedAllItems}}
     @indeterminate={{and (not this.isSelectedAllItems) this.isSelectedSomeItems}}


### PR DESCRIPTION
**Tickets binnen Jira:** 
- https://kanselarij.atlassian.net/browse/KAS-4378

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.