### PR TITLE
KAS-4679: Volledig scherm rdfa-editor werkt niet meer

### DIFF
--- a/app/styles/auk/_auk-components.scss
+++ b/app/styles/auk/_auk-components.scss
@@ -15,6 +15,7 @@
 @import '@kanselarij-vlaanderen/au-kaleidos-css/auk-container';
 @import '@kanselarij-vlaanderen/au-kaleidos-css/auk-content';
 @import '@kanselarij-vlaanderen/au-kaleidos-css/auk-document-card';
+@import '@kanselarij-vlaanderen/au-kaleidos-css/auk-editor';
 @import '@kanselarij-vlaanderen/au-kaleidos-css/auk-empty-state';
 @import '@kanselarij-vlaanderen/au-kaleidos-css/auk-file-upload';
 @import '@kanselarij-vlaanderen/au-kaleidos-css/auk-filter-pill';


### PR DESCRIPTION
**Tickets binnen Jira:** 
- https://kanselarij.atlassian.net/browse/KAS-4679

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.