### PR TITLE
fix: replace odp with odt

### DIFF
--- a/app/config/config.js
+++ b/app/config/config.js
@@ -31,7 +31,7 @@ export const DOCUMENT_DELETE_UNDO_TIME_MS = 15000;
 export const DOCUMENT_CONVERSION_SUPPORTED_EXTENSIONS = [
   'doc',
   'docx',
-  'odp',
+  'odt',
   'xls',
   'xlsx',
   'ods',


### PR DESCRIPTION
.odp is for presentation files (like powerpoints) which users won't upload to Kaleidos. .odt is for document files (like word files) which might be relevant.