### PR TITLE
KAS-4414: Ontbrekende overerving van type lijst binnen (read-only) view na invoer rdfa-editor

### DIFF
--- a/app/styles/au/_au-components.scss
+++ b/app/styles/au/_au-components.scss
@@ -516,6 +516,10 @@ $au-label-color: var(--au-gray-700);
     list-style: decimal;
     margin-left: $au-unit;
 
+    & > li > ol:not([data-list-style]) {
+      list-style-type: inherit;
+    }
+
     &[data-list-style='decimal'] {
       list-style-type: decimal;
     }


### PR DESCRIPTION
**Tickets binnen Jira:** 
- https://kanselarij.atlassian.net/browse/KAS-4414

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.