### PR TITLE
fix document regex to not strip when no type was found, support both ways

### DIFF
--- a/app/components/cases/subcases/new-subcase-form.hbs
+++ b/app/components/cases/subcases/new-subcase-form.hbs
@@ -204,7 +204,7 @@
         data-test-new-subcase-form-save
         @skin="primary"
         @disabled={{or this.createSubcase.isRunning this.isUploadingFiles}}
-        {{on "click" (toggle "showProposableAgendaModal" this)}}
+        {{on "click" (perform this.openProposableAgendaModal)}}
       >
         {{t "new-subcase"}}
       </AuButton>

--- a/app/components/cases/subcases/new-subcase-form.js
+++ b/app/components/cases/subcases/new-subcase-form.js
@@ -406,4 +406,25 @@ export default class NewSubcaseForm extends Component {
     await documentContainer?.destroyRecord();
     await piece?.destroyRecord();
   }
+
+  @task
+  *openProposableAgendaModal() {
+    if (this.pieces.length) {
+      // enforce all new pieces must have type on document container
+      const typesPromises = this.pieces.map(async (piece) => {
+        const container = await piece.documentContainer;
+        const type = await container.type;
+        return type;
+      });
+      const types = yield all(typesPromises);
+      if (types.some(type => !type)) {
+        this.toaster.error(
+          this.intl.t('document-type-required'),
+          this.intl.t('warning-title'),
+        );
+        return;
+      }
+    }
+    this.showProposableAgendaModal = true;
+  }
 }

--- a/app/controllers/agenda/agendaitems/agendaitem/documents.js
+++ b/app/controllers/agenda/agendaitems/agendaitem/documents.js
@@ -163,6 +163,20 @@ export default class DocumentsAgendaitemsAgendaController extends Controller {
   }
 
   savePieces = task(async () => {
+    // enforce all new pieces must have type on document container
+    const typesPromises = this.newPieces.map(async (piece) => {
+      const container = await piece.documentContainer;
+      const type = await container.type;
+      return type;
+    });
+    const types = await all(typesPromises);
+    if (types.some(type => !type)) {
+      this.toaster.error(
+        this.intl.t('document-type-required'),
+        this.intl.t('warning-title'),
+      );
+      return;
+    }
     const savePromises = this.sortedNewPieces.map(async (piece, index) => {
       try {
         await this.savePiece.perform(piece, index);

--- a/app/controllers/cases/case/subcases/subcase/index.js
+++ b/app/controllers/cases/case/subcases/subcase/index.js
@@ -118,6 +118,21 @@ export default class CasesCaseSubcasesSubcaseIndexController extends Controller 
 
   @task
   *savePieces() {
+    // enforce all new pieces must have type on document container
+    const typesPromises = this.newPieces.map(async (piece) => {
+      const container = await piece.documentContainer;
+      const type = await container.type;
+      return type;
+    });
+    const types = yield all(typesPromises);
+    if (types.some(type => !type)) {
+      this.toaster.error(
+        this.intl.t('document-type-required'),
+        this.intl.t('warning-title'),
+      );
+      return;
+    }
+
     const savePromises = this.sortedNewPieces.map(async(piece, index) => {
       try {
         await this.savePiece.perform(piece, index);
@@ -301,7 +316,6 @@ export default class CasesCaseSubcasesSubcaseIndexController extends Controller 
     }
     this.router.refresh('cases.case.subcases.subcase');
   }
-
 
   @action
   async openBatchDetails() {

--- a/app/utils/vr-cabinet-document-name.js
+++ b/app/utils/vr-cabinet-document-name.js
@@ -36,12 +36,13 @@ export default class VRCabinetDocumentName {
       match = this.regexTypeNumber.exec(this.name);
       if (!match || !match.groups.type) {
         return {
-          subject: this.name,
+            subject: this.name,
+            index: parseInt(match?.groups.index, 10),
         };
       }
     }
 
-    const subject = match.groups.subject;
+    const subject = match.groups.subject?.trim();
     const versionSuffix = match.groups.versionSuffix;
     let versionNumber = 1;
     if (versionSuffix) {
@@ -50,7 +51,6 @@ export default class VRCabinetDocumentName {
     const meta = {
       subject,
       type: match.groups.type,
-      indexNrRaw: match.groups.index,
       index: parseInt(match.groups.index, 10),
       versionSuffix,
       versionNumber,

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1379,5 +1379,6 @@
   "most-recent-documents": "Recentste documenten",
   "saving-in-progress-please-wait": "Bezig met opslaan, gelieve even te wachten.",
   "check-agenda": "Agenda controleren",
-  "an-agenda-was-approved-since-modal-was-opened": "Er werd in tussentijd reeds een agenda goedgekeurd. De automatische documentsnamen zijn niet meer up-to-date, herlaad de pagina en probeer opnieuw."
+  "an-agenda-was-approved-since-modal-was-opened": "Er werd in tussentijd reeds een agenda goedgekeurd. De automatische documentsnamen zijn niet meer up-to-date, herlaad de pagina en probeer opnieuw.",
+  "document-type-required": "Type document is verplicht, gelieve voor alle documenten een type in te stellen."
 }


### PR DESCRIPTION
no ticket yet.
Document name stripping on upload is too aggressive

changed the query to be less aggressive and support both "subject-type-index" and "subject-index-type" regardless of how many dashes subject has