### PR TITLE
Feature/fix dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="info@redpencil.io"
 WORKDIR /app
 COPY .npmrc .
 COPY package.json package-lock.json ./
-RUN CYPRESS_INSTALL_BINARY=0 npm install
+RUN CYPRESS_INSTALL_BINARY=0 npm ci
 COPY . .
 
 RUN ember build -prod

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="info@redpencil.io"
 
 WORKDIR /app
 COPY .npmrc .
-COPY package.json .
+COPY package.json package-lock.json ./
 RUN CYPRESS_INSTALL_BINARY=0 npm install
 COPY . .
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -4,7 +4,7 @@ LABEL maintainer="info@redpencil.io"
 
 WORKDIR /app
 COPY .npmrc .
-COPY package.json .
+COPY package.json package-lock.json ./
 RUN CYPRESS_INSTALL_BINARY=0 npm install
 COPY . .
 


### PR DESCRIPTION
CI and woodpecker was failing.

According to Sam it could be ember-data issue (we have 4.11.2, latest is 4.12.8).
In any case. our builds were failing because package lock exists but is not being used in docker builds.
Some dependency changed and is now breaking our build. Solved by forcing our lock file on build

This probably needs to be fixed on PROD and ACC aswell (if any hotfix happens, they will break)