### PR TITLE
add decision-result-pill loading state

### DIFF
--- a/app/components/decision/decision-result-pill.hbs
+++ b/app/components/decision/decision-result-pill.hbs
@@ -1,22 +1,33 @@
-{{#if (not @isEditable)}}
-  <AuPill
-    @size="small"
-    @skin={{this.skin}}
-    @icon={{this.icon}}
-    data-test-decision-result-pill
-  >
-    {{this.label}}
-  </AuPill>
-{{else}}
-  <AuPill
-    @size="small"
-    @skin={{this.skin}}
-    @icon={{this.icon}}
-    @onClickAction={{@onEdit}}
-    @actionIcon="pencil"
-    @actionText={{t "edit"}}
-    data-test-decision-result-pill
-  >
-    {{this.label}}
-  </AuPill>
-{{/if}}
+{{#let (load @decisionResultCode) as |decisionResultCode|}}
+  {{#if decisionResultCode.isResolved}}
+    {{#if (not @isEditable)}}
+      <AuPill
+        @size="small"
+        @skin={{this.skin}}
+        @icon={{this.icon}}
+        data-test-decision-result-pill
+      >
+        {{this.label}}
+      </AuPill>
+    {{else}}
+      <AuPill
+        @size="small"
+        @skin={{this.skin}}
+        @icon={{this.icon}}
+        @onClickAction={{@onEdit}}
+        @actionIcon="pencil"
+        @actionText={{t "edit"}}
+        data-test-decision-result-pill
+      >
+        {{this.label}}
+      </AuPill>
+    {{/if}}
+  {{else}}
+    <AuPill
+      @size="small"
+      @skin="default"
+    >
+      {{t "loading"}}
+    </AuPill>
+  {{/if}}
+{{/let}}

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "cypress": "^12.14.0",
     "date-fns": "^2.29.3",
     "dayjs": "^1.11.7",
+    "ember-async-data": "^1.0.3",
     "ember-auto-import": "^2.5.0",
     "ember-cli": "~4.8.0",
     "ember-cli-app-version": "^5.0.0",


### PR DESCRIPTION
Adds a separate loading state to the decision pills. This is better than the current behavior that shows "No decision yet" while loading. This is not what we want.