### PR TITLE
add checks before regenerating pdf's

### DIFF
--- a/app/components/meeting/edit-meeting-modal.js
+++ b/app/components/meeting/edit-meeting-modal.js
@@ -365,6 +365,9 @@ export default class MeetingEditMeetingComponent extends Component {
 
   async regenerateMinutes() {
     const minutes = await this.args.meeting.minutes;
+    if (! (await this.decisionReportGeneration.canReplaceMinutes(minutes))) {
+      return;
+    }
     if (minutes) {
       // new name
       const documentContainer = await minutes.documentContainer;

--- a/app/components/meeting/edit-meeting-modal.js
+++ b/app/components/meeting/edit-meeting-modal.js
@@ -255,6 +255,9 @@ export default class MeetingEditMeetingComponent extends Component {
       'filter[decision-activity][treatment][agendaitems][agenda][created-for][:id:]':
         this.args.meeting.id,
     });
+    if (!(await this.decisionReportGeneration.canReplaceAllReports(reports))) {
+      return;
+    }
     await Promise.all(reports.map(async (report) => {
       const agendaitem = await this.store.queryOne('agendaitem', {
         'filter[:has-no:next-version]': true,

--- a/app/services/decision-report-generation.js
+++ b/app/services/decision-report-generation.js
@@ -8,7 +8,7 @@ export default class DecisionReportGeneration extends Service {
   @service intl;
 
   generateReplacementReports = task(async (reports) => {
-    if (!(await this._canReplaceAllReports(reports))) {
+    if (!(await this.canReplaceAllReports(reports))) {
       return;
     }
 
@@ -74,10 +74,10 @@ export default class DecisionReportGeneration extends Service {
   });
 
   async _canReplaceReport(report) {
-    return await this._canReplaceAllReports([report]);
+    return await this.canReplaceAllReports([report]);
   }
 
-  async _canReplaceAllReports(reports) {
+  async canReplaceAllReports(reports) {
     const latestAgendas = await this.store.queryAll('agenda', {
       'filter[agendaitems][treatment][decision-activity][report][:id:]': reports
         .map((r) => r.id)

--- a/app/services/decision-report-generation.js
+++ b/app/services/decision-report-generation.js
@@ -145,7 +145,7 @@ export default class DecisionReportGeneration extends Service {
   });
 
   generateReplacementMinutes = task(async (minutes) => {
-    if (! (await this._canReplaceMinutes(minutes))) {
+    if (! (await this.canReplaceMinutes(minutes))) {
       return;
     }
     try {
@@ -179,7 +179,7 @@ export default class DecisionReportGeneration extends Service {
     }
   });
 
-  async _canReplaceMinutes(minutes) {
+  async canReplaceMinutes(minutes) {
     const latestAgenda = await this.store.queryOne('agenda', {
       'filter[created-for][minutes][:id:]': minutes.id,
       'filter[:has-no:next-version]': true,

--- a/app/services/decision-report-generation.js
+++ b/app/services/decision-report-generation.js
@@ -8,6 +8,10 @@ export default class DecisionReportGeneration extends Service {
   @service intl;
 
   generateReplacementReports = task(async (reports) => {
+    if (!(await this._canReplaceAllReports(reports))) {
+      return;
+    }
+
     const generatingPDFsToast = this.toaster.loading(
       this.intl.t('decision-report-generation--toast-generating--message', {
         total: reports.length,
@@ -69,7 +73,64 @@ export default class DecisionReportGeneration extends Service {
     }
   });
 
+  async _canReplaceReport(report) {
+    return await this._canReplaceAllReports([report]);
+  }
+
+  async _canReplaceAllReports(reports) {
+    const latestAgendas = await this.store.queryAll('agenda', {
+      'filter[agendaitems][treatment][decision-activity][report][:id:]': reports
+        .map((r) => r.id)
+        .join(','),
+      'filter[:has-no:next-version]': true,
+      include: 'status',
+    });
+
+    const agendaIsClosed = latestAgendas.toArray().some(
+      (agenda) =>
+        agenda.belongsTo('status').value().uri ===
+        CONSTANTS.AGENDA_STATUSSES.APPROVED
+    );
+
+    if (agendaIsClosed) {
+      return false;
+    }
+
+    const decisionInternallyPublished = !!(await this.store.queryOne(
+      'internal-decision-publication-activity',
+      {
+        'filter[meeting][agendas][:id:]': latestAgendas
+          .map((a) => a.id)
+          .join(','),
+        'filter[:has:start-date]': true,
+        'filter[status][:uri:]': CONSTANTS.RELEASE_STATUSES.RELEASED,
+      }
+    ));
+
+    if (decisionInternallyPublished) {
+      return false;
+    }
+
+    const hasPreparationActivity = !!(await this.store.queryOne(
+      'sign-preparation-activity',
+      {
+        'filter[sign-marking-activity][piece][:id:]': reports
+          .map((r) => r.id)
+          .join(','),
+      }
+    ));
+
+    if (hasPreparationActivity) {
+      return false;
+    }
+
+    return true;
+  }
+
   generateReplacementReport = task(async (report) => {
+    if (!await this._canReplaceReport(report)) {
+      return;
+    }
     try {
       await this.generateSinglePdf.perform(report, 'generate-decision-report');
       await this.reloadFile(report);


### PR DESCRIPTION
https://kanselarij.atlassian.net/jira/software/c/projects/KAS/boards/1?selectedIssue=KAS-4374

Adds 2 checks in `decision-report-generation.js` to make sure the following conditions are checked before regenerating the decision-reports and minutes.
- Vergadering is afgesloten (laatste agenda is afgesloten)
- Beslissing is vrijgegeven
- Proces voor ondertekenen is opgestart voor beslissingsfiche of notulen