### PR TITLE
cypress: use a config file for the current mandatees, enable VP sync service

### DIFF
--- a/app/components/publications/publication/case/mandatees/mandatees-panel.hbs
+++ b/app/components/publications/publication/case/mandatees/mandatees-panel.hbs
@@ -68,6 +68,7 @@
   isn't filled in, which in theory can be the case for a non-MR publication-flow, but in practice should
   hardly ever occur }}
   <Mandatees::MandateesSelectorModal
+    @excludeMandatees={{@publicationFlow.mandatees}}
     @referenceDate={{or
       @publicationFlow.decisionActivity.startDate
       @publicationFlow.openingDate

--- a/ci/docker-compose.override.yml
+++ b/ci/docker-compose.override.yml
@@ -87,3 +87,13 @@ services:
     user: ${HOST_UID_GID}
   file-bundling:
     user: ${HOST_UID_GID}
+  agenda-submission:
+    environment:
+      CACHE_CLEAR_TIMEOUT: 8000
+  vlaams-parlement-sync:
+    environment:
+      ENABLE_SENDING_TO_VP_API: "false" # enable/disable the actual call to the VP-API
+      ENABLE_ALWAYS_CREATE_PARLIAMENT_FLOW: "true" # always creates a (mock) parliament-flow, even when ENABLE_SENDING_TO_VP_API is false
+      VP_API_DOMAIN: "https://replace.by.actual.api.url"
+      VP_API_CLIENT_ID: "yourVpApiClientId"
+      VP_API_CLIENT_SECRET: "yourVpApiClientSecret"

--- a/cypress/e2e/all-flaky-tests/mandatee-assigning.cy.js
+++ b/cypress/e2e/all-flaky-tests/mandatee-assigning.cy.js
@@ -7,9 +7,14 @@ import utils from '../../selectors/utils.selectors';
 import newsletter from '../../selectors/newsletter.selectors';
 import appuniversum from '../../selectors/appuniversum.selectors';
 import dependency from '../../selectors/dependency.selectors';
+import mandateeNames from '../../selectors/mandatee-names.selectors';
 
 function currentTimestamp() {
   return Cypress.dayjs().unix();
+}
+
+function newsletterTitle(mandatee) {
+  return `${mandatee.title} ${mandatee.fullName}`;
 }
 
 function checkMandateesInList(mandatees, dateRange) {
@@ -22,8 +27,7 @@ function checkMandateesInList(mandatees, dateRange) {
 context('Assigning a mandatee to agendaitem or subcase should update linked subcase/agendaitems, KAS-1291', () => {
   const agendaDate = Cypress.dayjs().add(1, 'weeks')
     .day(4); // Next friday
-  // This variable is used multiple times to check if data is properly loaded
-  const nameToCheck = 'Jambon';
+
   // const caseTitle = 'Cypress test: mandatee sync - 1594023300';  // The case is in the default data set with id 5F02DD8A7DE3FC0008000001
   const isCI = Cypress.env('CI');
 
@@ -47,8 +51,8 @@ context('Assigning a mandatee to agendaitem or subcase should update linked subc
     cy.addSubcase(type, SubcaseTitleShort, subcaseTitleLong, subcaseType, subcaseName);
     cy.openSubcase(0, SubcaseTitleShort);
 
-    cy.addSubcaseMandatee(1);
-    cy.addSubcaseMandatee(2);
+    cy.addSubcaseMandatee(mandateeNames.current.first);
+    cy.addSubcaseMandatee(mandateeNames.current.second);
 
     cy.get(mandatee.mandateePanelView.rows).as('listItems');
     cy.get('@listItems').should('have.length', 2, {
@@ -58,7 +62,7 @@ context('Assigning a mandatee to agendaitem or subcase should update linked subc
     // Checking if name of first mandatee is present ensures data is loaded
     cy.get('@listItems').eq(0)
       .find(mandatee.mandateePanelView.row.name)
-      .should('contain', nameToCheck);
+      .should('contain', mandateeNames.current.first.lastName);
     cy.proposeSubcaseForAgenda(agendaDate);
 
     // Check if agendaitem has the same amount of mandatees
@@ -72,7 +76,7 @@ context('Assigning a mandatee to agendaitem or subcase should update linked subc
 
     cy.get('@listItems').eq(0)
       .find(mandatee.mandateePanelView.row.name)
-      .should('contain', nameToCheck);
+      .should('contain', mandateeNames.current.first.lastName);
 
     cy.changeDecisionResult('Goedgekeurd');
   });
@@ -90,7 +94,7 @@ context('Assigning a mandatee to agendaitem or subcase should update linked subc
 
     // Dependency: We should already have 2 mandatees that we inherit from previous subcase, now we add 1 more
 
-    cy.addSubcaseMandatee(3);
+    cy.addSubcaseMandatee(mandateeNames.current.third);
 
     cy.get(mandatee.mandateePanelView.rows).as('listItems');
     cy.get('@listItems').should('have.length', 3, {
@@ -99,7 +103,7 @@ context('Assigning a mandatee to agendaitem or subcase should update linked subc
 
     cy.get('@listItems').eq(0)
       .find(mandatee.mandateePanelView.row.name)
-      .should('contain', nameToCheck);
+      .should('contain', mandateeNames.current.first.lastName);
 
     // Check if agendaitem has the same amount of mandatees
     cy.openAgendaForDate(agendaDate);
@@ -112,7 +116,7 @@ context('Assigning a mandatee to agendaitem or subcase should update linked subc
 
     cy.get('@listItems').eq(0)
       .find(mandatee.mandateePanelView.row.name)
-      .should('contain', nameToCheck);
+      .should('contain', mandateeNames.current.first.lastName);
 
     cy.changeDecisionResult('Goedgekeurd');
   });
@@ -132,7 +136,7 @@ context('Assigning a mandatee to agendaitem or subcase should update linked subc
 
     // Dependency: We should already have 3 mandatees that we inherit from previous subcase, now we add 1 more
 
-    cy.addSubcaseMandatee(4);
+    cy.addSubcaseMandatee(mandateeNames.current.fourth);
     cy.get(mandatee.mandateePanelView.rows).as('listItems');
     cy.get('@listItems').should('have.length', 4, {
       timeout: 5000,
@@ -140,12 +144,12 @@ context('Assigning a mandatee to agendaitem or subcase should update linked subc
 
     cy.get('@listItems').eq(0)
       .find(mandatee.mandateePanelView.row.name)
-      .should('contain', nameToCheck);
+      .should('contain', mandateeNames.current.first.lastName);
 
     cy.openDetailOfAgendaitem(SubcaseTitleShort);
 
     // Add 1 more
-    cy.addSubcaseMandatee(5);
+    cy.addSubcaseMandatee(mandateeNames.current.fifth);
     cy.get(mandatee.mandateePanelView.rows).as('listItems');
     cy.get('@listItems').should('have.length', 5, {
       timeout: 5000,
@@ -153,7 +157,7 @@ context('Assigning a mandatee to agendaitem or subcase should update linked subc
 
     cy.get('@listItems').eq(0)
       .find(mandatee.mandateePanelView.row.name)
-      .should('contain', nameToCheck);
+      .should('contain', mandateeNames.current.first.lastName);
 
     cy.changeDecisionResult('Goedgekeurd');
 
@@ -169,7 +173,7 @@ context('Assigning a mandatee to agendaitem or subcase should update linked subc
     });
     cy.get('@listItems').eq(0)
       .find(mandatee.mandateePanelView.row.name)
-      .should('contain', nameToCheck);
+      .should('contain', mandateeNames.current.first.lastName);
   });
 
   it('should edit mandatees and show correct mandatees when switching agendaitems before, during and after edits', () => {
@@ -203,15 +207,15 @@ context('Assigning a mandatee to agendaitem or subcase should update linked subc
     cy.log('in non-edit view, check if mandatees of last selected agendaitem are correctly ordered');
     cy.get(mandatee.mandateePanelView.row.name).as('mandateeNames');
     cy.get('@mandateeNames').eq(0)
-      .should('contain', nameToCheck);
+      .should('contain', mandateeNames.current.first.fullName);
     cy.get('@mandateeNames').eq(1)
-      .should('contain', 'Hilde Crevits');
+      .should('contain', mandateeNames.current.second.fullName);
     cy.get('@mandateeNames').eq(2)
-      .should('contain', 'Gwendolyn Rutten');
+      .should('contain', mandateeNames.current.third.fullName);
     cy.get('@mandateeNames').eq(3)
-      .should('contain', 'Ben Weyts');
+      .should('contain', mandateeNames.current.fourth.fullName);
     cy.get('@mandateeNames').eq(4)
-      .should('contain', 'Zuhal Demir');
+      .should('contain', mandateeNames.current.fifth.fullName);
 
     cy.log('when edit is open, check if mandatees are correct (in reverse order)');
     cy.get(mandatee.mandateePanelView.actions.edit).click();
@@ -253,7 +257,7 @@ context('Assigning a mandatee to agendaitem or subcase should update linked subc
     cy.log('adding a mandatee and saving, check the non-edit view again');
     cy.get('@agendaitems').eq(2)
       .click();
-    cy.addAgendaitemMandatee(6);
+    cy.addAgendaitemMandatee(mandateeNames.current.sixth);
     cy.get('@agendaitems').eq(1)
       .click();
     cy.get(mandatee.mandateePanelView.rows).should('have.length', 2);
@@ -363,11 +367,11 @@ context('Assigning a mandatee to agendaitem or subcase should update linked subc
     cy.get(newsletter.newsletterPrint.printItemProposal).as('proposals')
       .should('have.length', 3);
     cy.get('@proposals').eq(0)
-      .contains('Op voorstel van minister-president Jan Jambon en viceminister-president Hilde Crevits');
+      .contains(`Op voorstel van ${newsletterTitle(mandateeNames.current.first)} en ${newsletterTitle(mandateeNames.current.second)}`);
     cy.get('@proposals').eq(1)
-      .contains('Op voorstel van minister-president Jan Jambon, viceminister-president Hilde Crevits, viceminister-president Gwendolyn Rutten, viceminister-president Ben Weyts en Vlaams minister Zuhal Demir');
+      .contains(`Op voorstel van ${newsletterTitle(mandateeNames.current.first)}, ${newsletterTitle(mandateeNames.current.second)}, ${newsletterTitle(mandateeNames.current.third)}, ${newsletterTitle(mandateeNames.current.fourth)} en ${newsletterTitle(mandateeNames.current.fifth)}`);
     cy.get('@proposals').eq(2)
-      .contains('Op voorstel van minister-president Jan Jambon, viceminister-president Hilde Crevits en Vlaams minister Matthias Diependaele');
+      .contains(`Op voorstel van ${newsletterTitle(mandateeNames.current.first)}, ${newsletterTitle(mandateeNames.current.second)} en ${newsletterTitle(mandateeNames.current.sixth)}`);
     cy.clickReverseTab('Klad');
     cy.wait('@getMandatees1', {
       timeout: 60000,
@@ -381,11 +385,11 @@ context('Assigning a mandatee to agendaitem or subcase should update linked subc
     cy.wait(2000);
     cy.get(newsletter.newsletterPrint.printItemProposal).as('proposals');
     cy.get('@proposals').eq(0)
-      .contains('Op voorstel van minister-president Jan Jambon en viceminister-president Hilde Crevits');
+      .contains(`Op voorstel van ${newsletterTitle(mandateeNames.current.first)} en ${newsletterTitle(mandateeNames.current.second)}`);
     cy.get('@proposals').eq(1)
-      .contains('Op voorstel van minister-president Jan Jambon, viceminister-president Hilde Crevits en Vlaams minister Matthias Diependaele');
+      .contains(`Op voorstel van ${newsletterTitle(mandateeNames.current.first)}, ${newsletterTitle(mandateeNames.current.second)} en ${newsletterTitle(mandateeNames.current.sixth)}`);
     cy.get('@proposals').eq(2)
-      .contains('Op voorstel van minister-president Jan Jambon, viceminister-president Hilde Crevits, viceminister-president Gwendolyn Rutten, viceminister-president Ben Weyts en Vlaams minister Zuhal Demir');
+      .contains(`Op voorstel van ${newsletterTitle(mandateeNames.current.first)}, ${newsletterTitle(mandateeNames.current.second)}, ${newsletterTitle(mandateeNames.current.third)}, ${newsletterTitle(mandateeNames.current.fourth)} en ${newsletterTitle(mandateeNames.current.fifth)}`);
   });
 
   it('check list of mandatees in 2020 agenda', () => {

--- a/cypress/e2e/all-flaky-tests/subcase.cy.js
+++ b/cypress/e2e/all-flaky-tests/subcase.cy.js
@@ -9,6 +9,7 @@ import route from '../../selectors/route.selectors';
 import utils from '../../selectors/utils.selectors';
 import dependency from '../../selectors/dependency.selectors';
 import document from '../../selectors/document.selectors';
+import mandateeNames from '../../selectors/mandatee-names.selectors';
 
 function currentTimestamp() {
   return Cypress.dayjs().unix();
@@ -75,8 +76,8 @@ context('Subcase tests', () => {
     cy.openSubcase(0, subcaseTitleShort);
 
     cy.changeSubcaseAccessLevel(true, subcaseTitleShort, 'Cypress test nieuwere lange titel');
-    cy.addSubcaseMandatee(2, 'Crevits');
-    cy.addSubcaseMandatee(3);
+    cy.addSubcaseMandatee(mandateeNames.current.second);
+    cy.addSubcaseMandatee(mandateeNames.current.third);
 
     cy.proposeSubcaseForAgenda(agendaDate);
 
@@ -97,7 +98,7 @@ context('Subcase tests', () => {
     cy.get(cases.subcaseDescription.decidedOn).contains('Nog niet beslist');
     // Deze test volgt het al dan niet default "beslist" zijn van een beslissing.
     // Default = beslist, assert dotted date; default = niet beslist: assert "nog niet beslist".
-    cy.get(cases.subcaseDescription.requestedBy).contains(/Hilde Crevits/);
+    cy.get(cases.subcaseDescription.requestedBy).contains(mandateeNames.current.second.fullName);
 
     cy.openAgendaForDate(agendaDate);
     cy.openAgendaitemDossierTab(subcaseTitleShort);
@@ -162,7 +163,7 @@ context('Subcase tests', () => {
     cy.get(cases.subcaseDescription.decidedOn).contains('Nog niet beslist');
     // Deze test volgt het al dan niet default "beslist" zijn van een beslissing.
     // Default = beslist, assert dotted date; default = niet beslist: assert "nog niet beslist".
-    cy.get(cases.subcaseDescription.requestedBy).contains(/Hilde Crevits/);
+    cy.get(cases.subcaseDescription.requestedBy).contains(mandateeNames.current.second.fullName);
     cy.get(cases.subcaseDescription.agendaLink).click();
     cy.url().should('contain', '/agenda/');
     cy.url().should('contain', '/agendapunten/');

--- a/cypress/e2e/unit/agenda-notice.cy.js
+++ b/cypress/e2e/unit/agenda-notice.cy.js
@@ -4,6 +4,7 @@
 import agenda from '../../selectors/agenda.selectors';
 import mandatee from '../../selectors/mandatee.selectors';
 import utils from '../../selectors/utils.selectors';
+import mandateeNames from '../../selectors/mandatee-names.selectors';
 
 function currentTimestamp() {
   return Cypress.dayjs().unix();
@@ -27,7 +28,6 @@ context('agenda notice test', () => {
     const type = 'Mededeling';
     const subcaseShortTitle = `test for adding minister - ${testId}`;
     const subcaseLongTitle  = `long title for test for adding minister - ${testId}`;
-    const nameToCheck = 'Jambon';
     const labelName1 = 'Cultuur, Jeugd, Sport en Media';
     const fieldsName1 = 'Media';
     const labelName2 = 'Economie, Wetenschap en Innovatie';
@@ -39,8 +39,8 @@ context('agenda notice test', () => {
     cy.addSubcase(type, subcaseShortTitle, subcaseLongTitle, null, null);
     cy.openSubcase(0, subcaseShortTitle);
     // add mandatees to notice
-    cy.addSubcaseMandatee(1);
-    cy.addSubcaseMandatee(2);
+    cy.addSubcaseMandatee(mandateeNames.current.first);
+    cy.addSubcaseMandatee(mandateeNames.current.second);
     // add fields
     cy.intercept('GET', '/concepts**').as('getConceptSchemes');
     cy.get(utils.governmentAreasPanel.edit).click();
@@ -78,7 +78,7 @@ context('agenda notice test', () => {
     });
     cy.get('@listItems').eq(0)
       .find(mandatee.mandateePanelView.row.name)
-      .should('contain', nameToCheck);
+      .should('contain', mandateeNames.current.first.fullName);
     cy.get('@listItems').eq(0)
       .find(mandatee.mandateePanelView.row.submitter)
       .children()
@@ -86,16 +86,16 @@ context('agenda notice test', () => {
     // TODO-notice add check for fields?
 
     // add more mandatees and check if they are shown correctly
-    cy.addAgendaitemMandatee(3);
-    cy.addAgendaitemMandatee(4);
-    cy.addAgendaitemMandatee(5);
+    cy.addAgendaitemMandatee(mandateeNames.current.third);
+    cy.addAgendaitemMandatee(mandateeNames.current.fourth);
+    cy.addAgendaitemMandatee(mandateeNames.current.fifth);
     cy.get('@listItems').eq(1)
-      .should('contain', 'Hilde Crevits');
+      .should('contain', mandateeNames.current.second.fullName);
     cy.get('@listItems').eq(2)
-      .should('contain', 'Gwendolyn Rutten');
+      .should('contain', mandateeNames.current.third.fullName);
     cy.get('@listItems').eq(3)
-      .should('contain', 'Ben Weyts');
+      .should('contain', mandateeNames.current.fourth.fullName);
     cy.get('@listItems').eq(4)
-      .should('contain', 'Zuhal Demir');
+      .should('contain', mandateeNames.current.fifth.fullName);
   });
 });

--- a/cypress/e2e/unit/agenda.cy.js
+++ b/cypress/e2e/unit/agenda.cy.js
@@ -6,6 +6,7 @@ import auk from '../../selectors/auk.selectors';
 import appuniversum from '../../selectors/appuniversum.selectors';
 import route from  '../../selectors/route.selectors';
 import utils from  '../../selectors/utils.selectors';
+import mandateeNames from '../../selectors/mandatee-names.selectors';
 
 function getTranslatedMonth(month) {
   switch (month) {
@@ -385,9 +386,9 @@ context('Agenda tests', () => {
     cy.visit('vergadering/62B06E87EC3CB8277FF058E9/agenda/62B06E89EC3CB8277FF058EA/agendapunten?anchor=62B06EBFEC3CB8277FF058F0');
     // setup
     cy.openAgendaitemDossierTab(shortSubcaseTitle1);
-    cy.addAgendaitemMandatee(1, null, null, false);
+    cy.addAgendaitemMandatee(mandateeNames['10052021-16052022'].first, false);
     cy.openAgendaitemDossierTab(shortSubcaseTitle2);
-    cy.addAgendaitemMandatee(2, null, null, false);
+    cy.addAgendaitemMandatee(mandateeNames['10052021-16052022'].second, false);
 
     cy.get(agenda.agendaActions.optionsDropdown)
       .children(appuniversum.button)
@@ -408,7 +409,7 @@ context('Agenda tests', () => {
       .should('contain', 'DOC.0002-05 propagatie vertrouwelijk publiek.pdf');
   });
 
-  it('Should download all files for Jambon', () => {
+  it('Should download all files for Prime-minister', () => {
     cy.visit('vergadering/62B06E87EC3CB8277FF058E9/agenda/62B06E89EC3CB8277FF058EA/agendapunten?anchor=62B06EBFEC3CB8277FF058F0');
 
     cy.get(agenda.agendaActions.optionsDropdown)
@@ -416,7 +417,7 @@ context('Agenda tests', () => {
       .click();
     cy.get(agenda.agendaActions.downloadDocuments).forceClick();
     cy.get(appuniversum.checkbox)
-      .contains('Jambon')
+      .contains(mandateeNames['10052021-16052022'].first.lastName)
       .click();
     downloadDocs(false);
     cy.readFile(downloadZipAgendaA, {
@@ -433,7 +434,7 @@ context('Agenda tests', () => {
       .should('not.contain', 'DOC.0002-05 propagatie vertrouwelijk publiek.pdf');
   });
 
-  it('Should download all files for Crevits', () => {
+  it('Should download all files for second minister', () => {
     cy.visit('vergadering/62B06E87EC3CB8277FF058E9/agenda/62B06E89EC3CB8277FF058EA/agendapunten?anchor=62B06EBFEC3CB8277FF058F0');
 
     cy.get(agenda.agendaActions.optionsDropdown)
@@ -441,7 +442,7 @@ context('Agenda tests', () => {
       .click();
     cy.get(agenda.agendaActions.downloadDocuments).forceClick();
     cy.get(appuniversum.checkbox)
-      .contains('Crevits')
+      .contains(mandateeNames['10052021-16052022'].second.lastName)
       .click();
     downloadDocs(false);
     cy.readFile(downloadZipAgendaA, {
@@ -513,14 +514,14 @@ context('Agenda tests', () => {
       cy.visit('vergadering/62B06E87EC3CB8277FF058E9/agenda/62B06E89EC3CB8277FF058EA/agendapunten?anchor=62B06EBFEC3CB8277FF058F0');
 
       cy.openDetailOfAgendaitem(shortSubcaseTitle1);
-      cy.addAgendaitemMandatee(1, null, null, false);
+      // cy.addAgendaitemMandatee(mandateeNames['10052021-16052022'].first, false); // This already happened in previous setup
       cy.get(agenda.agendaitemNav.decisionTab)
         .should('be.visible')
         .click();
       cy.addDocumentToTreatment(filePunt2);
       // cy.generateDecision(concerns, decision);
       cy.openDetailOfAgendaitem(shortSubcaseTitle2);
-      cy.addAgendaitemMandatee(2, null, null, false);
+      // cy.addAgendaitemMandatee(mandateeNames['10052021-16052022'].second, false); // This already happened in previous setup
       cy.get(agenda.agendaitemNav.decisionTab)
         .should('be.visible')
         .click();
@@ -528,14 +529,14 @@ context('Agenda tests', () => {
       cy.addDocumentToTreatment(filePunt3);
     });
 
-    it('Should download all decisions for Jambon', () => {
+    it('Should download all decisions for Prime-minister', () => {
       cy.visit('vergadering/62B06E87EC3CB8277FF058E9/agenda/62B06E89EC3CB8277FF058EA/agendapunten?anchor=62B06EBFEC3CB8277FF058F0');
       cy.get(agenda.agendaActions.optionsDropdown)
         .children(appuniversum.button)
         .click();
       cy.get(agenda.agendaActions.downloadDecisions).forceClick();
       cy.get(appuniversum.checkbox)
-        .contains('Jambon')
+        .contains(mandateeNames['10052021-16052022'].first.lastName)
         .click();
       downloadDocs(false);
       cy.readFile(downloadZipAgendaA, {
@@ -544,14 +545,14 @@ context('Agenda tests', () => {
         .should('not.contain', fileName3);
     });
 
-    it('Should download all decisions for Crevits', () => {
+    it('Should download all decisions for second minister', () => {
       cy.visit('vergadering/62B06E87EC3CB8277FF058E9/agenda/62B06E89EC3CB8277FF058EA/agendapunten?anchor=62B06EBFEC3CB8277FF058F0');
       cy.get(agenda.agendaActions.optionsDropdown)
         .children(appuniversum.button)
         .click();
       cy.get(agenda.agendaActions.downloadDecisions).forceClick();
       cy.get(appuniversum.checkbox)
-        .contains('Crevits')
+        .contains(mandateeNames['10052021-16052022'].second.lastName)
         .click();
       downloadDocs(false);
       cy.readFile(downloadZipAgendaA, {

--- a/cypress/e2e/unit/agendaitem-changes.cy.js
+++ b/cypress/e2e/unit/agendaitem-changes.cy.js
@@ -5,6 +5,7 @@ import agenda from '../../selectors/agenda.selectors';
 import appuniversum from '../../selectors/appuniversum.selectors';
 import document from '../../selectors/document.selectors';
 import route from '../../selectors/route.selectors';
+import mandateeNames from '../../selectors/mandatee-names.selectors';
 
 function agendaitemExistsInOverview(agendaitemTitle, exists) {
   if (exists) {
@@ -35,6 +36,7 @@ context('Agendaitem changes tests', () => {
     cy.logout();
   });
 
+  // const agendaDate = Cypress.dayjs('2020-04-02');
   const agendaURL = '/vergadering/5EBA48CF95A2760008000006/agenda/f66c6d79-6ad2-49e2-af55-702df3a936d8/agendapunten';
   const approvalTitle = 'Goedkeuring van het verslag van de vergadering van vrijdag 22-11-2019';
   const agendaitemIndex2 = 'testId=1589276690: Cypress test dossier 1 test stap 1';
@@ -206,7 +208,7 @@ context('Agendaitem changes tests', () => {
     // cy.get(agenda.agendaitemGroupHeader.section).eq(0)
     //   .should('contain.text', 'Geen toekenning');
     cy.openDetailOfAgendaitem('Cypress test dossier 1 test stap 1');
-    cy.addAgendaitemMandatee(1, 'Jambon', ministerTitle);
+    cy.addAgendaitemMandatee(mandateeNames['02102019-10052021'].first);
     cy.clickReverseTab('Overzicht');
     cy.get(agenda.agendaitemGroupHeader.section).eq(0)
       .should('contain.text', ministerTitle);

--- a/cypress/e2e/unit/news-item.cy.js
+++ b/cypress/e2e/unit/news-item.cy.js
@@ -9,6 +9,11 @@ import dependency from '../../selectors/dependency.selectors';
 import newsletter from '../../selectors/newsletter.selectors';
 import route from '../../selectors/route.selectors';
 import utils from '../../selectors/utils.selectors';
+import mandateeNames from '../../selectors/mandatee-names.selectors';
+
+function newsletterTitle(mandatee) {
+  return `${mandatee.title} ${mandatee.fullName}`;
+}
 
 // TODO-command, might not have any other usages
 function changeSubcaseType(subcaseLink, type) {
@@ -364,7 +369,7 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
     // const agendaDate = Cypress.dayjs('2020-04-01');
     const agendaitemKBLink = '/vergadering/5EBA84900A655F0008000004/agenda/5EBA84910A655F0008000005/agendapunten/6272890FE536C464112FFE76/kort-bestek';
     const subcaseTitleShort = 'Cypress test: KB edit - Nota edit full - 1651673319';
-    const proposalText = 'Op voorstel van minister-president Jan Jambon';
+    const proposalText = `Op voorstel van ${newsletterTitle(mandateeNames['02102019-10052021'].first)}`;
     const file = {
       folder: 'files', fileName: 'test', fileExtension: 'pdf', newFileName: 'test pdf', fileType: 'Nota',
     };
@@ -401,7 +406,7 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
     // check after adding nota and mandatee
     cy.get(newsletter.editItem.cancel).click();
     cy.openAgendaitemDossierTab(subcaseTitleShort);
-    cy.addAgendaitemMandatee(1);
+    cy.addAgendaitemMandatee(mandateeNames['02102019-10052021'].first);
     cy.addDocumentsToAgendaitem(subcaseTitleShort, files);
     // TODO-bug reload should not be necessary
     // reload necessary for nota
@@ -601,10 +606,10 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
     // *note the next htmlContent is used in search-other-spec-data.spec, keep them identical
     const htmlContentNota = 'this nota info should be visible in definitief';
     const remarkTextNota = 'this nota remark should not be visible in definitief';
-    const proposalTextNota = 'Op voorstel van minister-president Jan Jambon';
+    const proposalTextNota = `Op voorstel van ${newsletterTitle(mandateeNames['10052021-16052022'].first)}`;
     const htmlContentMededeling = 'this announcement info should be visible in definitief';
     const remarkTextMededeling = 'this announcement remark should not be visible in definitief';
-    const proposalTextMededeling = 'Op voorstel van viceminister-president Hilde Crevits';
+    const proposalTextMededeling = `Op voorstel van ${newsletterTitle(mandateeNames['10052021-16052022'].second)}`;
     const subcaseTitleMededeling = 'Cypress test: KB Definitief view - mededeling - 1651673497';
     const subcaseTitleNota = 'Cypress test: KB Definitief view - nota - 1651673497';
 
@@ -625,7 +630,7 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
 
     // add mandatee, info, remark and theme to mededeling, then check if shown/not shown correctly
     cy.visitAgendaWithLink(agendaLinkMed);
-    cy.addAgendaitemMandatee(2); // Hilde Crevits
+    cy.addAgendaitemMandatee(mandateeNames['10052021-16052022'].second); // Hilde Crevits
     cy.openAgendaitemKortBestekTab(subcaseTitleMededeling);
     cy.intercept('GET', '/themes**').as('getThemes_1');
     cy.get(newsletter.newsItem.edit).click();
@@ -692,7 +697,7 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
     // add mandatee and theme to nota, then check if shown/not shown correctly
     // visit link of mededeling, open nota (less agenda loading)
     cy.visitAgendaWithLink(agendaLinkNota);
-    cy.addAgendaitemMandatee(0);
+    cy.addAgendaitemMandatee(mandateeNames['10052021-16052022'].first);
     cy.openAgendaitemKortBestekTab(subcaseTitleNota);
     cy.intercept('GET', '/themes**').as('getThemes_2');
     cy.get(newsletter.newsItem.edit).click();

--- a/cypress/e2e/unit/search.cy.js
+++ b/cypress/e2e/unit/search.cy.js
@@ -8,6 +8,7 @@ import newsletter from '../../selectors/newsletter.selectors';
 import route from '../../selectors/route.selectors';
 import utils from '../../selectors/utils.selectors';
 import auk from '../../selectors/auk.selectors';
+import mandateeNames from '../../selectors/mandatee-names.selectors';
 
 function searchFunction(optionsToCheck, defaultOption) {
   optionsToCheck.forEach((option) => {
@@ -528,7 +529,7 @@ context('Search tests', () => {
         'Principiële goedkeuring',
         'Principiële goedkeuring m.h.o. op adviesaanvraag');
       cy.openSubcase(0, subcaseShortTitle);
-      cy.addSubcaseMandatee(4);
+      cy.addSubcaseMandatee(mandateeNames.current.fourth);
       cy.addDomainsAndFields(domains);
       cy.addDocumentsToSubcase(filesSubcase);
       cy.createAgenda(null, agendaDate, 'Zaal oxford bij Cronos Leuven');
@@ -597,9 +598,9 @@ context('Search tests', () => {
       searchOnRoute(subcaseShortTitle, searchFlow, resultRow, caseShortTitle);
       searchOnRoute(subcaseLongTitle, searchFlow, resultRow, caseShortTitle);
       // mandatees
-      searchOnRoute('Ben', searchFlow, resultRow, caseShortTitle);
-      searchOnRoute('Weyts', searchFlow, resultRow, caseShortTitle);
-      searchOnRoute('Vlaams minister van Onderwijs, Sport, Dierenwelzijn en Vlaamse Rand', searchFlow, resultRow, caseShortTitle);
+      searchOnRoute(mandateeNames.current.fourth.firstName, searchFlow, resultRow, caseShortTitle);
+      searchOnRoute(mandateeNames.current.fourth.lastName, searchFlow, resultRow, caseShortTitle);
+      searchOnRoute(mandateeNames.current.fourth.searchTitle, searchFlow, resultRow, caseShortTitle);
       // news-item
       searchOnRoute(newsItemShortTitle, searchFlow, resultRow, caseShortTitle);
       searchOnRoute(newsItemLongTitle, searchFlow, resultRow, caseShortTitle);
@@ -624,9 +625,9 @@ context('Search tests', () => {
       cy.visit('/zoeken/agendapunten');
 
       // mandatees
-      searchOnRoute('Ben', searchFlow, resultRow, subcaseShortTitle);
-      searchOnRoute('Weyts', searchFlow, resultRow, subcaseShortTitle);
-      searchOnRoute('Vlaams minister van Onderwijs, Sport, Dierenwelzijn en Vlaamse Rand', searchFlow, resultRow, subcaseShortTitle);
+      searchOnRoute(mandateeNames.current.fourth.firstName, searchFlow, resultRow, subcaseShortTitle);
+      searchOnRoute(mandateeNames.current.fourth.lastName, searchFlow, resultRow, subcaseShortTitle);
+      searchOnRoute(mandateeNames.current.fourth.searchTitle, searchFlow, resultRow, subcaseShortTitle);
       // news-item
       searchOnRoute(newsItemContent, searchFlow, resultRow, subcaseShortTitle);
       // documents
@@ -696,7 +697,7 @@ context('Search tests', () => {
     // const noResult = 'Er werden geen resultaten gevonden. Pas je trefwoord en filters aan.';
     const dateFrom = Cypress.dayjs().add(-1, 'years');
     const dateTo = Cypress.dayjs().add(1, 'years');
-    const checkbox1 = 'Ben Weyts';
+    const checkbox1 = mandateeNames.current.fourth.fullName;
     const checkbox2 = 'Cultuur, Jeugd, Sport en Media';
 
     // TODO-setup: remove a case

--- a/cypress/e2e/unit/shortlist-overview.cy.js
+++ b/cypress/e2e/unit/shortlist-overview.cy.js
@@ -11,6 +11,7 @@ import settings from '../../selectors/settings.selectors';
 import mandatee from '../../selectors/mandatee.selectors';
 import route from '../../selectors/route.selectors';
 import signature from '../../selectors/signature.selectors';
+import mandateeNames from '../../selectors/mandatee-names.selectors';
 
 import utils from '../../selectors/utils.selectors';
 
@@ -70,21 +71,9 @@ context('signatures shortlist overview tests', () => {
   const agendaDate = Cypress.dayjs().add(15, 'weeks')
     .day(5);
 
-  const mandatee1 = 'Gwendolyn Rutten';
-  const mandatee2 = 'Ben Weyts';
-
-  // TODO maintenance heavy, config file?
-  const currentMinisters = [
-    'Jan Jambon, Vlaams minister van Buitenlandse Zaken, Cultuur, Digitalisering en Facilitair Management, Minister-president van de Vlaamse Regering',
-    'Hilde Crevits, Vlaams minister van Welzijn, Volksgezondheid en Gezin',
-    'Gwendolyn Rutten, Vlaams minister van Binnenlands Bestuur, Bestuurszaken, Inburgering en Gelijke Kansen',
-    'Ben Weyts, Vlaams minister van Onderwijs, Sport, Dierenwelzijn en Vlaamse Rand',
-    'Zuhal Demir, Vlaams minister van Justitie en Handhaving, Omgeving, Energie en Toerisme',
-    'Matthias Diependaele, Vlaams minister van Financiën en Begroting, Wonen en Onroerend Erfgoed',
-    'Lydia Peeters, Vlaams minister van Mobiliteit en Openbare Werken',
-    'Benjamin Dalle, Vlaams minister van Brussel, Jeugd, Media en Armoedebestrijding',
-    'Jo Brouns, Vlaams minister van Economie, Innovatie, Werk, Sociale Economie en Landbouw'
-  ];
+  const primeMandatee = mandateeNames.current.first;
+  const mandatee1 = mandateeNames.current.third; // 'Gwendolyn Rutten'
+  const mandatee2 = mandateeNames.current.fourth; // 'Ben Weyts';
 
   const approverEmail = 'approver@test.com';
   const notificationEmail = 'notification@test.com';
@@ -119,12 +108,12 @@ context('signatures shortlist overview tests', () => {
     cy.approveDesignAgenda();
 
     cy.openDetailOfAgendaitem(subcaseTitleShort1);
-    cy.addAgendaitemMandatee(3);
+    cy.addAgendaitemMandatee(mandatee1);
     cy.get(agenda.agendaitemNav.documentsTab).click();
     cy.get(document.documentCard.actions).click();
     cy.get(document.documentCard.signMarking).forceClick();
     cy.openDetailOfAgendaitem(subcaseTitleShort2);
-    cy.addAgendaitemMandatee(4);
+    cy.addAgendaitemMandatee(mandatee2);
     cy.get(agenda.agendaitemNav.documentsTab).click();
     cy.get(document.documentCard.actions).click();
     cy.get(document.documentCard.signMarking).forceClick();
@@ -139,7 +128,7 @@ context('signatures shortlist overview tests', () => {
     cy.get(utils.mHeader.signatures).click()
       .wait('@getShortlist1');
 
-    cy.get(route.signatures.row.mandatee).contains(mandatee1)
+    cy.get(route.signatures.row.mandatee).contains(mandatee1.fullName)
       .parent()
       .as('currentDoc');
 
@@ -169,13 +158,13 @@ context('signatures shortlist overview tests', () => {
       });
 
     // no filters (all mandatees)
-    cy.get(route.signatures.row.mandatee).contains(mandatee1);
-    cy.get(route.signatures.row.mandatee).contains(mandatee2);
+    cy.get(route.signatures.row.mandatee).contains(mandatee1.fullName);
+    cy.get(route.signatures.row.mandatee).contains(mandatee2.fullName);
 
     // filter nonexistent
     cy.get(route.signatures.openMinisterFilter).click();
     cy.get(appuniversum.loader).should('not.exist');
-    cy.get(appuniversum.checkbox).contains('Jan Jambon')
+    cy.get(appuniversum.checkbox).contains(primeMandatee.fullName)
       .click();
     cy.intercept('GET', '/sign-flows*').as('getShortlist2');
     cy.get(route.signatures.applyFilter).click()
@@ -185,24 +174,24 @@ context('signatures shortlist overview tests', () => {
     // filter one
     cy.get(route.signatures.openMinisterFilter).click();
     cy.get(appuniversum.loader).should('not.exist');
-    cy.get(appuniversum.checkbox).contains(mandatee1)
+    cy.get(appuniversum.checkbox).contains(mandatee1.fullName)
       .click();
     cy.intercept('GET', '/sign-flows*').as('getShortlist3');
     cy.get(route.signatures.applyFilter).click()
       .wait('@getShortlist3');
-    cy.get(route.signatures.row.mandatee).contains(mandatee1);
-    cy.get(route.signatures.row.mandatee).should('not.contain', mandatee2);
+    cy.get(route.signatures.row.mandatee).contains(mandatee1.fullName);
+    cy.get(route.signatures.row.mandatee).should('not.contain', mandatee2.fullName);
 
     // filter both
     cy.get(route.signatures.openMinisterFilter).click();
     cy.get(appuniversum.loader).should('not.exist');
-    cy.get(appuniversum.checkbox).contains(mandatee2)
+    cy.get(appuniversum.checkbox).contains(mandatee2.fullName)
       .click();
     cy.intercept('GET', '/sign-flows*').as('getShortlist4');
     cy.get(route.signatures.applyFilter).click()
       .wait('@getShortlist4');
-    cy.get(route.signatures.row.mandatee).contains(mandatee1);
-    cy.get(route.signatures.row.mandatee).contains(mandatee2);
+    cy.get(route.signatures.row.mandatee).contains(mandatee1.fullName);
+    cy.get(route.signatures.row.mandatee).contains(mandatee2.fullName);
   });
 
   it('should check the signatures overview sidebar', () => {
@@ -210,7 +199,7 @@ context('signatures shortlist overview tests', () => {
     cy.get(utils.mHeader.signatures).click()
       .wait('@getShortlist1');
 
-    cy.get(route.signatures.row.mandatee).contains(mandatee1)
+    cy.get(route.signatures.row.mandatee).contains(mandatee1.fullName)
       .parent()
       .as('currentDoc');
 
@@ -243,9 +232,9 @@ context('signatures shortlist overview tests', () => {
 
     // check default signers
     cy.get(signature.createSignFlow.signers.item).eq(0)
-      .contains('Jan Jambon');
+      .contains(primeMandatee.fullName);
     cy.get(signature.createSignFlow.signers.item).eq(1)
-      .contains(mandatee1);
+      .contains(mandatee1.fullName);
     // remove signer with button
     cy.get(signature.createSignFlow.signers.remove).eq(1)
       .click();
@@ -256,17 +245,17 @@ context('signatures shortlist overview tests', () => {
     cy.get(appuniversum.loader).should('not.exist');
     // TODO can't add selector to container, only to checkboxlist, which isn't specific enough?
     cy.get(mandatee.mandateeCheckboxList).find(appuniversum.checkbox)
-      .contains(mandatee1)
+      .contains(mandatee1.fullName)
       .scrollIntoView()
       .click();
     cy.get(signature.selectMinisters.apply).click();
     cy.get(signature.createSignFlow.signers.item).eq(1)
-      .contains(mandatee1);
+      .contains(mandatee1.fullName);
     // remove signer with edit
     cy.get(signature.createSignFlow.signers.edit).click();
     cy.get(appuniversum.loader).should('not.exist');
     cy.get(mandatee.mandateeCheckboxList).find(appuniversum.checkbox)
-      .contains(mandatee1)
+      .contains(mandatee1.fullName)
       .scrollIntoView()
       .click();
     cy.get(signature.selectMinisters.apply).click();
@@ -278,7 +267,7 @@ context('signatures shortlist overview tests', () => {
     cy.get(appuniversum.loader).should('not.exist');
     cy.get(mandatee.mandateeCheckboxList).find(appuniversum.checkbox)
       .should('have.length', 9);
-    currentMinisters.forEach((minister) => {
+    mandateeNames.current.signatureTitles.forEach((minister) => {
       cy.get(appuniversum.checkbox).contains(minister);
     });
     cy.get(auk.modal.footer.cancel).click();
@@ -306,7 +295,7 @@ context('signatures shortlist overview tests', () => {
     // cy.wait(5000);
 
     // no email set
-    // TODO this fails, is there an email for jambon in the testdata?
+    // TODO this fails, is there an email for primeMandatee in the testdata?
     // cy.get(route.signatures.sidebar.startSignflow).should('be.disabled');
   });
 
@@ -318,7 +307,7 @@ context('signatures shortlist overview tests', () => {
     cy.get(utils.mandateeSelector.container).click();
     cy.get(dependency.emberPowerSelect.optionLoadingMessage).should('not.exist');
     cy.get(dependency.emberPowerSelect.optionTypeToSearchMessage).should('not.exist');
-    cy.get(dependency.emberPowerSelect.option).contains(mandatee1)
+    cy.get(dependency.emberPowerSelect.option).contains(mandatee1.fullName)
       .click();
     cy.intercept('PATCH', '/user-organizations/**').as('patchUserOrganizations');
     cy.get(utils.mandateesSelector.add).should('not.be.disabled')
@@ -332,7 +321,7 @@ context('signatures shortlist overview tests', () => {
     cy.get(utils.mHeader.signatures).click()
       .wait('@getShortlist1');
 
-    cy.get(route.signatures.row.mandatee).contains(mandatee1);
+    cy.get(route.signatures.row.mandatee).contains(mandatee1.fullName);
     cy.get(route.signatures.row.mandatee).should('have.length', 1);
   });
 
@@ -344,7 +333,7 @@ context('signatures shortlist overview tests', () => {
     cy.get(utils.mandateeSelector.container).click();
     cy.get(dependency.emberPowerSelect.optionLoadingMessage).should('not.exist');
     cy.get(dependency.emberPowerSelect.optionTypeToSearchMessage).should('not.exist');
-    cy.get(dependency.emberPowerSelect.option).contains(mandatee2)
+    cy.get(dependency.emberPowerSelect.option).contains(mandatee2.fullName)
       .click();
     cy.intercept('PATCH', '/user-organizations/**').as('patchUserOrganizations');
     cy.get(utils.mandateesSelector.add).should('not.be.disabled')
@@ -357,8 +346,8 @@ context('signatures shortlist overview tests', () => {
     cy.get(utils.mHeader.signatures).click()
       .wait('@getShortlist1');
 
-    cy.get(route.signatures.row.mandatee).contains(mandatee1);
-    cy.get(route.signatures.row.mandatee).contains(mandatee2);
+    cy.get(route.signatures.row.mandatee).contains(mandatee1.fullName);
+    cy.get(route.signatures.row.mandatee).contains(mandatee2.fullName);
     cy.get(route.signatures.row.mandatee).should('have.length', 2);
   });
 

--- a/cypress/selectors/mandatee-names.selectors.js
+++ b/cypress/selectors/mandatee-names.selectors.js
@@ -1,0 +1,147 @@
+const selectors = {
+  // all current mandatee name for specs who create new data with future dates so names have to be dynamic
+  // titles are case sensitive in some views, can be circumvented by using {matchCase: false}.
+  current: {
+    first: {
+      firstName: 'Jan',
+      lastName: 'Jambon',
+      fullName: 'Jan Jambon',
+      title: 'minister-president',
+      searchTitle: 'Minister-president',
+    },
+    second: {
+      firstName: 'Hilde',
+      lastName: 'Crevits',
+      fullName: 'Hilde Crevits',
+      title: 'viceminister-president',
+      searchTitle: 'Vlaams minister',
+    },
+    third: {
+      firstName: 'Gwendolyn',
+      lastName: 'Rutten',
+      fullName: 'Gwendolyn Rutten',
+      title: 'viceminister-president',
+      searchTitle: 'Vlaams minister',
+    },
+    fourth: {
+      firstName: 'Ben',
+      lastName: 'Weyts',
+      fullName: 'Ben Weyts',
+      title: 'viceminister-president',
+      searchTitle: 'Vlaams minister van Onderwijs, Sport, Dierenwelzijn en Vlaamse Rand',
+    },
+    fifth: {
+      firstName: 'Zuhal',
+      lastName: 'Demir',
+      fullName: 'Zuhal Demir',
+      title: 'Vlaams minister',
+    },
+    sixth: {
+      firstName: 'Matthias',
+      lastName: 'Diependaele',
+      fullName: 'Matthias Diependaele',
+      title: 'Vlaams minister',
+    },
+    seventh: {
+      firstName: 'Lydia',
+      lastName: 'Peeters',
+      fullName: 'Lydia Peeters',
+      ttitle: 'Vlaams minister',
+    },
+    eighth: {
+      firstName: 'Benjamin',
+      lastName: 'Dalle',
+      fullName: 'Benjamin Dalle',
+      title: 'Vlaams minister',
+    },
+    ninth: {
+      firstName: 'Jo',
+      lastName: 'Brouns',
+      fullName: 'Jo Brouns',
+      title: 'Vlaams minister',
+    },
+    // up to eleventh is possible, but is the minimum ninth?
+    // list of titles as shown when adding mandatees to signatures, only needed for current
+    signatureTitles: [
+      'Jan Jambon, Vlaams minister van Buitenlandse Zaken, Cultuur, Digitalisering en Facilitair Management, Minister-president van de Vlaamse Regering',
+      'Hilde Crevits, Vlaams minister van Welzijn, Volksgezondheid en Gezin',
+      'Gwendolyn Rutten, Vlaams minister van Binnenlands Bestuur, Bestuurszaken, Inburgering en Gelijke Kansen',
+      'Ben Weyts, Vlaams minister van Onderwijs, Sport, Dierenwelzijn en Vlaamse Rand',
+      'Zuhal Demir, Vlaams minister van Justitie en Handhaving, Omgeving, Energie en Toerisme',
+      'Matthias Diependaele, Vlaams minister van Financiën en Begroting, Wonen en Onroerend Erfgoed',
+      'Lydia Peeters, Vlaams minister van Mobiliteit en Openbare Werken',
+      'Benjamin Dalle, Vlaams minister van Brussel, Jeugd, Media en Armoedebestrijding',
+      'Jo Brouns, Vlaams minister van Economie, Innovatie, Werk, Sociale Economie en Landbouw'
+    ],
+  },
+
+  // older governmentbody data used in tests (will/should not change)
+  '16052022-08112023': {
+    first: {
+      firstName: 'Jan',
+      lastName: 'Jambon',
+      fullName: 'Jan Jambon',
+      title: 'minister-president',
+      searchTitle: 'Minister-president',
+    },
+    second: {
+      firstName: 'Hilde',
+      lastName: 'Crevits',
+      fullName: 'Hilde Crevits',
+      title: 'viceminister-president',
+      searchTitle: 'Vlaams minister',
+    },
+    third: {
+      firstName: 'Bart',
+      lastName: 'Somers',
+      fullName: 'Bart Somers',
+      title: 'viceminister-president',
+      searchTitle: 'Vlaams minister',
+    },
+  },
+
+  // no spec uses the governmentbody between 16052022 and 18052022
+
+  '10052021-16052022': {
+    first: {
+      firstName: 'Jan',
+      lastName: 'Jambon',
+      fullName: 'Jan Jambon',
+      title: 'minister-president',
+      searchTitle: 'Minister-president',
+    },
+    second: {
+      firstName: 'Hilde',
+      lastName: 'Crevits',
+      fullName: 'Hilde Crevits',
+      title: 'viceminister-president',
+      searchTitle: 'Vlaams minister',
+    },
+    third: {
+      firstName: 'Bart',
+      lastName: 'Somers',
+      fullName: 'Bart Somers',
+      title: 'viceminister-president',
+      searchTitle: 'Vlaams minister',
+    },
+  },
+
+  '02102019-10052021': {
+    first: {
+      firstName: 'Jan',
+      lastName: 'Jambon',
+      fullName: 'Jan Jambon',
+      title: 'minister-president',
+      searchTitle: 'Minister-president',
+    },
+    second: {
+      firstName: 'Hilde',
+      lastName: 'Crevits',
+      fullName: 'Hilde Crevits',
+      title: 'viceminister-president',
+      searchTitle: 'Vlaams minister',
+    },
+  },
+
+};
+export default selectors;


### PR DESCRIPTION
No ticket.

Recent change to mandatee selector meant that using index to select specific mandatees was failing.
To counter this, added a selector file with current mandatees.
Will need maintenance every switch of government body but will still be less maintenance than fixing all tests that are depending on specific mandatees to be selected.
Also to prevent having to reuse local variables with hardcoded mandatee names.
During the test, you either use active mandatees or you must select an existing mandatee from the government body of that period.

Tested some specs manually (mandatee-assigning.cy / subcase.cy / agenda.cy / agenda-notice.cy)
Rest I will leave up to jenkins.
