### PR TITLE
change incorrect wording

### DIFF
--- a/app/components/agenda/agenda-header.hbs
+++ b/app/components/agenda/agenda-header.hbs
@@ -8,7 +8,7 @@
               class="auk-toolbar-complex__title"
               data-test-agenda-header-title
             >
-              {{t "agenda-of"}}
+              {{t "session-of"}}
               {{#if @meeting.isPreKaleidos}}
                 {{date-phrase @meeting.plannedStart}}
               {{else}}


### PR DESCRIPTION
In the agenda detail view, the agenda header says "Agenda van", this should be "Vergadering van". An agenda does not have a date.