### PR TITLE
Feature/kas 4433 send to vp role permissions

### DIFF
--- a/app/components/agenda/agendaitem/agendaitem-controls.hbs
+++ b/app/components/agenda/agendaitem/agendaitem-controls.hbs
@@ -7,7 +7,7 @@
       @alignment="right"
       class="auk-u-hidden@print"
     >
-      {{#if (and this.areDecisionActionsEnabled this.isDesignAgenda)}}
+      {{#if (and this.areDecisionActionsEnabled this.isDesignAgenda (user-may "manage-agendaitems"))}}
         {{#if this.decisionActivity.isPostponed}}
           <AuButton
             data-test-agendaitem-controls-action-postpone-revert
@@ -56,6 +56,7 @@
         (and
           (or this.currentSession.isAdmin (await this.isDeletable))
           this.isDesignAgenda
+          (user-may "manage-agendaitems")
         )
       }}
         <AuButton

--- a/app/components/agenda/agendaitem/agendaitem-controls.js
+++ b/app/components/agenda/agendaitem/agendaitem-controls.js
@@ -43,7 +43,7 @@ export default class AgendaitemControls extends Component {
   }
 
   loadCanSendToVP = task(async () => {
-    if (!this.enableVlaamsParlement) {
+    if (!this.enableVlaamsParlement || !this.subcase) {
       this.canSendToVP = false;
       return
     }
@@ -58,7 +58,7 @@ export default class AgendaitemControls extends Component {
     }
 
     const fetchIsReadyForVp = async () => {
-      const decisionmakingFlow = await this.args.subcase.decisionmakingFlow;
+      const decisionmakingFlow = await this.subcase.decisionmakingFlow;
       const resp = await fetch(
         `/vlaams-parlement-sync/is-ready-for-vp/?uri=${decisionmakingFlow.uri}`,
         { headers: { Accept: 'application/vnd.api+json' } }

--- a/app/config/permissions.js
+++ b/app/config/permissions.js
@@ -45,6 +45,8 @@ const {
 // - view-only-specific-confidential-documents: allow the viewing of a restricted selection of confidential documents.
 // - search-confidential-cases: allow searching of cases that have at least 1 confidential subcase
 // - search-confidential-documents: allow searching of documents that have vertrouwelijk access level
+// - send-cases-to-vp: allow sending a case's documents to the VP (Flemish Parliament).
+// - send-only-specific-cases-to-vp: allow sending a restricted selection of cases' documents to the VP (Flemish Parliament).
 // - impersonate-users: Use the app as if you were a different user, without logging it with their credentials
 
 const groups = [
@@ -79,6 +81,7 @@ const groups = [
       'view-decisions-before-release',
       'search-confidential-cases',
       'search-confidential-documents',
+      'send-cases-to-vp',
       'impersonate-users',
     ]
   },
@@ -110,6 +113,7 @@ const groups = [
       'view-decisions-before-release',
       'search-confidential-cases',
       'search-confidential-documents',
+      'send-cases-to-vp',
     ]
   },
   {
@@ -138,6 +142,7 @@ const groups = [
       'view-decisions-before-release',
       'search-confidential-cases',
       'search-confidentnial-documents',
+      'send-cases-to-vp',
     ]
   },
   {
@@ -168,6 +173,7 @@ const groups = [
       'view-decisions-before-release',
       'search-confidential-cases',
       'search-confidential-documents',
+      'send-cases-to-vp',
     ],
   },
   {
@@ -189,7 +195,8 @@ const groups = [
       'manage-only-specific-signatures',
       'view-document-version-info',
       'view-documents-before-release',
-      'view-only-specific-confidential-documents'
+      'view-only-specific-confidential-documents',
+      'send-only-specific-cases-to-vp',
     ],
   },
   {

--- a/app/config/permissions.js
+++ b/app/config/permissions.js
@@ -113,7 +113,6 @@ const groups = [
       'view-decisions-before-release',
       'search-confidential-cases',
       'search-confidential-documents',
-      'send-cases-to-vp',
     ]
   },
   {
@@ -142,7 +141,6 @@ const groups = [
       'view-decisions-before-release',
       'search-confidential-cases',
       'search-confidentnial-documents',
-      'send-cases-to-vp',
     ]
   },
   {
@@ -173,7 +171,6 @@ const groups = [
       'view-decisions-before-release',
       'search-confidential-cases',
       'search-confidential-documents',
-      'send-cases-to-vp',
     ],
   },
   {

--- a/app/templates/agenda/agendaitems/agendaitem/index.hbs
+++ b/app/templates/agenda/agendaitems/agendaitem/index.hbs
@@ -25,16 +25,14 @@
   </Toolbar.Group>
   <Toolbar.Group @position="right" as |Group|>
     <Group.Item>
-      {{#if (user-may "manage-agendaitems")}}
-        <Agenda::Agendaitem::AgendaitemControls
-          @agendaitem={{this.model}}
-          @agendaActivity={{this.agendaActivity}}
-          @currentAgenda={{this.agenda}}
-          @subcase={{this.subcase}}
-          @reverseSortedAgendas={{this.reverseSortedAgendas}}
-          @onDeleteAgendaitem={{this.reassignNumbersAndNavigateToNeighbouringAgendaitem}}
-        />
-      {{/if}}
+      <Agenda::Agendaitem::AgendaitemControls
+        @agendaitem={{this.model}}
+        @agendaActivity={{this.agendaActivity}}
+        @currentAgenda={{this.agenda}}
+        @subcase={{this.subcase}}
+        @reverseSortedAgendas={{this.reverseSortedAgendas}}
+        @onDeleteAgendaitem={{this.reassignNumbersAndNavigateToNeighbouringAgendaitem}}
+      />
     </Group.Item>
   </Toolbar.Group>
 </Auk::Toolbar>


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4433

"Doorsturen naar het Vlaams Parlement" button is now shown to Admin (& secretarie & kanselarij) & Kabinetdossierbeheerders profiles. Other profiles can see the sending to VP (with the green banner) but cannot send to VP.

Related PRs:
- [ ] https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/439
- [ ] https://github.com/kanselarij-vlaanderen/cache-warmup-service/pull/14