### PR TITLE
feat: expand supported file types for conversion

### DIFF
--- a/app/config/config.js
+++ b/app/config/config.js
@@ -28,10 +28,23 @@ export const SIGN_FLOW_STATUS_REFRESH_INTERVAL_MS = 60 * 1000;
 
 export const DOCUMENT_DELETE_UNDO_TIME_MS = 15000;
 
+export const DOCUMENT_CONVERSION_SUPPORTED_EXTENSIONS = [
+  'doc',
+  'docx',
+  'odp',
+  'xls',
+  'xlsx',
+  'ods',
+];
 export const DOCUMENT_CONVERSION_SUPPORTED_MIME_TYPES = [
-  'application/msword',
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-  'application/octet-stream',
+  'application/msword', // DOC (LibreOffice)
+  'application/vnd.ms-excel', // XLS (LibreOffice)
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document', // DOCX (Word)
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', // XLSX (Excel)
+  'application/vnd.oasis.opendocument.text', // ODT (Google Docs, LibreOffice)
+  'application/vnd.oasis.opendocument.spreadsheet', // ODS (Google Docs, LibreOffice)
+  'application/zip', // DOCX (Google Docs), XLSX (Google Docs, LibreOffice)
+  'application/octet-stream' // DOCX (LibreOffice - Word 2010 - 365 format),
 ];
 export const EMAIL_ATTACHMENT_WARN_SIZE = 10 * 1000000; // 10 MB
 export const EMAIL_ATTACHMENT_MAX_SIZE = 30 * 1000000; // 30 MB

--- a/app/services/file-conversion-service.js
+++ b/app/services/file-conversion-service.js
@@ -1,6 +1,7 @@
 import Service, { inject as service } from '@ember/service';
 import fetch from 'fetch';
 import {
+  DOCUMENT_CONVERSION_SUPPORTED_EXTENSIONS,
   DOCUMENT_CONVERSION_SUPPORTED_MIME_TYPES,
 } from 'frontend-kaleidos/config/config';
 
@@ -8,7 +9,12 @@ export default class FileConversionService extends Service {
   @service store;
 
   async convertSourceFile(sourceFile) {
-    if (DOCUMENT_CONVERSION_SUPPORTED_MIME_TYPES.some((mimeType) => sourceFile.format.includes(mimeType))) {
+    if (
+      DOCUMENT_CONVERSION_SUPPORTED_MIME_TYPES.some(
+        (mimeType) => sourceFile.format.includes(mimeType)
+      )
+        && DOCUMENT_CONVERSION_SUPPORTED_EXTENSIONS.includes(sourceFile.extension)
+    ) {
       const oldDerivedFile = await sourceFile.derived;
       if (oldDerivedFile) {
         // if derived file exists we keep it. Generated PDF is not yet correct for users


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4627

Expands the config in the frontend to allow more files to be sent to the conversion service.

Conversion service (well, the API we use behind the screens) supports converting DOC(X), ODP, XLS(X), and ODT files (and some more that we're not interested in). So we also send these files for conversion.

TBD if we want/need to merge this → draft status