### PR TITLE
KAS-4472: Datum filter voor zoeken van dossiers geeft niet de verwachte resultaten

### DIFF
--- a/app/routes/search/all-types.js
+++ b/app/routes/search/all-types.js
@@ -92,7 +92,7 @@ export default class AllTypes extends Route {
             10,
             null,
             filter,
-            (searchData) => type.dataMapping(searchData, this.store),
+            (searchData) => type.dataMapping(searchData, this.store, params),
             {
               fields: type.highlightFields,
             }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4472

Use the `dateTo` parameter as the ceiling of the session date show in the case result card.