### PR TITLE
fix: initialize decision-activity filter in the right place

### DIFF
--- a/app/routes/signatures/ongoing.js
+++ b/app/routes/signatures/ongoing.js
@@ -72,6 +72,7 @@ export default class SignaturesOngoingRoute extends Route {
       };
     }
 
+    filter['decision-activity'] = {};
     if (params.mandatees?.length > 0) {
       filter['decision-activity'] = {
         subcase: {
@@ -89,7 +90,6 @@ export default class SignaturesOngoingRoute extends Route {
       };
     }
 
-    filter['decision-activity'] = {};
     if (isPresent(params.dateFrom)) {
       const date = startOfDay(parseDate(params.dateFrom));
       filter['decision-activity'][':gte:start-date'] = date.toISOString().slice(0, 10);


### PR DESCRIPTION
For flag on https://kanselarij.atlassian.net/browse/KAS-4385

Issue probably related to a faulty merge conflict resolution, before we were resetting the decision activity filter after setting it, which isn't great.