### PR TITLE
KAS-4698: ember-appuniversum package updaten naar meest recente versie (3.4.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@appuniversum/appuniversum": "^1.2.0",
-        "@appuniversum/ember-appuniversum": "3.3.1",
+        "@appuniversum/ember-appuniversum": "3.4.2",
         "@babel/eslint-parser": "^7.21.3",
         "@babel/plugin-proposal-decorators": "^7.21.0",
         "@codemirror/basic-setup": "^0.20.0",
@@ -155,9 +155,9 @@
       "dev": true
     },
     "node_modules/@appuniversum/ember-appuniversum": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-3.3.1.tgz",
-      "integrity": "sha512-Molgrks+lR74v0+YOTXYOKo2QXO+e1GGQtJOOS0M5Or0fjNXQ6xcoVDkKSOAk5j+zGluhYlDkqkI3gzcyJB+Ng==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-3.4.2.tgz",
+      "integrity": "sha512-GsMbEhk5KucUwiLLTY8dP7q++7kE8vKSWvqVkrz9FilBuPTGUn6vAkfx9904eyGRKYfmutVRbVUZQQOn4nagrA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.23.2",
@@ -174,7 +174,7 @@
         "ember-file-upload": "^8.4.0",
         "ember-focus-trap": "^1.1.0",
         "ember-modifier": "^4.1.0",
-        "ember-template-imports": "^3.4.2",
+        "ember-template-imports": "^4.1.1",
         "ember-test-selectors": "^6.0.0",
         "ember-truth-helpers": "^3.1.1 || ^4.0.3",
         "inputmask": "^5.0.9-beta.45",
@@ -966,6 +966,20 @@
         "@babel/core": "^7.3.4",
         "object-assign": "4.1.1",
         "rsvp": "^4.8.4"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-template-imports": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ember-template-imports/-/ember-template-imports-4.1.1.tgz",
+      "integrity": "sha512-mnbL3hjo/Ctg7rkBtuYkBRJUn5bDYRQCEZQxmNozRnfoEp2RLSbT6SFJRAFDYXT2OrY+8i821S4kPL1i0QuGIw==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-stew": "^3.0.0",
+        "content-tag": "^2.0.1",
+        "ember-cli-version-checker": "^5.1.2"
+      },
+      "engines": {
+        "node": "16.* || >= 18"
       }
     },
     "node_modules/@appuniversum/ember-appuniversum/node_modules/find-babel-config": {
@@ -14268,6 +14282,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/content-tag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/content-tag/-/content-tag-2.0.1.tgz",
+      "integrity": "sha512-jxsETSDs5NbNwyiDuIp672fUMhUyu8Qxc5MOBOJOcgW/fQESI6o5K1LBDrnEE7Bh810a685lWEZHTF4jQYGEEw==",
+      "dev": true
     },
     "node_modules/content-type": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@appuniversum/appuniversum": "^1.2.0",
-    "@appuniversum/ember-appuniversum": "3.3.1",
+    "@appuniversum/ember-appuniversum": "3.4.2",
     "@babel/eslint-parser": "^7.21.3",
     "@babel/plugin-proposal-decorators": "^7.21.0",
     "@codemirror/basic-setup": "^0.20.0",


### PR DESCRIPTION
**Tickets binnen Jira:** 
- https://kanselarij.atlassian.net/browse/KAS-4698

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.