### PR TITLE
Feature/kas 4718 upload confidential parsing

### DIFF
--- a/app/utils/vr-cabinet-document-name.js
+++ b/app/utils/vr-cabinet-document-name.js
@@ -31,9 +31,13 @@ export default class VRCabinetDocumentName {
   }
 
   parseMeta() {
-    let match = this.regexNumberType.exec(this.name);
+    // 1 side effect, if "vertrouwelijk" is also in the subject this will replace that one instead
+    const trimmedName = this.name.replace(/[\s-]*VERTROUWELIJK/i, '');
+    const confidential = this.name.length < trimmedName.length ? true : false;
+
+    let match = this.regexNumberType.exec(trimmedName);
     if (!match || !match.groups.type) {
-      match = this.regexTypeNumber.exec(this.name);
+      match = this.regexTypeNumber.exec(trimmedName);
       if (!match || !match.groups.type) {
         return {
             subject: this.name,
@@ -54,6 +58,7 @@ export default class VRCabinetDocumentName {
       index: parseInt(match.groups.index, 10),
       versionSuffix,
       versionNumber,
+      confidential
     };
     return meta;
   }

--- a/app/utils/vr-cabinet-document-name.js
+++ b/app/utils/vr-cabinet-document-name.js
@@ -27,14 +27,13 @@ export default class VRCabinetDocumentName {
 
   get regexNumberType() {
     // versionSuffix doesn't really work here, since type uses .*; even with tweaks, QUATER matches with TER
-    // parsing confidential is also difficult in this regex, it will be included in type just as suffix
     const regexGroup = VRCabinetDocumentName.regexGroups;
     return new RegExp(`(?<subject>.*)?[/-]${regexGroup.index}(?:[/-]${regexGroup.type})${regexGroup.versionSuffix}?$`);
   }
 
-  get regexTypeNumberConfidential() {
+  get regexTypeNumber() {
     const regexGroup = VRCabinetDocumentName.regexGroups;
-    // versionSuffex is probably not in the right location here, but realistically this is only used for first upload and version should never be present
+    // versionSuffix is included here, but realistically this is only used for first upload and version should never be present
     return new RegExp(`(?<subject>.*)(?:[/-]${regexGroup.type})[/-]${regexGroup.index}${regexGroup.versionSuffix}?$`);
   }
 
@@ -52,7 +51,7 @@ export default class VRCabinetDocumentName {
 
     let match = this.regexNumberType.exec(strippedName);
     if (!match || !match.groups.type) {
-      match = this.regexTypeNumberConfidential.exec(strippedName);
+      match = this.regexTypeNumber.exec(strippedName);
       if (!match || !match.groups.type) {
         return {
             subject: this.name,

--- a/app/utils/vr-cabinet-document-name.js
+++ b/app/utils/vr-cabinet-document-name.js
@@ -21,8 +21,9 @@ export default class VRCabinetDocumentName {
   }
 
   get regexConfidential() {
+    // the group before confidential group matches greedily after index is found to include all extra spaces and dashes
     const regexGroup = VRCabinetDocumentName.regexGroups;
-    return new RegExp(`(?<subject>.*)?[\\s/-]+(?:${regexGroup.confidential})$`);
+    return new RegExp(`(?<subject>.*)[/-]${regexGroup.index}(?:.*${regexGroup.confidential})$`);
   }
 
   get regexNumberType() {

--- a/app/utils/vr-cabinet-document-name.js
+++ b/app/utils/vr-cabinet-document-name.js
@@ -7,7 +7,7 @@ export default class VRCabinetDocumentName {
       index: '(?<index>\\d{1,3})',
       versionSuffix: `(?<versionSuffix>(${Object.values(CONFIG.latinAdverbialNumberals).map((suffix) => suffix?.toUpperCase())
         .join(')|(')}))`.replace('()|', ''), // Hack to get out the value for piece '0'
-      confidential: '(?<confidential>VERTROUWELIJK)', //
+      confidential: '(?<confidential>VERTROUWELIJK)', // check with uppercased string
     });
   }
 


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4718

## first attempt, quickly abandoned (see final attempt for actual solution, did not want to remove all this info I gathered)
tried changing both regexes, did not work since the first regex has the `.*` it catches all

## second attempt 

Just replacing the text "vertrouwelijk" before the regexes is very unreliable, since the subject may have it and/or in the end of the name. In some (rare) cases the subject will be stripped.

Tried with regex but the possibility where a space is used to separate makes it difficult to parse without making the regex needlessly more complex for the first regex (subject-index-type, the desired format to use)

The second regex (subject-type-index, the format Kenny was using to test even after we agreed the first format) would fail without changing the regex or replacing unless regex was expanded.

So the solution (not ideal, but close):
- The first regex remains as is, everything will be included in the match "type" since that catches all remaining `.*`
After that we try to replace "vertrouwelijk" case insensitive, if it works, we know it was confidential and update the type so we can match it against the correct document-type (we should probably do versionsuffix at this stage aswell since the first regex does not work with versionsuffix but I would argue versionsuffix should never exist in this scenario of first upload...)
- The second regex (if first misses) will except "vertrouwelijk" all uppercase or all lowercase to exist 0 to 1 time at the end.
Making it case insensitive is not possible here.
when it is matched, we can determine it by checking that match group.


We pass on the confidential param in the meta.

If all else fails, return the full name (including the possible "vertrouwelijk")
Fails could be:
- misspelling in regex 2 (vetrouwelijk)
- caps usage in regex 2 ("Vertrouwelijk")
- version suffix being present (if it does ever happen, will it be "onderwerp-2-notaBIS-vertrouwelijk" or "onderwerp-2-nota-vertrouwelijkBIS"??


Existing rules still apply (dashes in subject and whatnot)
Examples
First regex:
![image](https://github.com/kanselarij-vlaanderen/frontend-kaleidos/assets/22245223/e3aadb36-549f-41c6-9cdc-0d994d818367)

**There is still an issue with this. the matches are not ok.**

Second regex:
![image](https://github.com/kanselarij-vlaanderen/frontend-kaleidos/assets/22245223/7a38b533-e79c-495e-8aea-8beeda26a6da)

# final attempt (when typing out attempt 2 I noticed more issues with it that are not easy to solve.

Follow the ticket more, replacing text before the regexes but instead of doing a string replace right away I added a new simpler regex to detect "VERTROUWELIJK" first and case insensitive (making the name all uppercase before)
If detected: we will do the string replace but we have a clear separation of where it was found.
If it was in the subject  > not found, nothing happens, we continue with the other regexes
If it was at the end > strip it out of that part > we continue with the other regexes (which now no longer need to check for "vertrouwelijk", making is way easier to keep working code as-is

examples:
First check for confidential
![image](https://github.com/kanselarij-vlaanderen/frontend-kaleidos/assets/22245223/ae92c788-461d-4a0b-920f-00628044f835)

Then, the name is stripped so vertrouwelijk is gone from the name.
this was actually **another issue** I just found, the subject is way too long and could contain whitespaces and dashes, changed to regex a bit:

![image](https://github.com/kanselarij-vlaanderen/frontend-kaleidos/assets/22245223/869b56c6-1c10-4666-98e1-7edc5ec764e2)

Now the subject is shorter and we still only hit the confidential match if it exists
Now we can split the string using subject length, replace the final part of the string to remove "vertrouwelijk" and reassemble the string.

Then we can do the existing regexes.
Which will look like this (vertrouwelijk removed ofc)

first regex
![image](https://github.com/kanselarij-vlaanderen/frontend-kaleidos/assets/22245223/067075d6-61f0-417a-baf1-828fcbbb2b3d)

second regex
![image](https://github.com/kanselarij-vlaanderen/frontend-kaleidos/assets/22245223/eb678c01-fc51-4c1e-adbb-3916f075d3d7)


Made is so that it shouldn't matter how many spaces or dashes exist in combination with "vertrouwelijk", they should all get removed before attempting to do the other regexes
