### PR TITLE
KAS-4483: Accesslevel pills staan te dicht bij tekst in afdrukbare versie agenda

### DIFF
--- a/app/components/agenda/printable-agenda/list-section/item-group/item/document.hbs
+++ b/app/components/agenda/printable-agenda/list-section/item-group/item/document.hbs
@@ -1,4 +1,6 @@
 <span>({{@piece.name}})</span>
 {{#if this.showAccessLevel}}
-  <AccessLevelPill @accessLevel={{@accessLevel}} />
+  <div class="auk-u-ml-2">
+    <AccessLevelPill @accessLevel={{@accessLevel}} />
+  </div>
 {{/if}}


### PR DESCRIPTION
**Tickets binnen Jira:** 
- https://kanselarij.atlassian.net/browse/KAS-4483

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.