### PR TITLE
fix: add inverse relation of signed piece copy

### DIFF
--- a/app/models/piece.js
+++ b/app/models/piece.js
@@ -37,11 +37,17 @@ export default class Piece extends Model {
   })
   unsignedPiece;
   @belongsTo('piece', {
-    inverse: null,
+    inverse: 'signedPieceCopyOf',
     async: true,
     polymorphic: true,
   })
   signedPieceCopy;
+  @belongsTo('piece', {
+    inverse: 'signedPieceCopy',
+    async: true,
+    polymorphic: true,
+  })
+  signedPieceCopyOf;
 
   // resources with pieces linked:
 


### PR DESCRIPTION
Otherwise when doing `signedPieceCopy.destroyRecord()`, the link from piece to the copy will be left intact.

Related: https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/440