### PR TITLE
Feature/kas 4104 array like sort by

### DIFF
--- a/app/components/agenda/agenda-header/agenda-actions.js
+++ b/app/components/agenda/agenda-header/agenda-actions.js
@@ -133,7 +133,7 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
     const agendaitems = await this.args.currentAgenda.agendaitems;
     return agendaitems
       .filter((agendaitem) => [CONSTANTS.ACCEPTANCE_STATUSSES.NOT_OK, CONSTANTS.ACCEPTANCE_STATUSSES.NOT_YET_OK].includes(agendaitem.formallyOk))
-      .sortBy('number');
+      .sort((a1, a2) => a1.number - a2.number);
   }
 
   @task

--- a/app/components/agenda/agenda-header/agenda-version-actions.js
+++ b/app/components/agenda/agenda-header/agenda-version-actions.js
@@ -145,7 +145,7 @@ export default class AgendaAgendaHeaderAgendaVersionActions extends Component {
     const agendaitems = await this.args.currentAgenda.agendaitems;
     return agendaitems
       .filter((agendaitem) => [CONSTANTS.ACCEPTANCE_STATUSSES.NOT_OK, CONSTANTS.ACCEPTANCE_STATUSSES.NOT_YET_OK].includes(agendaitem.formallyOk))
-      .sortBy('number');
+      .sort((a1, a2) => a1.number - a2.number);
   }
 
   @bind

--- a/app/components/agenda/printable-agenda/list-section/item-group.hbs
+++ b/app/components/agenda/printable-agenda/list-section/item-group.hbs
@@ -15,7 +15,7 @@
             {{#if mandatees}}
               {{#each mandatees as |mandatee|}}
                 {{mandatee.title}}
-                {{#if (not-eq mandatee mandatees.lastObject)}}
+                {{#if (has-next mandatee mandatees)}}
                   <br />&
                 {{/if}}
               {{/each}}
@@ -30,7 +30,7 @@
           />
         </div>
       </div>
-      {{#if first.pieces}}
+      {{#if (await first.pieces)}}
         <Agenda::PrintableAgenda::ListSection::ItemGroup::Item::DocumentList
           @pieces={{first.pieces}}
         />
@@ -45,7 +45,7 @@
             @item={{agendaitem}}
           />
         </div>
-        {{#if @item.pieces}}
+        {{#if (await @item.pieces)}}
           <Agenda::PrintableAgenda::ListSection::ItemGroup::Item::DocumentList
             @pieces={{agendaitem.pieces}}
           />

--- a/app/components/agenda/printable-agenda/list-section/item-group.js
+++ b/app/components/agenda/printable-agenda/list-section/item-group.js
@@ -1,8 +1,21 @@
 import Component from '@glimmer/component';
+import { TrackedArray } from 'tracked-built-ins';
+import { resource, use } from 'ember-resources';
 
 export default class AgendaPrintableAgendaListSectionItemGroupComponent extends Component {
 
-  get sortedMandateesFromFirst() {
-    return this.args.items.firstObject.mandatees.sortBy('priority');
-  }
+  @use sortedMandateesFromFirst = resource(() => {
+    const sortedMandatees = new TrackedArray([]);
+    const calculateSortedMandatees = async () => {
+      sortedMandatees.length = 0;
+      const agendaitem = this.args.items.at(0);
+      const mandatees = await agendaitem.mandatees;
+      mandatees
+        .slice()
+        .sort((m1, m2) => m1.priority - m2.priority)
+        .forEach((mandatee) => sortedMandatees.push(mandatee));
+    };
+    calculateSortedMandatees();
+    return sortedMandatees;
+  });
 }

--- a/app/components/agenda/printable-agenda/list-section/item-group/item/document-list.js
+++ b/app/components/agenda/printable-agenda/list-section/item-group/item/document-list.js
@@ -1,9 +1,19 @@
 import Component from '@glimmer/component';
+import { TrackedArray } from 'tracked-built-ins';
+import { resource, use } from 'ember-resources';
 import { sortPieces } from 'frontend-kaleidos/utils/documents';
 
 export default class AgendaPrintableAgendaListSectionItemGroupItemDocumentListComponent extends Component {
 
-  get sortedPieces() {
-    return sortPieces(this.args.pieces.slice());
-  }
+  @use sortedPieces = resource(() => {
+    const sortedPieces = new TrackedArray([]);
+    const calculateSortedPieces = async () => {
+      sortedPieces.length = 0;
+      const pieces = await this.args.pieces;
+      sortPieces(pieces)
+        .forEach((piece) => sortedPieces.push(piece));
+    };
+    calculateSortedPieces();
+    return sortedPieces;
+  });
 }

--- a/app/components/cases/subcases/government-areas-panel.js
+++ b/app/components/cases/subcases/government-areas-panel.js
@@ -59,7 +59,8 @@ export default class GovernmentAreasPanel extends Component {
 
     let uniqueDomains = domainsFromAvailableFields
       .uniq()
-      .sortBy('label');
+      .slice()
+      .sort((d1, d2) => d1.label - d2.label);
 
     // process args.governmentAreas into domains and fields
     const selectedDomains = [];
@@ -84,7 +85,7 @@ export default class GovernmentAreasPanel extends Component {
     this.domainSelections = uniqueDomains.map((domain) => {
       const availableFieldsForDomain = this.governmentFields.filter(
         (_, index) => domainsFromAvailableFields[index] === domain
-      ).sortBy('position');
+      ).sort((d1, d2) => d1.position - d2.position);
       const selectedFieldsForDomain = selectedFields.filter(
         (_, index) => domainsFromSelectedFields[index] === domain
       );

--- a/app/components/documents/linked-document-link.js
+++ b/app/components/documents/linked-document-link.js
@@ -21,7 +21,9 @@ export default class LinkedDocumentLink extends Component {
   @task
   *loadData() {
     const containerPieces = yield this.args.documentContainer.pieces;
-    const sortedContainerPieces = containerPieces.sortBy('created');
+    const sortedContainerPieces = containerPieces
+      .slice()
+      .sort((p1, p2) => p1.created - p2.created);
     if (this.args.lastPiece) {
       const idx = sortedContainerPieces.indexOf(this.args.lastPiece);
       this.sortedPieces = A(sortedContainerPieces.slice(0, idx + 1));

--- a/app/components/documents/linked-document-list.js
+++ b/app/components/documents/linked-document-list.js
@@ -84,7 +84,9 @@ export default class LinkedDocumentList extends Component {
       warn('More than 1 possible head found for linked list of pieces. Falling back to sort by document creation date', {
         id: 'multiple-possible-linked-list-heads',
       });
-      sortedContainerPieces = containerPieces.sortBy('created');
+      sortedContainerPieces = containerPieces
+        .slice()
+        .sort((p1, p2) => p1.created - p2.created);
     } else {
       let next = heads[0];
       while (next) {

--- a/app/components/documents/uploaded-document.js
+++ b/app/components/documents/uploaded-document.js
@@ -27,7 +27,9 @@ export default class UploadedDocument extends Component {
   }
 
   get sortedDocumentTypes() {
-    return this.documentTypes.sortBy('position');
+    return this.documentTypes
+      .slice()
+      .sort((d1, d2) => d1.position - d2.position);
   }
 
   @action

--- a/app/components/mandatees/mandatee-person-selector.js
+++ b/app/components/mandatees/mandatee-person-selector.js
@@ -69,6 +69,6 @@ export default class MandateePersonSelector extends Component {
       persons.addObject(person);
     }
 
-    return persons.sortBy('lastName');
+    return persons.sort((p1, p2) => p1.lastName.localeCompare(p2.lastName));
   }
 }

--- a/app/components/publications/overview/reports/generate-report-modal.js
+++ b/app/components/publications/overview/reports/generate-report-modal.js
@@ -160,7 +160,9 @@ export default class GenerateReportModalComponent extends Component {
         'filter[deprecated]': false,
       }), // Exclude deprecated government domains when generating modern reports
     });
-    this.governmentDomains = governmentDomains.slice().sortBy('label');
+    this.governmentDomains = governmentDomains
+      .slice()
+      .sort((d1, d2) => d1.label.localeCompare(d2.label));
     // everything selected by default
     this.selectedGovernmentDomains = this.governmentDomains.slice(0);
   }
@@ -173,8 +175,9 @@ export default class GenerateReportModalComponent extends Component {
   @task // @task: for consistency with other loadData tasks
   *loadRegulationTypes() {
     let regulationTypes = this.store.peekAll('regulation-type');
-    regulationTypes = regulationTypes.slice();
-    regulationTypes = regulationTypes.sortBy('position');
+    regulationTypes = regulationTypes
+      .slice()
+      .sort((c1, c2) => c1.position - c2.position);
     this.regulationTypes = regulationTypes;
     yield; // for linter
     // everything selected by default

--- a/app/components/publications/publication-status-modal.js
+++ b/app/components/publications/publication-status-modal.js
@@ -15,7 +15,9 @@ export default class PublicationStatusModal extends Component {
   }
 
   get publicationStatusses() {
-    return this.store.peekAll('publication-status').sortBy('position');
+    return this.store.peekAll('publication-status')
+      .slice()
+      .sort((s1, s2) => s1.position - s2.position);
   }
 
   get isDisabledSave() {

--- a/app/components/publications/publication/case/info/publication-case-info-panel.js
+++ b/app/components/publications/publication/case/info/publication-case-info-panel.js
@@ -69,7 +69,9 @@ export default class PublicationsPublicationCaseInfoPanelComponent extends Compo
   }
 
   get publicationModes() {
-    return this.store.peekAll('publication-mode').sortBy('position');
+    return this.store.peekAll('publication-mode')
+      .slice()
+      .sort((p1, p2) => p1.position - p2.position);
   }
 
   get isValid() {

--- a/app/components/publications/publication/decisions/info/decisions-info-panel.js
+++ b/app/components/publications/publication/decisions/info/decisions-info-panel.js
@@ -20,7 +20,9 @@ export default class PublicationsPublicationCaseInfoPanelComponent extends Compo
   }
 
   get sortedRegulationTypes() {
-    return this.store.peekAll('regulation-type').sortBy('position');
+    return this.store.peekAll('regulation-type')
+      .slice()
+      .sort((r1, r2) => r1.position - r2.position);
   }
 
   get isValid() {

--- a/app/components/publications/publication/proofs/proof-request-modal.js
+++ b/app/components/publications/publication/proofs/proof-request-modal.js
@@ -97,7 +97,9 @@ export default class PublicationsPublicationProofsProofRequestModalComponent ext
       this.transferredPieces = [
         ...usedPieces.slice(),
         ...generatedPieces.slice(),
-      ].sortBy('name', 'created');
+      ].sort(
+        (p1, p2) => p1.name.localeCompare(p2.name) || p1.created - p2.created
+      );
     } else {
       this.transferredPieces = [];
     }

--- a/app/components/publications/publication/publication-activities/publication-registered-panel.js
+++ b/app/components/publications/publication/publication-activities/publication-registered-panel.js
@@ -20,7 +20,10 @@ export default class PublicationsPublicationPublicationActivitiesPublicationRegi
   }
 
   get latestDecision() {
-    return this.decisions.sortBy('publicationDate').lastObject;
+    return this.decisions
+      .slice()
+      .sort((d1, d2) => d1.publicationDate - d2.publicationDate)
+      .at(-1);
   }
 
   get isEditDisabled() {

--- a/app/components/publications/publication/publication-activities/publication-request-modal.js
+++ b/app/components/publications/publication/publication-activities/publication-request-modal.js
@@ -69,8 +69,12 @@ export default class PublicationsPublicationPublicationActivitiesPublicationRequ
     let proofingActivity = this.args.proofingActivity;
     if (proofingActivity) {
       let generatedPieces = yield proofingActivity.generatedPieces;
-      generatedPieces = generatedPieces.slice();
-      generatedPieces = generatedPieces.sortBy('name', 'receivedDate');
+      generatedPieces = generatedPieces
+        .slice()
+        .sort(
+          (p1, p2) =>
+            p1.name.localeCompare(p2.name) || p1.receivedDate - p2.receivedDate
+        );
       this.transferredPieces = generatedPieces;
     } else {
       this.transferredPieces = [];

--- a/app/components/subcase/subcase-description-panel/subcase-description-view.js
+++ b/app/components/subcase/subcase-description-panel/subcase-description-view.js
@@ -47,7 +47,9 @@ export default class SubcaseDescriptionView extends Component {
   *loadAgendaData() {
     this.subcaseType = yield this.args.subcase.type;
     const agendaActivities = yield this.args.subcase.hasMany('agendaActivities').reload();
-    const sortedAgendaActivities = agendaActivities?.sortBy('startDate');
+    const sortedAgendaActivities = agendaActivities
+      ?.slice()
+      ?.sort((a1, a2) => a1.startDate - a2.startDate);
 
     this.modelsOfMeetings = [];
     for (const [index, agendaActivity] of sortedAgendaActivities.slice().entries()) {

--- a/app/components/subcases/subcase-item.js
+++ b/app/components/subcases/subcase-item.js
@@ -109,7 +109,10 @@ export default class SubcaseItemSubcasesComponent extends Component {
     };
     // only get the documents on latest agendaActivity if applicable
     const agendaActivities = yield this.args.subcase.agendaActivities;
-    const latestActivity = agendaActivities.sortBy('startDate')?.lastObject;
+    const latestActivity = agendaActivities
+      .slice()
+      .sort((a1, a2) => a1.startDate - a2.startDate)
+      .at(-1);
     if (latestActivity) {
       queryParams['filter[agenda-activity][:id:]'] = latestActivity.id;
     }

--- a/app/components/utils/government-areas/area-selector/government-area-selector-form.js
+++ b/app/components/utils/government-areas/area-selector/government-area-selector-form.js
@@ -31,8 +31,8 @@ export default class GovernmentAreaSelectorForm extends Component {
     );
 
     let uniqueDomains = domainsFromAvailableFields
-      .uniq()
-      .sortBy('label');
+      .filter((value, index, array) => array.indexOf(value) === index) // like .uniq()
+      .sort((d1, d2) => d1.label.localeCompare(d2.label));
 
     const selectedFields = this.args.selectedFields ?? [];
     const domainsFromSelectedFields = yield Promise.all(
@@ -42,9 +42,9 @@ export default class GovernmentAreaSelectorForm extends Component {
     const selectedDomains = this.args.selectedDomains ?? [];
 
     this.domainSelections = uniqueDomains.map((domain) => {
-      const availableFieldsForDomain = availableFields.filter(
-        (_, index) => domainsFromAvailableFields[index] === domain
-      ).sortBy('position');
+      const availableFieldsForDomain = availableFields
+        .filter((_, index) => domainsFromAvailableFields[index] === domain)
+        .sort((f1, f2) => f1.position - f2.position);
       const selectedFieldsForDomain = selectedFields.filter(
         (_, index) => domainsFromSelectedFields[index] === domain
       );

--- a/app/components/utils/government-areas/government-areas-panel.js
+++ b/app/components/utils/government-areas/government-areas-panel.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
+import { action, get } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { keepLatestTask } from 'ember-concurrency';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
@@ -14,7 +14,9 @@ class Row {
   }
 
   get sortedGovernmentFields() {
-    return this.governmentFields.sortBy('label');
+    return this.governmentFields.slice().sort((g1, g2) =>
+      g1.label.localeCompare(g2.label)
+    );
   }
 }
 
@@ -58,7 +60,8 @@ export default class GovernmentAreasPanel extends Component {
         governmentDomain: domain,
         governmentFields: fields,
       }))
-      .sortBy('governmentDomain.label');
+      // eslint-disable-next-line ember/no-get
+      .sort((r1, r2) => get(r1, 'governmentDomain.label').localeCompare(get(r2, 'governmentDomain.label')));
     this.governmentFields = fields;
     this.governmentDomains = domains;
   }

--- a/app/controllers/cases/case/subcases/subcase/documents.js
+++ b/app/controllers/cases/case/subcases/subcase/documents.js
@@ -163,7 +163,10 @@ export default class CasesCaseSubcasesSubcaseDocumentsController extends Control
       // only continue if there is a piece left in the container (a container could have 0 pieces left)
       if (lastPiece) {
         const agendaActivities = await this.subcase.agendaActivities;
-        const latestActivity = agendaActivities.sortBy('startDate')?.lastObject;
+        const latestActivity = agendaActivities
+          .slice()
+          .sort((a1, a2) => a1.startDate - a2.startDate)
+          .at(-1);
         if (latestActivity) {
           const agendaitems = await latestActivity.hasMany('agendaitems').reload(); // This fixes a case where approving an agenda did not update latestAgendaitem
           const latestMeeting = await this.store.queryOne('meeting', {
@@ -171,10 +174,13 @@ export default class CasesCaseSubcasesSubcaseDocumentsController extends Control
             sort: '-planned-start',
           });
           const agendas = await latestMeeting.agendas;
-          const sortedAgendas = agendas.sortBy('serialnumber').reverse();
-          const latestAgenda = sortedAgendas.firstObject;
+          const sortedAgendas = agendas
+            .slice()
+            .sort((a1, a2) => a1.serialnumber.localeCompare(a2.serialnumber))
+            .reverse();
+          const latestAgenda = sortedAgendas.at(0);
           for (let index = 0; index < agendaitems.length; index++) {
-            const agendaitem = agendaitems.objectAt(index);
+            const agendaitem = agendaitems.at(index);
             const agenda = await agendaitem.agenda;
 
             if (agenda.id === latestAgenda.id) {

--- a/app/controllers/newsletters/index.js
+++ b/app/controllers/newsletters/index.js
@@ -36,7 +36,11 @@ export default class NewslettersIndexController extends Controller {
   @bind
   async latestAgenda(meeting) {
     const agendas = await meeting.agendas;
-    return agendas?.sortBy('serialnumber').reverse().firstObject;
+    return agendas
+      ?.slice()
+      .sort((a1, a2) => a1.serialNumber.localeCompare(a2.serialNumber))
+      .reverse()
+      .at(0);
   }
 
   @action

--- a/app/routes/agenda/agendaitems/agendaitem/index.js
+++ b/app/routes/agenda/agendaitems/agendaitem/index.js
@@ -40,7 +40,9 @@ export default class DetailAgendaitemAgendaitemsAgendaRoute extends Route {
     // The reload in model refreshes only the attributes and includes relations, makes saves with stale relation data possible
     await model.hasMany('mandatees').reload();
     await model.hasMany('pieces').reload();
-    this.mandatees = (await model.mandatees).sortBy('priority');
+    this.mandatees = (await model.mandatees)
+      .slice()
+      .sort((m1, m2) => m1.priority - m2.priority);
   }
 
   async setupController(controller) {

--- a/app/routes/agenda/print.js
+++ b/app/routes/agenda/print.js
@@ -19,7 +19,8 @@ export default class AgendaPrintRoute extends Route {
     });
     const notas = [];
     const announcements = [];
-    for (const agendaitem of agendaitems.sortBy('number').slice()) {
+    const sortedAgendaitems = agendaitems?.slice().sort((a1, a2) => a1.number - a2.number)
+    for (const agendaitem of sortedAgendaitems) {
       const type = await agendaitem.type;
       if (type.uri === CONSTANTS.AGENDA_ITEM_TYPES.NOTA) {
         notas.push(agendaitem);

--- a/app/routes/cases/case/subcases/subcase/documents.js
+++ b/app/routes/cases/case/subcases/subcase/documents.js
@@ -22,7 +22,10 @@ export default class DocumentsSubcaseSubcasesRoute extends Route {
     let submissionActivities = [...submissionActivitiesWithoutActivity.slice()];
     // Get the submission from latest meeting if applicable
     const agendaActivities = await this.subcase.agendaActivities;
-    const latestActivity = agendaActivities.sortBy('startDate')?.lastObject;
+    const latestActivity = agendaActivities
+      .slice()
+      .sort((a1, a2) => a1.startDate - a2.startDate)
+      .at(-1);
     if (latestActivity) {
       this.latestMeeting = await this.store.queryOne('meeting', {
         'filter[agendas][agendaitems][agenda-activity][:id:]': latestActivity.id,

--- a/app/routes/cases/case/subcases/subcase/index.js
+++ b/app/routes/cases/case/subcases/subcase/index.js
@@ -40,10 +40,15 @@ export default class CasesCaseSubcasesSubcaseIndexRoute extends Route {
   }
 
   async afterModel(model) {
-    this.mandatees = (await model.subcase.mandatees).sortBy('priority');
+    this.mandatees = (await model.subcase.mandatees)
+      .slice()
+      .sort((m1, m2) => m1.priority - m2.priority);
     this.submitter = await model.subcase.requestedBy;
     const agendaActivities = await model.subcase.agendaActivities;
-    const latestActivity = agendaActivities.sortBy('startDate')?.lastObject;
+    const latestActivity = agendaActivities
+      .slice()
+      .sort((a1, a2) => a1.startDate - a2.startDate)
+      .at(-1);
     if (latestActivity) {
       this.meeting = await this.store.queryOne('meeting', {
         'filter[agendas][agendaitems][agenda-activity][:id:]': latestActivity.id,

--- a/app/routes/newsletter/print.js
+++ b/app/routes/newsletter/print.js
@@ -44,7 +44,10 @@ export default class PrintNewsletterRoute extends Route {
 
     let notas = []
     let announcements = [];
-    for (const agendaitem of agendaitems.sortBy('number').slice()) {
+    const sortedAgendaitems = agendaitems
+      ?.slice()
+      .sort((a1, a2) => a1.number - a2.number)
+    for (const agendaitem of sortedAgendaitems) {
       const type = await agendaitem.type;
       if (type.uri === CONSTANTS.AGENDA_ITEM_TYPES.NOTA) {
         notas.push(agendaitem);
@@ -54,8 +57,8 @@ export default class PrintNewsletterRoute extends Route {
     }
 
     if (params.showDraft) {
-      notas = notas.sortBy('number');
-      announcements = announcements.sortBy('number');
+      notas = notas.sort((n1, n2) => n1.number - n2.number);
+      announcements = announcements.sort((a1, a2) => a1.number - a2.number);
     } else { // Items need to be ordered by minister protocol order
       // TODO: Below is a hacky way of grouping agendaitems for protocol order. Refactor.
       await setCalculatedGroupNumbers(notas);

--- a/app/routes/newsletters/search.js
+++ b/app/routes/newsletters/search.js
@@ -171,7 +171,9 @@ export default class NewslettersSearchRoute extends Route {
   postProcessMandatees(newsletter) {
     const mandatees = newsletter.attributes.latestAgendaitem.mandatees;
     if (Array.isArray(mandatees)) {
-      const sortedMandatees = mandatees.sortBy('priority');
+      const sortedMandatees = mandatees.sort(
+        (m1, m2) => m1.priority - m2.priority
+      );
       newsletter.attributes.mandatees = sortedMandatees;
     } else {
       newsletter.attributes.mandatees = [mandatees];

--- a/app/routes/publications/publication/proofs/index.js
+++ b/app/routes/publications/publication/proofs/index.js
@@ -89,7 +89,7 @@ export default class PublicationsPublicationProofsRoute extends Route {
       ...requestActivities.map((request) => TimelineActivity.create(request)),
       ...proofingActivities.map((proofing) => TimelineActivity.create(proofing)),
     ]);
-    rows = rows.sortBy('date').reverseObjects();
+    rows = rows.sort((r1, r2) => r1.date - r2.date).reverse();
     return rows;
   }
 

--- a/app/routes/publications/publication/publication-activities/index.js
+++ b/app/routes/publications/publication/publication-activities/index.js
@@ -79,8 +79,8 @@ export default class PublicationsPublicationPublicationActivitiesIndexRoute exte
       ...requestActivities.map((request) => new TimelineActivity(request)),
       ...publicationActivities.map((publication) => new TimelineActivity(publication)),
     ]
-      .sortBy('date')
-      .reverseObjects();
+      .sort((a1, a2) => a1.date - a2.date)
+      .reverse();
   }
 
   afterModel() {

--- a/app/routes/publications/publication/translations/index.js
+++ b/app/routes/publications/publication/translations/index.js
@@ -91,7 +91,7 @@ export default class PublicationsPublicationTranslationsIndexRoute extends Route
       ...requestActivities.map((request) => TimelineActivity.create(request)),
       ...translationActivities.map((translation) => TimelineActivity.create(translation)),
     ]);
-    rows = rows.sortBy('date').reverseObjects();
+    rows = rows.sort((a1, a2) => a1.date - a2.date).reverse();
     return rows;
   }
 

--- a/app/routes/search/news-items.js
+++ b/app/routes/search/news-items.js
@@ -188,7 +188,9 @@ export default class SearchNewsItemsRoute extends Route {
   static postProcessMandatees(newsletter) {
     const mandatees = newsletter.latestAgendaitem.mandatees;
     if (Array.isArray(mandatees)) {
-      const sortedMandatees = mandatees.sortBy('priority');
+      const sortedMandatees = mandatees
+        .slice()
+        .sort((m1, m2) => m1.priority - m2.priority);
       newsletter.mandatees = sortedMandatees;
     } else {
       newsletter.mandatees = [mandatees];

--- a/app/services/agenda-service.js
+++ b/app/services/agenda-service.js
@@ -154,7 +154,9 @@ export default class AgendaService extends Service {
       agendaitems.map(async (agendaitem) => {
         let currentAgendaitemGroupName;
         const mandatees = await agendaitem.mandatees;
-        const sortedMandatees = mandatees.sortBy('priority');
+        const sortedMandatees = mandatees
+          .slice()
+          .sort((m1, m2) => m1.priority - m2.priority);
         if (agendaitem.isApproval) {
           agendaitem.set('groupName', null);
           agendaitem.set('ownGroupName', null);

--- a/app/services/mandatees.js
+++ b/app/services/mandatees.js
@@ -136,7 +136,8 @@ export default class MandateesService extends Service {
         }
       });
     }
-    mandatees = mandatees.sortBy('priority').slice(); // TODO: sorting on both "start" and "priority" yields incomplete results. Thus part of the sort in frontend
+    // sorting on both "start" and "priority" yields incomplete results. Thus part of the sort in frontend
+    mandatees = mandatees.sort((m1, m2) => m1.priority - m2.priority);
     return mandatees;
   }
 

--- a/app/services/publication-service.js
+++ b/app/services/publication-service.js
@@ -190,14 +190,14 @@ export default class PublicationService extends Service {
     const publicationSubcase = await publicationFlow.publicationSubcase;
     const publicationActivities = (
       await publicationSubcase.publicationActivities
-    ).sortBy('startDate');
+    ).sort((a1, a2) => a1.startDate - a2.startDate);
     if (publicationActivities.length) {
       for (let publicationActivity of publicationActivities) {
-        const publishedDecisions = (await publicationActivity.decisions).sortBy(
-          'publicationDate'
+        const publishedDecisions = (await publicationActivity.decisions).sort(
+          (d1, d2) => d1.publicationDate - d2.publicationDate
         );
         if (publishedDecisions.length) {
-          return publishedDecisions.firstObject.publicationDate;
+          return publishedDecisions.at(0).publicationDate;
         }
       }
     }
@@ -490,7 +490,9 @@ export default class PublicationService extends Service {
 
     if (!decision) {
       const publicationActivities = await publicationSubcase.publicationActivities;
-      let publicationActivity = publicationActivities.sortBy('-startDate')?.[0];
+      let publicationActivity = publicationActivities
+        ?.slice()
+        ?.sort((a1, a2) => a2.startDate - a1.startDate)?.[0];
 
       if (!publicationActivity) {
         publicationActivity = this.store.createRecord(

--- a/app/services/subcase-is-approved.js
+++ b/app/services/subcase-is-approved.js
@@ -7,7 +7,10 @@ export default class SubcaseIsApprovedService extends Service {
   async isApproved(subcase) {
     // we need to see if the last meeting isFinal
     const agendaActivities = await subcase.agendaActivities;
-    const latestActivity = agendaActivities?.sortBy('startDate').lastObject;
+    const latestActivity = agendaActivities
+      ?.slice()
+      ?.sort((a1, a2) => a1.startDate - a2.startdate)
+      ?.at(-1);
     const latestMeeting = await this.store.queryOne('meeting', {
       'filter[agendas][agendaitems][agenda-activity][:id:]': latestActivity?.id,
       sort: '-planned-start',

--- a/app/utils/agendaitem-utils.js
+++ b/app/utils/agendaitem-utils.js
@@ -77,7 +77,9 @@ export const sortByNumber = (groupedAgendaitems, allowEmptyGroups) => {
     groupsArray = groupsArray.filter((group) => group.groupname !== 'Geen toegekende ministers');
   }
 
-  groupsArray = groupsArray.sortBy('groupNumber').map((group) => EmberObject.create(group));
+  groupsArray = groupsArray
+    .sort((g1, g2) => g1.groupNumber.localeCompare(g2.groupNumber))
+    .map((group) => EmberObject.create(group));
 
   return groupsArray;
 };
@@ -128,7 +130,8 @@ export const reorderAgendaitemsOnAgenda = async(agenda, store, decisionReportGen
   const agendaitems = await agenda.get('agendaitems');
   const actualAgendaitems = [];
   const actualAnnouncements = [];
-  for (const agendaitem of agendaitems.sortBy('number').slice()) {
+  const sortedAgendaitems = agendaitems.slice().sort((a1, a2) => a1.number - a2.number)
+  for (const agendaitem of sortedAgendaitems) {
     if (!agendaitem.isDeleted) {
       const type = await agendaitem.type;
       if (type.uri === CONSTANTS.AGENDA_ITEM_TYPES.NOTA) {
@@ -165,7 +168,7 @@ export class AgendaitemGroup {
   static sortedMandatees(mandatees) {
     // Copy array by value. Manipulating the by-reference array would trigger changes when mandatees is an array from the store
     const copiedMandatees = A(mandatees.slice());
-    return copiedMandatees.sortBy('priority');
+    return copiedMandatees.sort((m1, m2) => m1.priority - m2.priority);
   }
 
   static generateMandateeGroupId(sortedMandatees) {

--- a/app/utils/documents.js
+++ b/app/utils/documents.js
@@ -1,12 +1,29 @@
 import { A } from '@ember/array';
-import VRDocumentName, { compareFunction } from 'frontend-kaleidos/utils/vr-document-name';
+import VRDocumentName, {
+  compareFunction,
+} from 'frontend-kaleidos/utils/vr-document-name';
 import fetch from 'fetch';
 
-export const sortDocumentContainers = (pieces, containers) => {
+export const sortDocumentContainers = async (
+  piecesOrPromise,
+  containersOrPromise
+) => {
   // Sorting is done in the frontend to work around a Virtuoso issue, where
   // FROM-statements for multiple graphs, combined with GROUP BY, ORDER BY results in
   // some items not being returned. By not having a sort parameter, this doesn't occur.
-  const sortedPieces = A(pieces.slice()).sort((pieceA, pieceB) => compareFunction(new VRDocumentName(pieceA.get('name')), new VRDocumentName(pieceB.get('name'))));
+  const pieces = await piecesOrPromise;
+  const containers = await containersOrPromise;
+
+  const sortedPieces = A(pieces.slice()).sort((pieceA, pieceB) =>
+    compareFunction(
+      new VRDocumentName(pieceA.get('name')),
+      new VRDocumentName(pieceB.get('name'))
+    )
+  );
+  // Load the pieces linked to container so we can access them later
+  await Promise.all(
+    containers.map(async (container) => await container.pieces)
+  );
   /*
     Code below for compatibility towards mixin consumers.
     Since names are now on each piece
@@ -15,43 +32,67 @@ export const sortDocumentContainers = (pieces, containers) => {
   return A(containers.slice()).sort((containerA, containerB) => {
     let matchingPieceA = null;
     let matchingPieceB = null;
-    for (let index = 0; index < containerA.get('pieces.length'); index++) {
-      const piece = containerA.get('pieces').objectAt(index);
-      matchingPieceA = sortedPieces.filterBy('id', piece.id).sortBy('created').lastObject;
+    // Use .value() to get the value of a ManyArray, instead of working with the
+    // deprecated PromiseManyArray. Because we loaded them earlier we're sure
+    // there's data (if they were unloaded, they would be null here)
+    let piecesA = containerA.hasMany('pieces').value();
+    let piecesB = containerB.hasMany('pieces').value();
+    for (let index = 0; index < piecesA.length; index++) {
+      const piece = piecesA.slice().at(index);
+      matchingPieceA = sortedPieces
+        .filter((p) => p.id === piece.id)
+        .slice()
+        .sort((p1, p2) => p1.created - p2.created)
+        .at(-1);
       if (matchingPieceA) {
         break;
       }
     }
-    for (let index = 0; index < containerB.get('pieces.length'); index++) {
-      const piece = containerB.get('pieces').objectAt(index);
-      matchingPieceB = sortedPieces.filterBy('id', piece.id).sortBy('created').lastObject;
+    for (let index = 0; index < piecesB.length; index++) {
+      const piece = piecesB.slice().at(index);
+      matchingPieceB = sortedPieces
+        .filter((p) => p.id === piece.id)
+        .slice()
+        .sort((p1, p2) => p1.created - p2.created)
+        .at(-1);
       if (matchingPieceB) {
         break;
       }
     }
-    return sortedPieces.indexOf(matchingPieceA) - sortedPieces.indexOf(matchingPieceB);
+    return (
+      sortedPieces.indexOf(matchingPieceA) -
+      sortedPieces.indexOf(matchingPieceB)
+    );
   });
 };
 
-export const sortPieces = (pieces, NameClass = VRDocumentName, sortingFunc = compareFunction) => {
+export const sortPieces = (
+  pieces,
+  NameClass = VRDocumentName,
+  sortingFunc = compareFunction
+) => {
   const validNamedPieces = [];
   let invalidNamedPieces = A();
   for (const piece of pieces) {
     try {
-      (new NameClass(piece.name)).parseMeta();
+      new NameClass(piece.name).parseMeta();
       validNamedPieces.push(piece);
     } catch {
       invalidNamedPieces.push(piece);
     }
   }
-  validNamedPieces.sort((docA, docB) => sortingFunc(new NameClass(docA.name), new NameClass(docB.name)));
-  invalidNamedPieces = invalidNamedPieces.sortBy('created').slice();
+  validNamedPieces.sort((docA, docB) =>
+    sortingFunc(new NameClass(docA.name), new NameClass(docB.name))
+  );
+  invalidNamedPieces = invalidNamedPieces.sort(
+    (p1, p2) => p1.created - p2.created
+  );
   invalidNamedPieces.reverse();
 
   return [...validNamedPieces, ...invalidNamedPieces];
 };
 
-export const addPieceToAgendaitem = async function(agendaitem, piece) {
+export const addPieceToAgendaitem = async function (agendaitem, piece) {
   const endpoint = `/agendaitems/${agendaitem.get('id')}/pieces`;
   const body = {
     data: {
@@ -67,11 +108,18 @@ export const addPieceToAgendaitem = async function(agendaitem, piece) {
     body: JSON.stringify(body),
   });
   if (!response.ok) {
-    throw new Error(`Failed to add document ${piece.get('id')} to agendaitem ${agendaitem.get('id')}`);
+    throw new Error(
+      `Failed to add document ${piece.get('id')} to agendaitem ${agendaitem.get(
+        'id'
+      )}`
+    );
   }
 };
 
-export const restorePiecesFromPreviousAgendaitem = async function(agendaitem, documentContainer) {
+export const restorePiecesFromPreviousAgendaitem = async function (
+  agendaitem,
+  documentContainer
+) {
   const endpoint = `/agendaitems/${agendaitem.get('id')}/pieces/restore`;
   const body = {
     data: {
@@ -87,6 +135,10 @@ export const restorePiecesFromPreviousAgendaitem = async function(agendaitem, do
     body: JSON.stringify(body),
   });
   if (!response.ok) {
-    throw new Error(`Failed to restore pieces from container ${documentContainer.get('id')} to agendaitem ${agendaitem.get('id')}`);
+    throw new Error(
+      `Failed to restore pieces from container ${documentContainer.get(
+        'id'
+      )} to agendaitem ${agendaitem.get('id')}`
+    );
   }
 };


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4104

earlier PR was too large and old.
Separating into individual PR's per issue (hopefully easier/faster to merge...)


replace all occurrences of `sortBy('property')` to `sort((a1, a2) => a1.property - a2.property)` for numbers or `sort((a1, a2) => a1.property.localeCompare(a2.property))` if property is a string
replaced some of `firstObject` and `lastObject` because it was the same line.
replaced some use of async getters with `sortBy` to `@use` resources.
