### PR TITLE
cypress: attempt to reduce flakyness by adding afterEach logout

### DIFF
--- a/cypress/e2e/unit/profile-kort-bestek.cy.js
+++ b/cypress/e2e/unit/profile-kort-bestek.cy.js
@@ -1,4 +1,4 @@
-/* global context, it, cy, beforeEach */
+/* global context, it, cy, beforeEach, afterEach*/
 // / <reference types="Cypress" />
 
 import agenda from '../../selectors/agenda.selectors';
@@ -18,6 +18,10 @@ context('Testing the application as Kort bestek user', () => {
     cy.loginFlow('Kort bestek');
     cy.wait(1000);
     cy.url().should('include', 'kort-bestek'); // make sure we transitioned to default route
+  });
+
+  afterEach(() => {
+    cy.logout();
   });
 
   context('M-header toolbar tests', () => {

--- a/cypress/e2e/unit/profile-ovrb.cy.js
+++ b/cypress/e2e/unit/profile-ovrb.cy.js
@@ -1,4 +1,4 @@
-/* global context, it, cy, beforeEach */
+/* global context, it, cy, beforeEach, afterEach */
 // / <reference types="Cypress" />
 
 import agenda from '../../selectors/agenda.selectors';
@@ -18,6 +18,10 @@ context('Testing the application as OVRB', () => {
     // cy.login does not trigger the transtition to the default route for this profile for some reason
     cy.loginFlow('OVRB');
     cy.wait(1000);
+  });
+
+  afterEach(() => {
+    cy.logout();
   });
 
   context('M-header toolbar tests', () => {


### PR DESCRIPTION
Profile-kort-bestek.cy.js and profile-ovrb.cy.js are flaky.
These tests only look at data so they really shouldn't be.
It might be an issue with login info.

From experience, too many tests in 1 file with no `afterEach` where we logout can cause issues.
Because we do login in the `beforeEach`.
This is because each test should be able to run in isolation so sessions should be removed.
This might not always happen correctly in larger files.
So just checking if logging out after each reduces flakyness in this case.