### PR TITLE
KAS-4408: Uitlijnen afwezigen & aanwezigen in read-only HTML view & PDF

### DIFF
--- a/app/components/sanitize-html.js
+++ b/app/components/sanitize-html.js
@@ -4,7 +4,15 @@ import merge from 'lodash/merge';
 import { isPresent } from '@ember/utils';
 
 const additionalAllowedTags = ['del'];
-const additionalAllowedAttributes = {'ol': ['data-list-style']};
+const additionalAllowedAttributes = {
+  'ol': ['data-list-style'],
+  'table': [
+    {
+      name: 'id',
+      values: ['attendees', 'absentees'],
+    },
+  ],
+};
 
 export default class SanitizeHtmlComponent extends Component {
   constructor() {

--- a/app/styles/au/_au-components.scss
+++ b/app/styles/au/_au-components.scss
@@ -590,3 +590,11 @@ $au-label-color: var(--au-gray-700);
     @include decimal-extended-styling(5, 1);
   }
 }
+
+// TODO: the selector below is not an ideal solution, this needs to replaced by a class selector like `.rdfa-table--fixed` or something similar when the omitted class issue on tabled within ember-rdfa-editor is fixed
+.au-c-content {
+  #attendees,
+  #absentees {
+    table-layout: fixed;
+  }
+}


### PR DESCRIPTION
**Tickets binnen Jira:** 
- https://kanselarij.atlassian.net/browse/KAS-4408

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.