### PR TITLE
KAS-4619

### DIFF
--- a/app/components/subcase/description-panel/view.hbs
+++ b/app/components/subcase/description-panel/view.hbs
@@ -58,6 +58,9 @@
       {{#if @subcase.title}}
         <p data-test-subcase-description-title>{{capitalize @subcase.title}}</p>
       {{/if}}
+      {{#if @subcase.parliamentRetrievalActivity}}
+        <AuHelpText @skin="secondary">{{t "from-parliament"}}</AuHelpText>
+      {{/if}}
     </Auk::Panel::Body>
     <Auk::Panel::Body>
       <div class="au-o-grid au-o-grid--small au-u-1-1">
@@ -145,6 +148,22 @@
             {{if @subcase.subcaseName @subcase.subcaseName '-'}}
           </p>
         </div>
+        {{#if @subcase.parliamentRetrievalActivity}}
+          <div class="au-o-grid__item au-u-1-2 au-u-1-4@medium">
+            <AuHeading @level="4" @skin="6">
+              {{capitalize (t "remark")}}
+            </AuHeading>
+            {{#if this.loadComments.isRunning}}
+              <Auk::Loader />
+            {{else}}
+              {{#each this.comments as |comment|}}
+                <AuHelpText @skin="secondary">{{comment}}</AuHelpText>
+              {{else}}
+              -
+              {{/each}}
+            {{/if}}
+          </div>
+        {{/if}}
       </div>
     </Auk::Panel::Body>
   </Auk::Panel>

--- a/app/components/subcase/description-panel/view.js
+++ b/app/components/subcase/description-panel/view.js
@@ -24,7 +24,22 @@ export default class SubcaseDescriptionView extends Component {
   constructor() {
     super(...arguments);
     this.loadAgendaData.perform();
+    this.loadComments.perform();
   }
+
+  loadComments = task(async () => {
+    const retrievedPieces = await this.store.queryAll('retrieved-piece', {
+      'filter[parliament-retrieval-activity][generated-subcase][:id:]':
+        this.args.subcase.id,
+    });
+    if (!retrievedPieces) {
+      this.comments =  [];
+    } else {
+      this.comments = retrievedPieces
+        .map((piece) => piece.comment)
+        .filter((comment) => comment?.length);
+    }
+  });
 
   get canShowDecisionStatus() {
     return (

--- a/app/models/parliament-retrieval-activity.js
+++ b/app/models/parliament-retrieval-activity.js
@@ -19,5 +19,5 @@ export default class ParliamentRetrievalActivity extends Model {
   })
   generatedSubcase;
 
-  @hasMany('retrieved-piece', { inverse: null, async: true }) submittedPieces;
+  @hasMany('retrieved-piece', { inverse: null, async: true }) retrievedPieces;
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4619

A normal "definitieve goedkeuring" is the same as before:
![image](https://github.com/kanselarij-vlaanderen/frontend-kaleidos/assets/22411874/e3cf0b16-d704-4f59-a07e-3f8db2f1caf8)

A "definitieve goedkeuring" that was created from a VP flow now includes a text "Van het Vlaams Parlement" and the remarks if there were any:
![image](https://github.com/kanselarij-vlaanderen/frontend-kaleidos/assets/22411874/1470a69a-9e40-46fc-a992-6ca0e79039d7)
