### PR TITLE
fix: use correct intl string when report generation fails

### DIFF
--- a/app/services/decision-report-generation.js
+++ b/app/services/decision-report-generation.js
@@ -58,7 +58,7 @@ export default class DecisionReportGeneration extends Service {
           );
       } else if (jobResult.status === CONSTANTS.DECISION_REPORT_JOB_STATUSSES.FAILURE) {
         this.toaster.error(
-          this.intl.t('error-while-generating-report-pdfs')
+          this.intl.t('error-while-generating-report-pdfs-no-reaseon')
         );
       } else {
         setTimeout(() => {

--- a/app/services/decision-report-generation.js
+++ b/app/services/decision-report-generation.js
@@ -58,7 +58,7 @@ export default class DecisionReportGeneration extends Service {
           );
       } else if (jobResult.status === CONSTANTS.DECISION_REPORT_JOB_STATUSSES.FAILURE) {
         this.toaster.error(
-          this.intl.t('error-while-generating-report-pdfs-no-reaseon')
+          this.intl.t('error-while-generating-report-pdfs-no-reason')
         );
       } else {
         setTimeout(() => {

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1187,6 +1187,7 @@
   "error-while-exporting-pdf": "Er ging iets mis tijdens het exporteren naar PDF",
   "error-while-generating-report-name-pdf": "Er ging iets mis tijdens het aanmaken van de beslissingsfiche {name}. Reden: {error}",
   "error-while-generating-report-pdfs": "Er ging iets mis tijdens het aanmaken van de beslissingsfiches. Reden: {error}",
+  "error-while-generating-report-pdfs-no-reason": "Er ging iets mis tijdens het aanmaken van de beslissingsfiches.",
   "error-while-generating-minutes-pdf": "Er ging iets mis tijdens het aanmaken van de notulen",
   "version-of-date-at-time": "Versie van {date} om {time}",
   "download-agenda-documents-info": "Deze functie brengt standaard alle documenten van deze vergadering samen in een zip bestand dat je dan kan downloaden. Ben je enkel geïnteresseerd in de documenten ingediend door of met één of meerdere ministers, vink dan de betreffende minister(s) aan.",


### PR DESCRIPTION
We don't store a reason/message when a job fails so we have nothing to show to users, so we shouldn't try to generate a message that takes in a reason argument, otherwise the intl library generates an error.

We *should* store reasons at some point, but we don't, this is just a patch to not have exceptions bubbling.