### PR TITLE
KAS-4452: Replace `store.query` with `store.queryAll`

### DIFF
--- a/app/components/agenda/agendaitem/agendaitem-postponed.js
+++ b/app/components/agenda/agendaitem/agendaitem-postponed.js
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
-import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 import { action } from '@ember/object';
 import subDays from 'date-fns/subDays';
 
@@ -77,17 +76,15 @@ export default class AgendaitemPostponed extends Component {
   @task
   *reProposeForMeeting(meeting) {
     this.closeProposingForOtherMeetingModal();
-    const submissionActivitiesFromAgendaActivity = yield this.store.query('submission-activity', {
+    const submissionActivitiesFromAgendaActivity = yield this.store.queryAll('submission-activity', {
       'filter[subcase][:id:]': this.args.subcase.id,
       'filter[agenda-activity][:id:]': this.args.agendaActivity.id,
-      'page[size]': PAGE_SIZE.ACTIVITIES,
       include: 'pieces', // Make sure we have all pieces, unpaginated
     });
     // there could be new submission-activities after finalizing agenda
-    const newSubmissionActivities = yield this.store.query('submission-activity', {
+    const newSubmissionActivities = yield this.store.queryAll('submission-activity', {
       'filter[subcase][:id:]': this.args.subcase.id,
       'filter[:has-no:agenda-activity]': true,
-      'page[size]': PAGE_SIZE.ACTIVITIES,
       include: 'pieces', // Make sure we have all pieces, unpaginated
     });
     const submissionActivities = [...submissionActivitiesFromAgendaActivity.toArray(), ...newSubmissionActivities.toArray()];

--- a/app/components/agenda/agendaitem/create-agendaitem.js
+++ b/app/components/agenda/agendaitem/create-agendaitem.js
@@ -82,7 +82,7 @@ export default class CreateAgendaitem extends Component {
     const subcasesToAdd = new Set([...this.selectedSubcases]);
     const agendaItems = [];
     for (const subcase of subcasesToAdd) {
-      let submissionActivities = yield this.store.query('submission-activity', {
+      let submissionActivities = yield this.store.queryAll('submission-activity', {
         'filter[subcase][:id:]': subcase.id,
         'filter[:has-no:agenda-activity]': true,
       });

--- a/app/components/cases/new-subcase.js
+++ b/app/components/cases/new-subcase.js
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 import { trimText } from 'frontend-kaleidos/utils/trim-util';
-import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { task } from 'ember-concurrency';
@@ -80,9 +79,8 @@ export default class CasesNewSubcase extends Component {
   async loadSubcasePieces(subcase) {
     // 2-step procees (submission-activity -> pieces). Querying pieces directly doesn't
     // work since the inverse isn't present in API config
-    const submissionActivities = await this.store.query('submission-activity', {
+    const submissionActivities = await this.store.queryAll('submission-activity', {
       'filter[subcase][:id:]': subcase.id,
-      'page[size]': PAGE_SIZE.CASES,
       include: 'pieces', // Make sure we have all pieces, unpaginated
     });
     const pieces = [];

--- a/app/components/documents/linked-documents.js
+++ b/app/components/documents/linked-documents.js
@@ -52,11 +52,8 @@ export default class DocumentsLinkedDocumentsComponent extends Component {
   *saveLinkedPieces() {
     let allPiecesToLink = [];
     for (const linkedPiece of this.newLinkedPieces) {
-      const linkedPieces = yield this.store.query('piece', {
+      const linkedPieces = yield this.store.queryAll('piece', {
         'filter[document-container][pieces][:id:]': linkedPiece.get('id'),
-        page: {
-          size: 300,
-        },
       });
       allPiecesToLink = [...allPiecesToLink, ...linkedPieces.toArray()];
     }

--- a/app/components/mandatees/checkbox-select.js
+++ b/app/components/mandatees/checkbox-select.js
@@ -36,7 +36,7 @@ export default class MandateesCheckboxSelect extends Component {
 
   loadMinisters = task(async () => {
     if (this.args.referenceAgenda) {
-      const mandatees = await this.store.query('mandatee', {
+      const mandatees = await this.store.queryAll('mandatee', {
         'filter[agendaitems][agenda][:id:]': this.args.referenceAgenda.id,
         include: 'person',
         sort: 'priority',

--- a/app/components/publications/overview/reports/generate-report-modal.js
+++ b/app/components/publications/overview/reports/generate-report-modal.js
@@ -151,7 +151,7 @@ export default class GenerateReportModalComponent extends Component {
 
   @task
   *loadGovernmentDomains() {
-    let governmentDomains = yield this.store.query('concept', {
+    let governmentDomains = yield this.store.queryAll('concept', {
       'filter[top-concept-schemes][:uri:]':
         CONSTANTS.CONCEPT_SCHEMES.BELEIDSDOMEIN,
       'filter[:has-no:broader]': true, // only top-level government-domains
@@ -159,7 +159,6 @@ export default class GenerateReportModalComponent extends Component {
         CONFIG.PUBLICATIONS_IN_KALEIDOS_START_DATE.getFullYear() && {
         'filter[deprecated]': false,
       }), // Exclude deprecated government domains when generating modern reports
-      'page[size]': 100,
     });
     this.governmentDomains = governmentDomains.toArray().sortBy('label');
     // everything selected by default

--- a/app/components/publications/publication/publication-navigation.js
+++ b/app/components/publications/publication/publication-navigation.js
@@ -19,11 +19,9 @@ export default class PublicationNavigation extends Component {
   *loadData() {
     const { publicationFlow } = this.args;
 
-    const pieces = yield this.store.query('piece', {
+    this.numberOfDocuments = yield this.store.count('piece', {
       'filter[publication-flow][:id:]': publicationFlow.id,
-      'page[size]': 1,
     });
-    this.numberOfDocuments = pieces.meta.count;
 
     this.isViaCouncilOfMinisters = this.publicationService.getIsViaCouncilOfMinisters(publicationFlow);
   }

--- a/app/components/signatures/status-filter.js
+++ b/app/components/signatures/status-filter.js
@@ -24,7 +24,7 @@ export default class SignaturesStatusFilterComponent extends Component {
 
   @task
   *loadStatuses() {
-    const statuses = yield this.store.query('concept', {
+    const statuses = yield this.store.queryAll('concept', {
       filter: {
         'concept-schemes': {
           ':uri:': CONSTANTS.CONCEPT_SCHEMES.SIGNFLOW_STATUSES,
@@ -35,7 +35,7 @@ export default class SignaturesStatusFilterComponent extends Component {
     if (statuses) {
       this.statusFilterItems = [];
       this.selectedStatuses = [];
-      for (const status of statuses) {
+      for (const status of statuses.slice()) {
         const statusItem = {
           label: status.label,
           value: status.id

--- a/app/components/subcase/subcase-description-panel/subcase-description-edit.js
+++ b/app/components/subcase/subcase-description-panel/subcase-description-edit.js
@@ -102,7 +102,7 @@ export default class SubcaseDescriptionEdit extends Component {
 
   async updateDecisionReports() {
     if (this.enableDigitalAgenda) {
-      const reports = await this.store.query('report', {
+      const reports = await this.store.queryAll('report', {
         'filter[decision-activity][subcase][:id:]': this.args.subcase.id,
         'filter[:has-no:next-piece]': true,
         sort: '-created',

--- a/app/components/subcase/subcase-description-panel/subcase-description-edit.js
+++ b/app/components/subcase/subcase-description-panel/subcase-description-edit.js
@@ -107,7 +107,7 @@ export default class SubcaseDescriptionEdit extends Component {
         'filter[:has-no:next-piece]': true,
         sort: '-created',
       });
-      for (const report of reports) {
+      for (const report of reports.slice()) {
         const pieceParts = await report?.pieceParts;
         if (pieceParts?.length) {
           await this.decisionReportGeneration.generateReplacementReport.perform(

--- a/app/components/subcase/timeline.js
+++ b/app/components/subcase/timeline.js
@@ -28,7 +28,7 @@ export default class SubcaseTimeline extends Component {
   @dropTask
   *loadSubcasePhases() {
     const phases = [];
-    const sortedAgendaActivities = yield this.store.query('agenda-activity', {
+    const sortedAgendaActivities = yield this.store.queryAll('agenda-activity', {
       'filter[subcase][:id:]': this.args.subcase.id,
       sort: 'start-date',
     });

--- a/app/components/subcases/proposable-meetings.js
+++ b/app/components/subcases/proposable-meetings.js
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
-import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 import { action } from '@ember/object';
 
 /**
@@ -28,14 +27,10 @@ export default class ProposableMeetings extends Component {
       filter: {
         ':has-no:agenda': true
       },
-      // high page size is mainly for testing, results will be < 5 in normal situations
-      page: {
-        size: PAGE_SIZE.MEETINGS,
-      },
       sort: 'planned-start',
       include: 'kind',
     };
-    this.meetings = yield this.store.query('meeting', queryParams);
+    this.meetings = yield this.store.queryAll('meeting', queryParams);
     this.datesToEnable = this.meetings.map((meeting) => meeting.plannedStart);
   }
 

--- a/app/components/subcases/subcase-header.js
+++ b/app/components/subcases/subcase-header.js
@@ -105,7 +105,7 @@ export default class SubcasesSubcaseHeaderComponent extends Component {
   *proposeForAgenda(meeting) {
     this.isAssigningToOtherAgenda = false;
     this.isLoading = true;
-    let submissionActivities = yield this.store.query('submission-activity', {
+    let submissionActivities = yield this.store.queryAll('submission-activity', {
       'filter[subcase][:id:]': this.args.subcase.id,
       'filter[:has-no:agenda-activity]': true,
     });

--- a/app/components/subcases/subcase-item.js
+++ b/app/components/subcases/subcase-item.js
@@ -4,7 +4,6 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { sortPieces } from 'frontend-kaleidos/utils/documents';
-import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 import VrLegacyDocumentName,
 { compareFunction as compareLegacyDocuments } from 'frontend-kaleidos/utils/vr-legacy-document-name';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
@@ -105,9 +104,6 @@ export default class SubcaseItemSubcasesComponent extends Component {
   *loadSubcaseDocuments() {
     // proceed to get the documents
     const queryParams = {
-      page: {
-        size: PAGE_SIZE.ACTIVITIES,
-      },
       include: 'pieces', // Make sure we have all pieces, unpaginated
       'filter[subcase][:id:]': this.args.subcase.id,
     };
@@ -119,7 +115,7 @@ export default class SubcaseItemSubcasesComponent extends Component {
     }
     // 2-step procees (submission-activity -> pieces). Querying pieces directly doesn't
     // work since the inverse isn't present in API config
-    const submissionActivities = yield this.store.query('submission-activity', queryParams);
+    const submissionActivities = yield this.store.queryAll('submission-activity', queryParams);
 
     const pieces = [];
     for (const submissionActivity of submissionActivities.toArray()) {

--- a/app/components/user-role-filter.js
+++ b/app/components/user-role-filter.js
@@ -37,7 +37,7 @@ export default class UserRoleFilterComponent extends Component {
 
   @task
   *loadData() {
-    this.roles = yield this.store.query('role', {
+    this.roles = yield this.store.queryAll('role', {
       filter: {
         'concept-scheme': {
           ':uri:': CONSTANTS.CONCEPT_SCHEMES.USER_ROLES,

--- a/app/config/config.js
+++ b/app/config/config.js
@@ -1,15 +1,9 @@
 export const PAGE_SIZE = {
   PUBLICATION_FLOWS: 10,
-  NOTAS: 50,
-  PUBLICATION_FLOW_PIECES: 200,
   CODE_LISTS: 100,
   AGENDAITEMS: 300,
   PIECES: 500,
-  ACTIVITIES: 500,
-  CASES: 500,
   SELECT: 10,
-  MANDATEES_IN_GOV_BODY: 300, // assumes max +- 20 gov body config changes for a 15-mandatee government (15 including doubles for vice-mp etc)
-  MEETINGS: 100,
 };
 
 export const LIVE_SEARCH_DEBOUNCE_TIME = 300;

--- a/app/routes/agenda.js
+++ b/app/routes/agenda.js
@@ -20,7 +20,7 @@ export default class AgendaRoute extends Route {
     const agenda = await this.store.findRecord('agenda', agendaId, {
       reload: true,
     });
-    const reverseSortedAgendas = await this.store.query('agenda', {
+    const reverseSortedAgendas = await this.store.queryAll('agenda', {
       'filter[created-for][:id:]': meetingId,
       sort: '-serialnumber',
       include: 'status',

--- a/app/routes/agenda/documents.js
+++ b/app/routes/agenda/documents.js
@@ -1,7 +1,6 @@
 import Route from '@ember/routing/route';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 import { sortPieces } from 'frontend-kaleidos/utils/documents';
-import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 import { inject as service } from '@ember/service';
 
 export default class AgendaDocumentsRoute extends Route {
@@ -9,9 +8,8 @@ export default class AgendaDocumentsRoute extends Route {
 
   async model() {
     const meeting = this.modelFor('agenda').meeting;
-    let pieces = await this.store.query('piece', {
+    let pieces = await this.store.queryAll('piece', {
       'filter[meeting][:id:]': meeting.id,
-      'page[size]': PAGE_SIZE.PIECES, // TODO add pagination when sorting is done in the backend
       include: 'document-container',
     });
     pieces = pieces.toArray();

--- a/app/routes/cases/case/subcases/subcase/documents.js
+++ b/app/routes/cases/case/subcases/subcase/documents.js
@@ -1,6 +1,5 @@
 import Route from '@ember/routing/route';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
-import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 import { inject as service } from '@ember/service';
 import { sortPieces } from 'frontend-kaleidos/utils/documents';
 import VrLegacyDocumentName,
@@ -15,10 +14,9 @@ export default class DocumentsSubcaseSubcasesRoute extends Route {
   async model() {
     this.subcase = this.modelFor('cases.case.subcases.subcase');
     // Get any submission that is not yet on a meeting
-    const submissionActivitiesWithoutActivity = await this.store.query('submission-activity', {
+    const submissionActivitiesWithoutActivity = await this.store.queryAll('submission-activity', {
       'filter[subcase][:id:]': this.subcase.id,
       'filter[:has-no:agenda-activity]': true,
-      'page[size]': PAGE_SIZE.ACTIVITIES,
       include: 'pieces,pieces.document-container', // Make sure we have all pieces, unpaginated
     });
     let submissionActivities = [...submissionActivitiesWithoutActivity.toArray()];
@@ -30,10 +28,9 @@ export default class DocumentsSubcaseSubcasesRoute extends Route {
         'filter[agendas][agendaitems][agenda-activity][:id:]': latestActivity.id,
         sort: '-planned-start',
       });
-      const submissionActivitiesFromLatestMeeting = await this.store.query('submission-activity', {
+      const submissionActivitiesFromLatestMeeting = await this.store.queryAll('submission-activity', {
         'filter[subcase][:id:]': this.subcase.id,
         'filter[agenda-activity][:id:]': latestActivity.id,
-        'page[size]': PAGE_SIZE.ACTIVITIES,
         include: 'pieces,pieces.document-container', // Make sure we have all pieces, unpaginated
       });
       submissionActivities.addObjects(submissionActivitiesFromLatestMeeting.toArray());

--- a/app/routes/mock-login.js
+++ b/app/routes/mock-login.js
@@ -11,16 +11,12 @@ export default class MockLoginRoute extends Route {
   }
 
   model() {
-    return this.store.query('account', {
+    return this.store.queryAll('account', {
       include: 'user',
       filter: {
         provider: CONSTANTS.SERVICE_PROVIDERS.MOCK_LOGIN,
       },
       sort: 'user.memberships.role.position,user.first-name,user.last-name',
-      page: {
-        size: 100,
-        number: 0,
-      },
     });
   }
 }

--- a/app/routes/newsletter/index.js
+++ b/app/routes/newsletter/index.js
@@ -1,6 +1,5 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 
 export default class IndexNewsletterRoute extends Route {
@@ -30,7 +29,6 @@ export default class IndexNewsletterRoute extends Route {
       },
       include: 'treatment.news-item',
       sort: params.sort,
-      'page[size]': PAGE_SIZE.AGENDAITEMS,
     });
 
     // The approval items should not be shown on newsletter views

--- a/app/routes/newsletter/index.js
+++ b/app/routes/newsletter/index.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
+import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 
 export default class IndexNewsletterRoute extends Route {
   @service store;
@@ -29,6 +30,7 @@ export default class IndexNewsletterRoute extends Route {
       },
       include: 'treatment.news-item',
       sort: params.sort,
+      'page[size]': PAGE_SIZE.AGENDAITEMS,
     });
 
     // The approval items should not be shown on newsletter views

--- a/app/routes/newsletter/nota-updates.js
+++ b/app/routes/newsletter/nota-updates.js
@@ -1,7 +1,6 @@
 import Route from '@ember/routing/route';
 import { A } from '@ember/array';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
-import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 import {
   task, timeout
 } from 'ember-concurrency';
@@ -37,7 +36,7 @@ export default class NewsletterNotaUpdatesRoute extends Route {
     const agenda = newsletterModel.agenda;
     const agendaId = agenda.id;
     const meetingId = meeting.id;
-    const notas = await this.store.query('piece', {
+    const notas = await this.store.queryAll('piece', {
       'filter[agendaitems][agenda][:id:]': agendaId,
       'filter[agendaitems][type][:uri:]': CONSTANTS.AGENDA_ITEM_TYPES.NOTA,
       'filter[document-container][type][:uri:]': CONSTANTS.DOCUMENT_TYPES.NOTA,
@@ -45,7 +44,6 @@ export default class NewsletterNotaUpdatesRoute extends Route {
       include: 'agendaitems',
       'fields[agendaitems]': 'id,number,short-title',
       'fields[piece]': 'id,name,modified',
-      'page[size]': PAGE_SIZE.NOTAS,
       sort: params.sort,
     });
     for (const nota of notas.toArray()) { // proxyarray to native JS array

--- a/app/routes/newsletter/print.js
+++ b/app/routes/newsletter/print.js
@@ -8,6 +8,7 @@ import {
   sortByNumber
 } from 'frontend-kaleidos/utils/agendaitem-utils';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
+import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 
 export default class PrintNewsletterRoute extends Route {
   queryParams = {
@@ -34,6 +35,7 @@ export default class PrintNewsletterRoute extends Route {
       },
       include: 'treatment.news-item',
       sort: 'number',
+      'page[size]': PAGE_SIZE.AGENDAITEMS,
     });
 
     // The approval items should not be shown on newsletter views

--- a/app/routes/newsletter/print.js
+++ b/app/routes/newsletter/print.js
@@ -7,7 +7,6 @@ import {
   groupAgendaitemsByGroupname,
   sortByNumber
 } from 'frontend-kaleidos/utils/agendaitem-utils';
-import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 
 export default class PrintNewsletterRoute extends Route {
@@ -35,7 +34,6 @@ export default class PrintNewsletterRoute extends Route {
       },
       include: 'treatment.news-item',
       sort: 'number',
-      'page[size]': PAGE_SIZE.AGENDAITEMS,
     });
 
     // The approval items should not be shown on newsletter views

--- a/app/routes/publications/publication/decisions/index.js
+++ b/app/routes/publications/publication/decisions/index.js
@@ -1,6 +1,5 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 
 export default class PublicationsPublicationDecisionsIndexRoute extends Route {
   @service store;
@@ -8,9 +7,8 @@ export default class PublicationsPublicationDecisionsIndexRoute extends Route {
 
   async model() {
     const parentParams = this.paramsFor('publications.publication');
-    const pieces = await this.store.query('piece', {
+    const pieces = await this.store.queryAll('piece', {
       'filter[publication-flow][:id:]': parentParams.publication_id,
-      'page[size]': PAGE_SIZE.PUBLICATION_FLOW_PIECES,
       include: [
         'file',
         'document-container',

--- a/app/routes/publications/publication/proofs/index.js
+++ b/app/routes/publications/publication/proofs/index.js
@@ -62,14 +62,14 @@ export default class PublicationsPublicationProofsRoute extends Route {
   async model() {
     this.publicationSubcase = this.modelFor('publications.publication.proofs');
 
-    let requestActivities = this.store.query('request-activity', {
+    let requestActivities = this.store.queryAll('request-activity', {
       'filter[publication-subcase][:id:]': this.publicationSubcase.id,
       'filter[:has:proofing-activity]': true,
       include: 'email,used-pieces,used-pieces.file',
       sort: '-start-date',
     });
 
-    let proofingActivities = this.store.query('proofing-activity', {
+    let proofingActivities = this.store.queryAll('proofing-activity', {
       'filter[subcase][:id:]': this.publicationSubcase.id,
       include: [
         'used-pieces',

--- a/app/routes/publications/publication/publication-activities/index.js
+++ b/app/routes/publications/publication/publication-activities/index.js
@@ -52,7 +52,7 @@ export default class PublicationsPublicationPublicationActivitiesIndexRoute exte
       'publications.publication.publication-activities'
     );
 
-    let requestActivities = this.store.query('request-activity', {
+    let requestActivities = this.store.queryAll('request-activity', {
       'filter[publication-subcase][:id:]': this.publicationSubcase.id,
       'filter[:has:publication-activity]': true,
       // eslint-disable-next-line prettier/prettier
@@ -62,7 +62,7 @@ export default class PublicationsPublicationPublicationActivitiesIndexRoute exte
         'used-pieces.file'
       ].join(','),
     });
-    let publicationActivities = this.store.query('publication-activity', {
+    let publicationActivities = this.store.queryAll('publication-activity', {
       'filter[subcase][:id:]': this.publicationSubcase.id,
       // eslint-disable-next-line prettier/prettier
       include: [

--- a/app/routes/publications/publication/translations/index.js
+++ b/app/routes/publications/publication/translations/index.js
@@ -66,13 +66,13 @@ export default class PublicationsPublicationTranslationsIndexRoute extends Route
       'publications.publication.translations'
     );
 
-    const requestActivities = await this.store.query('request-activity', {
+    const requestActivities = await this.store.queryAll('request-activity', {
       'filter[translation-subcase][:id:]': this.translationSubcase.id,
       include: 'email,used-pieces,used-pieces.file',
       sort: '-start-date',
     });
 
-    const translationActivities = await this.store.query(
+    const translationActivities = await this.store.queryAll(
       'translation-activity',
       {
         'filter[subcase][:id:]': this.translationSubcase.id,

--- a/app/services/mandatees.js
+++ b/app/services/mandatees.js
@@ -1,6 +1,5 @@
 import Service, { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
-import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 
 const DEFAULT_VISIBLE_ROLES = [
@@ -71,7 +70,7 @@ export default class MandateesService extends Service {
   @task
   *fetchGovernmentBodies(referenceDateFrom, referenceDateTo) {
     const governmentBodies = [];
-    const closedInRange = this.store.query('government-body', {
+    const closedInRange = this.store.queryAll('government-body', {
       'filter[is-timespecialization-of][:has:is-timespecialization-of]': 'yes',
       'filter[generation][:lt:time]': referenceDateTo.toISOString(),
       'filter[invalidation][:gte:time]': referenceDateFrom.toISOString(),
@@ -112,7 +111,6 @@ export default class MandateesService extends Service {
       'filter[mandate][role][:id:]': visibleRoles
         .map((role) => role.id)
         .join(','),
-      'page[size]': PAGE_SIZE.MANDATEES_IN_GOV_BODY,
     };
     if (searchText) {
       queryOptions['filter[person][last-name]'] = searchText;
@@ -126,7 +124,7 @@ export default class MandateesService extends Service {
       // mu-cl-resources doesn't have :has-no:-capability for simple properties (which end-date is)
       // That's why we do some filtering client-side (see below)
     }
-    let mandatees = yield this.store.query('mandatee', queryOptions);
+    let mandatees = yield this.store.queryAll('mandatee', queryOptions);
     // We need to filter out the mandatees that are in the body
     // but have an end date before the range starts or active mandatees (i.e. no end date)
     if (referenceDateFrom) {

--- a/app/services/newsletter-service.js
+++ b/app/services/newsletter-service.js
@@ -1,6 +1,5 @@
 import Service, { inject as service } from '@ember/service';
 import fetch from 'fetch';
-import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 
 export default class NewsletterService extends Service {
@@ -171,12 +170,9 @@ export default class NewsletterService extends Service {
       sort: '-agendaitems.agenda-activity.start-date',
     });
     if (treatment) {
-      let mandatees = await this.store.query('mandatee', {
+      let mandatees = await this.store.queryAll('mandatee', {
         'filter[subcases][decision-activities][treatment][:id:]': treatment.id,
         sort: 'priority',
-        page: {
-          size: PAGE_SIZE.MANDATEES_IN_GOV_BODY,
-        },
       });
 
       if (!mandatees.length) {

--- a/app/services/piece-access-level-service.js
+++ b/app/services/piece-access-level-service.js
@@ -1,6 +1,5 @@
 import Service, { inject as service } from '@ember/service';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
-import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 
 /*
  * This service is used to make necessary changes to access levels of certain pieces when an access level
@@ -140,7 +139,7 @@ export default class PieceAccessLevelService extends Service {
    * "Vertrouwelijk" access level.
    */
   async updateDecisionsAccessLevelOfSubcase(subcase) {
-    const reports = await this.store.query('report', {
+    const reports = await this.store.queryAll('report', {
       'filter[decision-activity][subcase][:id:]': subcase.id,
       include: 'access-level',
     });
@@ -157,10 +156,9 @@ export default class PieceAccessLevelService extends Service {
    */
 
   async updateSubmissionAccessLevelOfSubcase(subcase) {
-    const pieces = await this.store.query('piece', {
+    const pieces = await this.store.queryAll('piece', {
       'filter[submission-activity][subcase][:id:]': subcase.id,
       'filter[:has-no:next-piece]': true,
-      'page[size]': PAGE_SIZE.PIECES,
     });
     
     await Promise.all(pieces.toArray().map(async (piece) => {

--- a/cypress/e2e/unit/document-version.cy.js
+++ b/cypress/e2e/unit/document-version.cy.js
@@ -23,7 +23,7 @@ context('Tests on pieces and page-sizes of agendaitems and subcase', () => {
     const amountOfDocs = 25;
 
     // verify more than 20 docs are showing on agendaitem (default page-size is capped at 20, needed to artificially increase)
-    cy.intercept('GET', '/pieces?filter**agendaitems**page**size**500').as('getPiecesOfAgendaitem');
+    cy.intercept('GET', '/pieces?filter**agendaitems**').as('getPiecesOfAgendaitem');
     cy.visitAgendaWithLink('/vergadering/5EBA94D7751CF70008000001/agenda/5EBA94D8751CF70008000002/agendapunten/5EBA9512751CF70008000008/documenten');
     cy.wait('@getPiecesOfAgendaitem', {
       timeout: 60000,
@@ -32,7 +32,7 @@ context('Tests on pieces and page-sizes of agendaitems and subcase', () => {
 
     // verify more than 20 docs are showing from 1 submission-activity on subcase
     // (default page size submissActivity.pieces is not increased, but all pieces are included in a query)
-    cy.intercept('GET', '/submission-activities?filter**subcase**include**pieces**page**size**500').as('getPiecesOfSubcase');
+    cy.intercept('GET', '/submission-activities?filter**subcase**include**pieces**').as('getPiecesOfSubcase');
     cy.visit('/dossiers/E14FB5E6-3347-11ED-B8A0-F82C0F9DE1CF/deeldossiers/5EBA94F7751CF70008000007/documenten');
     cy.wait('@getPiecesOfSubcase', {
       timeout: 60000,

--- a/cypress/e2e/unit/news-item.cy.js
+++ b/cypress/e2e/unit/news-item.cy.js
@@ -1,4 +1,4 @@
-/* global context, beforeEach, afterEach, it, cy */
+/* global Cypress, context, beforeEach, afterEach, it, cy */
 // / <reference types="Cypress" />
 
 import agenda from '../../selectors/agenda.selectors';
@@ -39,6 +39,7 @@ function changeSubcaseType(subcaseLink, type) {
 context('newsletter tests, both in agenda detail view and newsletter route', () => {
   const theme = 'Justitie en Handhaving';
   const theme2 = 'Landbouw en Visserij';
+  const isCI = Cypress.env('CI');
 
   beforeEach(() => {
     cy.login('Admin');
@@ -611,7 +612,12 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
     cy.visit(newsletterLink);
     cy.clickReverseTab('Definitief');
     // actual time is 14:00, but server time is being used as "local time" in the test it seems
-    cy.get(newsletter.newsletterPrintHeader.publicationPlannedDate).contains('11 april 2022 - 12:00');
+    if (isCI) {
+      cy.get(newsletter.newsletterPrintHeader.publicationPlannedDate).contains('11 april 2022 - 12:00');
+    } else {
+      cy.get(newsletter.newsletterPrintHeader.publicationPlannedDate).contains('11 april 2022 - 14:00');
+    }
+
     cy.get(newsletter.newsletterPrint.container).should('have.length', 1);
     cy.get(newsletter.newsletterPrint.title).contains(subcaseTitleMededeling);
     cy.get(newsletter.newsletterPrint.printItemProposal).should('not.exist');


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4452

Where applicable and necessary calls to `store.query` are replaced with calls to `store.queryAll`. In most of the places this is done just for consistency's sake, though a couple of cases were found where `store.query` was used which could lead too little results being shown or linked.

The ticket contains an attachment with a spreadsheet where each case is listed, specified what was done and why.