### PR TITLE
KAS-4104 replace mapBy with map

### DIFF
--- a/app/components/cases/subcases/government-areas-panel.js
+++ b/app/components/cases/subcases/government-areas-panel.js
@@ -54,7 +54,7 @@ export default class GovernmentAreasPanel extends Component {
   @task
   *calculateDomainSelections() {
     let domainsFromAvailableFields = yield Promise.all(
-      this.governmentFields.mapBy('broader')
+      this.governmentFields.map((c) => c.broader)
     );
 
     let uniqueDomains = domainsFromAvailableFields
@@ -77,7 +77,7 @@ export default class GovernmentAreasPanel extends Component {
     }
 
     const domainsFromSelectedFields = yield Promise.all(
-      selectedFields.mapBy('broader')
+      selectedFields.map((c) => c.broader)
     );
 
     // construct a DomainSelection for each active domain with its fields

--- a/app/components/publications/overview/publications-table-row.js
+++ b/app/components/publications/overview/publications-table-row.js
@@ -64,7 +64,7 @@ export default class PublicationsTableRowComponent extends Component {
   async getTranslationRequestDate(publicationFlow) {
     const publicationSubcase = await publicationFlow.translationSubcase;
     const translationActivities = await publicationSubcase.translationActivities;
-    const requestDates = translationActivities.mapBy('startDate').filter(d => d);
+    const requestDates = translationActivities.map((a) => a.startDate).filter(d => d);
     return requestDates.length ? maxDate(requestDates) : null;
   }
 
@@ -72,7 +72,7 @@ export default class PublicationsTableRowComponent extends Component {
   async getProofRequestDate(publicationFlow) {
     const publicationSubcase = await publicationFlow.publicationSubcase;
     const proofingActivities = await publicationSubcase.proofingActivities;
-    const requestDates = proofingActivities.mapBy('startDate').filter(d => d);
+    const requestDates = proofingActivities.map((a) => a.startDate).filter(d => d);
     return requestDates.length ? maxDate(requestDates) : null;
   }
 
@@ -80,7 +80,7 @@ export default class PublicationsTableRowComponent extends Component {
   async getProofReceivedDate(publicationFlow) {
     const publicationSubcase = await publicationFlow.publicationSubcase;
     const proofingActivities = await publicationSubcase.proofingActivities;
-    const receivedDates = proofingActivities.mapBy('endDate').filter(d => d);
+    const receivedDates = proofingActivities.map((a) => a.endDate).filter(d => d);
     return receivedDates.length ? maxDate(receivedDates) : null;
   }
 

--- a/app/components/publications/overview/reports/generate-report-modal.js
+++ b/app/components/publications/overview/reports/generate-report-modal.js
@@ -244,7 +244,7 @@ export default class GenerateReportModalComponent extends Component {
 
     if (this.args.userInputFields.mandateePersons) {
       if (this.selectedMandateePersons.length) {
-        const mandateePersons = this.selectedMandateePersons.mapBy('uri');
+        const mandateePersons = this.selectedMandateePersons.map((p) => p.uri);
         filterParams.mandateePersons = mandateePersons;
       }
     }

--- a/app/components/utils/government-areas/area-selector/government-area-selector-form.js
+++ b/app/components/utils/government-areas/area-selector/government-area-selector-form.js
@@ -27,7 +27,7 @@ export default class GovernmentAreaSelectorForm extends Component {
     // Step 2: use the array of step 1 to verify whether the domain fetched for the field is the current domain
     const availableFields = this.args.availableFields ?? [];
     let domainsFromAvailableFields = yield Promise.all(
-      availableFields.mapBy('broader')
+      availableFields.map((c) => c.broader)
     );
 
     let uniqueDomains = domainsFromAvailableFields
@@ -36,7 +36,7 @@ export default class GovernmentAreaSelectorForm extends Component {
 
     const selectedFields = this.args.selectedFields ?? [];
     const domainsFromSelectedFields = yield Promise.all(
-      selectedFields.mapBy('broader')
+      selectedFields.map((c) => c.broader)
     );
 
     const selectedDomains = this.args.selectedDomains ?? [];

--- a/app/controllers/publications/publication/translations/index.js
+++ b/app/controllers/publications/publication/translations/index.js
@@ -149,7 +149,7 @@ export default class PublicationsPublicationTranslationsIndexController extends 
     }
 
     const [files, outbox, mailSettings] = yield Promise.all([
-      Promise.all(pieces.mapBy('file')),
+      Promise.all(pieces.map((p) => p.file)),
       this.store.findRecordByUri('mail-folder', PUBLICATION_EMAIL.OUTBOX),
       this.store.queryOne('email-notification-setting'),
     ]);

--- a/app/routes/publications/overview/late.js
+++ b/app/routes/publications/overview/late.js
@@ -20,7 +20,7 @@ export default class PublicationsOverviewLateRoute extends PublicationsOverviewB
     const pendingStatuses = this.store.peekAll('publication-status').rejectBy('isFinal');
     this.filter = {
       status: {
-        ':id:': pendingStatuses.mapBy('id').join(','),
+        ':id:': pendingStatuses.map((s) => s.id).join(','),
       },
       'publication-subcase': {
         // notice: target-end-date is datetime but appears as a date to the user

--- a/app/routes/publications/overview/proof.js
+++ b/app/routes/publications/overview/proof.js
@@ -30,7 +30,7 @@ export default class PublicationsOverviewProofRoute extends PublicationsOverview
     });
     this.filter = {
       status: {
-        ':id:': proofStatuses.mapBy('id').join(','),
+        ':id:': proofStatuses.map((s) => s.id).join(','),
       },
     };
   }

--- a/app/routes/publications/overview/proofread.js
+++ b/app/routes/publications/overview/proofread.js
@@ -31,7 +31,7 @@ export default class PublicationsOverviewProofreadRoute extends PublicationsOver
     });
     this.filter = {
       status: {
-        ':id:': proofreadStatuses.mapBy('id').join(','),
+        ':id:': proofreadStatuses.map((s) => s.id).join(','),
       },
     };
   }

--- a/app/routes/publications/overview/urgent.js
+++ b/app/routes/publications/overview/urgent.js
@@ -24,7 +24,7 @@ export default class PublicationsOverviewUrgentRoute extends PublicationsOvervie
         ':uri:': CONSTANTS.URGENCY_LEVELS.SPEEDPROCEDURE,
       },
       status: {
-        ':id:': allStatusesExceptPublished.mapBy('id').join(','),
+        ':id:': allStatusesExceptPublished.map((s) => s.id).join(','),
       },
     };
   }

--- a/app/routes/publications/publication/proofs/index.js
+++ b/app/routes/publications/publication/proofs/index.js
@@ -11,7 +11,7 @@ export class TimelineActivity {
     if (row.isProofingActivity) {
       let pieces = await row.activity.generatedPieces;
       pieces = pieces.toArray();
-      let publicationActivities = pieces.mapBy('publicationActivitiesUsedBy');
+      let publicationActivities = pieces.map((a) => a.publicationActivitiesUsedBy);
       publicationActivities = await Promise.all(publicationActivities);
       publicationActivities = publicationActivities.map((publicationActivities) => publicationActivities.toArray());
       publicationActivities = publicationActivities.flat();

--- a/app/routes/publications/publication/translations/index.js
+++ b/app/routes/publications/publication/translations/index.js
@@ -15,7 +15,7 @@ export class TimelineActivity {
       ]);
       pieces = pieces.map((pieces) => pieces.toArray());
       pieces = pieces.flat();
-      let proofingActivities = pieces.mapBy('proofingActivitiesUsedBy');
+      let proofingActivities = pieces.map((a) => a.proofingActivitiesUsedBy);
       proofingActivities = await Promise.all(proofingActivities);
       proofingActivities = proofingActivities.map((proofingActivities) => proofingActivities.toArray());
       proofingActivities = proofingActivities.flat();

--- a/app/services/publication-service.js
+++ b/app/services/publication-service.js
@@ -335,7 +335,7 @@ export default class PublicationService extends Service {
     await proofingActivity.save();
 
     const [files, outbox, mailSettings] = await Promise.all([
-      Promise.all(pieces.mapBy('file')),
+      Promise.all(pieces.map((p) => p.file)),
       this.store.findRecordByUri('mail-folder', PUBLICATION_EMAIL.OUTBOX),
       this.store.queryOne('email-notification-setting'),
     ]);
@@ -396,7 +396,7 @@ export default class PublicationService extends Service {
     await publicationActivity.save();
 
     const [files, outbox, mailSettings] = await Promise.all([
-      Promise.all(pieces.mapBy('file')),
+      Promise.all(pieces.map((p) => p.file)),
       this.store.findRecordByUri('mail-folder', PUBLICATION_EMAIL.OUTBOX),
       this.store.queryOne('email-notification-setting'),
     ]);

--- a/app/services/system-alert.js
+++ b/app/services/system-alert.js
@@ -62,8 +62,12 @@ export default class SystemAlertService extends Service {
       },
     });
     // Ensure that the client-local "confirmed" mark doesn't get erased when refreshing
-    const confirmedAlertIds = this.alerts.filterBy('confirmed').map((a) => a.id);
-    const prevConfirmedAlerts = alerts.filter((alert) => confirmedAlertIds.includes(alert.id));
+    const confirmedAlertIds = this.alerts
+      .filter((alert) => alert.confirmed)
+      .map((alert) => alert.id);
+    const prevConfirmedAlerts = alerts.filter((alert) =>
+      confirmedAlertIds.includes(alert.id)
+    );
     prevConfirmedAlerts.setEach('confirmed', true);
 
     this.alerts = A(alerts);

--- a/app/services/system-alert.js
+++ b/app/services/system-alert.js
@@ -62,7 +62,7 @@ export default class SystemAlertService extends Service {
       },
     });
     // Ensure that the client-local "confirmed" mark doesn't get erased when refreshing
-    const confirmedAlertIds = this.alerts.filterBy('confirmed').mapBy('id');
+    const confirmedAlertIds = this.alerts.filterBy('confirmed').map((a) => a.id);
     const prevConfirmedAlerts = alerts.filter((alert) => confirmedAlertIds.includes(alert.id));
     prevConfirmedAlerts.setEach('confirmed', true);
 

--- a/app/utils/agendaitem-utils.js
+++ b/app/utils/agendaitem-utils.js
@@ -170,7 +170,7 @@ export class AgendaitemGroup {
 
   static generateMandateeGroupId(sortedMandatees) {
     // Assumes mandatees to be sorted
-    return sortedMandatees.mapBy('id').join();
+    return sortedMandatees.map((m) => m.id).join();
   }
 
   /**

--- a/app/utils/publication-email.js
+++ b/app/utils/publication-email.js
@@ -95,7 +95,7 @@ function proofRequestEmail(params) {
 function publicationRequestEmail(params) {
   const targetEndDate = params.targetEndDate ? dateFormat(params.targetEndDate, 'dd-MM-yyyy') : '-';
   const numacNumbers = params.numacNumbers
-        ? params.numacNumbers.mapBy('idName').join(', ')
+        ? params.numacNumbers.map((n) => n.idName).join(', ')
         : '-';
   let subject = '';
 


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4104

earlier PR was too large and old.
Separating into individual PR's per issue (hopefully easier/faster to merge...)


replace all occurrences of `mapBy('property')` to `map((x) => (x.property))`
replace 1 occurrence of `filterBy` in combination of `mapBy`  (`filterBy` only used 3 times, not worth its own PR)