### PR TITLE
KAS-4606: Agenda activity numbering migration

### DIFF
--- a/app/models/piece.js
+++ b/app/models/piece.js
@@ -16,6 +16,8 @@ export default class Piece extends Model {
   @attr('datetime') receivedDate;
   @attr('datetime') modified;
   @attr('datetime') accessLevelLastModified;
+  @attr('number') position;
+  @attr originalName;
 
   @belongsTo('concept', { inverse: null, async: true }) accessLevel;
   @belongsTo('language', { inverse: null, async: true }) language;

--- a/app/models/piece.js
+++ b/app/models/piece.js
@@ -17,7 +17,7 @@ export default class Piece extends Model {
   @attr('datetime') modified;
   @attr('datetime') accessLevelLastModified;
   @attr('number') position;
-  @attr originalName;
+  @attr('string') originalName;
 
   @belongsTo('concept', { inverse: null, async: true }) accessLevel;
   @belongsTo('language', { inverse: null, async: true }) language;

--- a/app/models/subcase.js
+++ b/app/models/subcase.js
@@ -10,6 +10,7 @@ export default class Subcase extends ModelWithModifier {
   @attr title;
   @attr('boolean') confidential; // this is now "limited access"
   @attr subcaseName;
+  @attr('number') agendaActivityNumber;
 
   get modelName() {
     return this.constructor.modelName;


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4606

Adds new properties to subcase and piece.

Related PRs:

- [ ] https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/463
- [ ] https://github.com/kanselarij-vlaanderen/document-numbering-migration-service/pull/1
