### PR TITLE
KAS-4665: Witruimte valt weg bij bepaalde panels binnen dossierweergave

### DIFF
--- a/app/styles/custom-application/cases.scss
+++ b/app/styles/custom-application/cases.scss
@@ -136,10 +136,10 @@
 }
 
 .c-document-panel {
-  padding: 0;
   .auk-u-mb-2 {
     margin-bottom: 0 !important;
   }
+
   .vlc-document-card {
     background-color: white;
     border: 0;


### PR DESCRIPTION
**Tickets binnen Jira:** 
- https://kanselarij.atlassian.net/browse/KAS-4665

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.