### PR TITLE
Fix document badge list on mobile

### DIFF
--- a/app/components/documents/document-badge.hbs
+++ b/app/components/documents/document-badge.hbs
@@ -1,11 +1,11 @@
-<div class="au-u-flex au-u-flex--spaced-tiny au-u-flex--vertical-center">
+<div class="au-u-flex au-u-flex--spaced-tiny au-u-flex--vertical-center au-u-flex--wrap">
   <a
     href={{@doc.viewDocumentURL}} rel="noreferrer noopener"
     data-test-document-badge-link
   >
     {{#let (await @doc.documentContainer) as |documentContainer|}}
       {{#if documentContainer.position}}
-        <p>{{documentContainer.position}}.&nbsp;</p>
+        <p class="vlc-document-list__position">{{documentContainer.position}}.&nbsp;</p>
       {{/if}}
     {{/let}}
     <AuIcon @icon={{if @isHighlighted "document-added" "document"}} class="au-u-flex-item--fixed" />
@@ -14,7 +14,7 @@
     </span>
   </a>
   {{#if @isHighlighted}}
-    <span data-test-document-badge-isNew class="auk-o-flex auk-o-flex--spaced auk-u-text-small au-u-muted auk-u-text-nowrap auk-u-mr-2">
+    <span data-test-document-badge-isNew class="auk-o-flex auk-o-flex--spaced auk-u-text-small au-u-muted auk-u-text-nowrap auk-u-mr-2 auk-u-ml-2">
       <Auk::ColorBadge @skin="success" class="au-u-padding-right-none" />
       <span>{{t "new-document"}}</span>
     </span>

--- a/app/styles/custom-components/_vlc-document-list.scss
+++ b/app/styles/custom-components/_vlc-document-list.scss
@@ -11,10 +11,19 @@
 .vlc-document-list__item {
   list-style: none;
   margin: 0.5rem 1rem 0.5rem 0;
+  padding-left: 1.25rem;
+  position: relative;
+
+  .vlc-document-list__position { 
+    flex: none;
+    position: absolute;
+    top: .25ex;
+    left: 0;
+  }
 
   a, span:not(.au-c-pill) {
     display: flex;
-    align-items: center;
+    align-items: baseline;
     padding-right: .5rem;
 
     color: $auk-gray-600;
@@ -31,7 +40,7 @@
     &:hover,
     &:active {
       background: $auk-gray-100;
-      border-radius: 1.5rem;
+      border-radius: 1rem;
     }
 
     &:focus {
@@ -41,6 +50,7 @@
 
   .au-c-icon {
     margin-right: 0.5rem;
+    bottom: -.5ex;
   }
 
   .au-c-pill {


### PR DESCRIPTION
Improve layout of document badge list on mobile:
- fix overflow
- improve spacing of numbers and pills