### PR TITLE
KAS-4618: Spatie tonen incorrect binnen subcase anchor navigatie

### DIFF
--- a/app/components/on-this-page-links.hbs
+++ b/app/components/on-this-page-links.hbs
@@ -1,6 +1,6 @@
 <div>
   <div class="c-anchor-nav-holder">
-    <p>{{t "on-this-page"}}: </p>
+    <p>{{t "on-this-page"}}:&nbsp;</p>
     <ul class="au-c-anchor-nav">
       {{#each @items as |item|}}
         <li>

--- a/app/styles/custom-application/cases.scss
+++ b/app/styles/custom-application/cases.scss
@@ -56,16 +56,27 @@
 }
 
 .c-anchor-nav-holder {
-  color: var(--au-gray-700);
   display: flex;
-  align-items: center;
+  align-items: start;
+
+  margin: $au-unit-tiny 0;
+
+  color: var(--au-gray-700);
+
+  > p {
+    flex: 0 0 auto;
+  }
 }
 
 .au-c-anchor-nav {
   display: flex;
-  gap: $au-unit-tiny;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  gap: $au-unit-tiny / 1.5;
+  row-gap: 0;
 
   a {
+    display: inline-flex;
     font-weight: var(--au-medium);
   }
 
@@ -80,7 +91,7 @@
   }
 
   li:not(:last-child) a:after {
-    content: ","
+    content: ",";
   }
 }
 


### PR DESCRIPTION
**Tickets binnen Jira:** 
- https://kanselarij.atlassian.net/browse/KAS-4618

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.