### PR TITLE
Feature/KAS-4409: Fix conflicting signers alert not going away after deselecting conflicting sign flows

### DIFF
--- a/app/components/signatures/create-sign-flow/report-or-minutes.js
+++ b/app/components/signatures/create-sign-flow/report-or-minutes.js
@@ -41,6 +41,7 @@ export default class SignaturesCreateSignFlowReportOrMinutesComponent extends Co
     if (!hasConflictingSigners && secretary) {
       signers = [secretary];
     }
+    this.args.onChangeSigners?.(signers);
     return {
       signers,
       hasConflictingSigners,


### PR DESCRIPTION
Ensure that hasConflictingSigners is reset when changing selection

To make it work (and be more consistent with the programming style of ember-resources), we make the loadSigners resource return the value of hasConflictingSigners instead of mutating it. Mutating it can cause errors: e.g. the resource gets fired as soon as rendering occurs, but we're also reading hasConflictingSigners at that point, if we write to a tracked variable that has already been read in a render cycle, Ember will crash.

Instead the proper way (according to ember-resources) is for a resource not to mutate anything outside of itself and for the resource to return whatever state is needed and that can be depended on.