### PR TITLE
fix: replace query call with queryAll

### DIFF
--- a/app/components/agenda/agendaitem/agendaitem-decision.js
+++ b/app/components/agenda/agendaitem/agendaitem-decision.js
@@ -87,7 +87,7 @@ export default class AgendaitemDecisionComponent extends Component {
   });
 
   loadDocuments = task(async () => {
-    let pieces = await this.store.query('piece', {
+    let pieces = await this.store.queryAll('piece', {
       'filter[agendaitems][:id:]': this.args.agendaitem.id,
       'filter[:has-no:next-piece]': true,
     });


### PR DESCRIPTION
query is by default limited to the page size set by resources (20 in the case of Kaleidos).