### PR TITLE
KAS-4470 upgrade ember-file-upload

### DIFF
--- a/app/components/auk/file-uploader.hbs
+++ b/app/components/auk/file-uploader.hbs
@@ -1,3 +1,4 @@
+{{! multiple defaults to true, false means 1 file will be sliced if multiple files are dropped}}
 <FileDropzone
   @queue={{this.fileQueue}}
   @multiple={{@multiple}}
@@ -5,7 +6,6 @@
   class="auk-file-upload {{if this.uploadIsRunning "auk-file-upload--gray-100"}} {{if this.uploadIsCompleted "auk-file-upload--success"}} {{if @fullHeight "auk-file-upload--full-height"}}"
   as |dropzone|
 >
-  {{!-- Note that "@multiple" has been deprecated, but still works in v 5.x.x beta --}}
   {{!-- template-lint-disable require-input-label --}}
   <input
     type="file"

--- a/app/components/auk/file-uploader.js
+++ b/app/components/auk/file-uploader.js
@@ -62,7 +62,8 @@ export default class FileUploader extends Component {
     try {
       this.args.onQueueUpdate?.(this.queueInfo);
       const response = yield file.upload('/files');
-      const fileFromStore = yield this.store.findRecord('file', response.body.data.id);
+      const body = yield response.json();
+      const fileFromStore = yield this.store.findRecord('file', body.data.id);
       if (this.args.onUpload) {
         this.args.onUpload(fileFromStore);
       }

--- a/app/components/documents/document-card.hbs
+++ b/app/components/documents/document-card.hbs
@@ -333,7 +333,7 @@
         @onDelete={{perform this.deleteUploadedPiece}}
       />
     {{else}}
-      <Auk::FileUploader @onUpload={{perform this.uploadPiece}} />
+      <Auk::FileUploader @multiple={{false}} @onUpload={{perform this.uploadPiece}} />
     {{/if}}
   </:body>
 </ConfirmationModal>

--- a/app/components/documents/document-card/edit-modal.hbs
+++ b/app/components/documents/document-card/edit-modal.hbs
@@ -45,6 +45,7 @@
       {{#if this.isReplacingSourceFile}}
         <c.content data-test-document-edit-source-file-replacer>
           <Auk::FileUploader
+            @multiple={{false}}
             @onUpload={{set this "replacementSourceFile"}}
             @onQueueUpdate={{this.handleReplacementSourceFileUploadQueue}}
           />
@@ -97,6 +98,7 @@
         {{#if this.isReplacingDerivedFile}}
           <c.content data-test-document-edit-derived-file-replacer>
             <Auk::FileUploader
+              @multiple={{false}}
               @onUpload={{set this "replacementDerivedFile"}}
               @onQueueUpdate={{this.handleReplacementDerivedFileUploadQueue}}
             />
@@ -119,6 +121,7 @@
         </c.header>
         <c.content data-test-document-edit-derived-file-uploader>
           <Auk::FileUploader
+            @multiple={{false}}
             @onUpload={{set this "uploadedDerivedFile"}}
             @onQueueUpdate={{this.handleDerivedFileUploadQueue}}
           />

--- a/app/components/documents/document-details-panel.hbs
+++ b/app/components/documents/document-details-panel.hbs
@@ -61,6 +61,7 @@
       </Auk::KeyValue>
       {{#if this.isReplacingSourceFile}}
         <Auk::FileUploader
+          @multiple={{false}}
           @onUpload={{set this "replacementSourceFile"}}
           @onQueueUpdate={{this.handleReplacementFileUploadQueue}}
         />

--- a/app/components/utils/add-document.hbs
+++ b/app/components/utils/add-document.hbs
@@ -22,6 +22,7 @@
       </div>
     {{else}}
       <Auk::FileUploader
+        @multiple={{false}}
         @onUpload={{this.createNewPiece}}
       />
     {{/if}}

--- a/app/templates/styleguide/upload.hbs
+++ b/app/templates/styleguide/upload.hbs
@@ -5,5 +5,5 @@
         @title="Default"
         @code="&lt;Auk::FileUploader/&gt;"
 >
-  <Auk::FileUploader @reusable={{true}} />
+  <Auk::FileUploader @multiple={{false}} @reusable={{true}} />
 </StyleguideSample>

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "ember-data-storefront": "0.18.2-ember4.0",
     "ember-element-helper": "^0.6.1",
     "ember-fetch": "^8.1.2",
-    "ember-file-upload": "5.0.0-beta.8",
+    "ember-file-upload": "7.4.0",
     "ember-flatpickr": "^3.2.3",
     "ember-functions-as-helper-polyfill": "^2.1.1",
     "ember-in-viewport": "4.1.0",


### PR DESCRIPTION
## :warning: started from ACCEPTANCE. 

### This PR blocks the ACC release because some users primarily drop files on the uploader in daily workflow.

https://kanselarij.atlassian.net/browse/KAS-4470

Upgraded ember-file-upload to 7.4.0 (fixed) to overcome issues with ember-appuniversum's 7.0.3 dependency.
- not many changes needed (there was a migrations guide, but we are not using any deprecated methods/args it seems)
- The response from uploading changed, needed to transform the response to json.
- dropping files works again
- dropping multiple files was possible on replacing files / adding BIS/TER so added `@multiple={{false}}` where needed. You can still do it but only 1 file will be sliced and uploaded.

potential issue:
The dropzone can't be disabled out of the box so it is possible to drop files when a file selection upload with button is not possible. (might have already been the case prior to breaking)


Don't forget to pull this back into DEV aswell
