### PR TITLE
added new indentation and fixed au-c-content bug

### DIFF
--- a/app/components/agenda/agendaitem/agendaitem-decision.hbs
+++ b/app/components/agenda/agendaitem/agendaitem-decision.hbs
@@ -218,7 +218,6 @@
         <Auk::Panel::Body
           class="au-o-flow {{if this.isEditing 'au-u-background-gray-100'}}"
         >
-          <AuContent @size="small">
         {{#if (and this.isEditingAnnotation this.mayEditDecisionReport)}}
            <h4 class="auk-h4">{{t "annotation"}}</h4>
            <AuInput
@@ -251,37 +250,39 @@
              </Auk::Toolbar::Group>
            </Auk::Toolbar>
            {{else}}
-           <Auk::Toolbar @auto={{true}} as |Toolbar|>
-             <Toolbar.Group @position="left">
-               <h4 class="auk-toolbar__title">
-                   {{t "annotation"}}:
-               </h4>
-             </Toolbar.Group>
-             <Toolbar.Group @position="right" as |Group|>
-               {{#if 
-                  (and
-                     (not this.isEditingAnnotation)
-                     this.mayEditDecisionReport
-                   )
-                 }}
-                   <Group.Item>
-                     <AuButton
-                       @skin="naked"
-                       @icon="pencil"
-                       @iconAlignment="left"
-                       @disabled={{this.saveReport.isRunning}}
-                       {{on "click" this.startEditingAnnotation}}
-                     >
-                       {{t "edit"}}
-                     </AuButton>
-                   </Group.Item>
-                 {{/if}}
-             </Toolbar.Group>
-           </Auk::Toolbar>
-         <SanitizeHtml
-           @raw={{true}}
-           @value={{this.annotatiePiecePart.htmlContent}}
-         />
+             <Auk::Toolbar @auto={{true}} as |Toolbar|>
+               <Toolbar.Group @position="left">
+                 <h4 class="auk-toolbar__title">
+                     {{t "annotation"}}:
+                 </h4>
+               </Toolbar.Group>
+               <Toolbar.Group @position="right" as |Group|>
+                 {{#if
+                    (and
+                       (not this.isEditingAnnotation)
+                       this.mayEditDecisionReport
+                     )
+                   }}
+                     <Group.Item>
+                       <AuButton
+                         @skin="naked"
+                         @icon="pencil"
+                         @iconAlignment="left"
+                         @disabled={{this.saveReport.isRunning}}
+                         {{on "click" this.startEditingAnnotation}}
+                       >
+                         {{t "edit"}}
+                       </AuButton>
+                     </Group.Item>
+                   {{/if}}
+               </Toolbar.Group>
+             </Auk::Toolbar>
+             <AuContent @size="small">
+               <SanitizeHtml
+                 @raw={{true}}
+                 @value={{this.annotatiePiecePart.htmlContent}}
+               />
+             </AuContent>
         {{/if}}
         {{#if (and this.isEditingConcern this.mayEditDecisionReport)}}
            <h4 class="auk-h4">{{t "concerns"}}</h4>
@@ -360,10 +361,12 @@
                     {{/if}}
                 </Toolbar.Group>
               </Auk::Toolbar>
-            <SanitizeHtml
-              @raw={{true}}
-              @value={{this.betreftPiecePart.htmlContent}}
-            />
+              <AuContent @size="small">
+                <SanitizeHtml
+                  @raw={{true}}
+                  @value={{this.betreftPiecePart.htmlContent}}
+                />
+              </AuContent>
             {{/if}}
              {{#if (and this.isEditingTreatment this.mayEditDecisionReport)}}
               <h4 class="auk-h4 au-u-padding-top">{{t "agendaitem-decision"}}</h4>
@@ -442,12 +445,13 @@
                     {{/if}}
                   </Toolbar.Group>
               </Auk::Toolbar>
-            <SanitizeHtml
-              @raw={{true}}
-              @value={{this.beslissingPiecePart.htmlContent}}
-            />
+              <AuContent @size="small">
+                <SanitizeHtml
+                  @raw={{true}}
+                  @value={{this.beslissingPiecePart.htmlContent}}
+                />
+              </AuContent>
             {{/if}}
-          </AuContent>
         </Auk::Panel::Body>
       {{/if}}
     {{/if}}

--- a/app/styles/addon-overrides/_ember-rdfa-editor.scss
+++ b/app/styles/addon-overrides/_ember-rdfa-editor.scss
@@ -129,6 +129,14 @@ $say-editor-border-radius: $au-input-border-radius;
     ol {
       padding-left: 3.8rem;
     }
+
+    &[data-list-style='upper-alpha'] {
+      padding-left: 2.9rem;
+
+      ol {
+        padding-left: 1.9rem;
+      }
+    }
   }
 
   @mixin decimal-extended-styling($levels, $current-level: 1) {

--- a/app/styles/au/_au-components.scss
+++ b/app/styles/au/_au-components.scss
@@ -541,6 +541,10 @@ $au-label-color: var(--au-gray-700);
 
     &[data-list-style='upper-alpha'] {
       list-style-type: upper-alpha;
+      margin-left: 2rem;
+      ol {
+        margin-left: 2rem;
+      }
     }
   }
 


### PR DESCRIPTION
The editors for decisions were wrapped in `AuContent`, causing the styling to be messed up in `sayeditor`.

Fixed that, as well as what we think the secretarie wants for `upper-alpha` lists