### PR TITLE
KAS-4567: add `process/browser` webpack polyfill

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 const Funnel = require('broccoli-funnel');
+const webpack = require('webpack');
 
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
@@ -46,6 +47,15 @@ module.exports = function (defaults) {
         '@ember-data/store': {
           polyfillUUID: true,
         },
+      },
+    },
+    autoImport: {
+      webpack: {
+        plugins: [
+          new webpack.ProvidePlugin({
+            process: 'process/browser.js',
+          }),
+        ],
       },
     },
   });


### PR DESCRIPTION
### Overview

Adds a `process/browser` polyfill which should be a solution to the error `process is undefined` which shows up when opening the `ember-rdfa-editor`.

##### connected issues and PRs:
KAS-4567

### How to test/reproduce

- Start-up the application
- Open a page which contains the editor
- Notice that the `process is undefined` error is gone and the editor is usable again

### Challenges/uncertainties

Unsure why this error pops-up now, our projects using the editor do not require this polyfill. This can, of course, be caused by a transitive dependency.