### PR TITLE
KAS-4771 various fixes after user tests

### DIFF
--- a/app/components/cases/submissions/notifications.hbs
+++ b/app/components/cases/submissions/notifications.hbs
@@ -84,22 +84,25 @@
             {{/each}}
           </AuList>
         </Auk::Panel::Body>
-        {{#if this.isEditing }}
         <Auk::Panel::Body class="auk-u-p-2">
           <div class="auk-form-group">
             <AuLabel for="approvalComment">
               {{t "additional-information"}}
             </AuLabel>
-            <AuTextarea
-              @width="block"
-              rows="4"
-              value={{@approvalComment}}
-              id="approvalComment"
-              {{on "change" (pick "target.value" this.onChangeApprovalComment)}}
-            />
+            {{#if this.isEditing }}
+              <AuTextarea
+                @width="block"
+                rows="4"
+                value={{@approvalComment}}
+                id="approvalComment"
+                {{on "change" (pick "target.value" this.onChangeApprovalComment)}}
+              />
+            {{else}}
+              <hr class="auk-u-my-2"/>
+              <pre class="auk-u-text-pre-line">{{@approvalComment}}</pre>
+            {{/if}}
           </div>
         </Auk::Panel::Body>
-        {{/if}}
       </Auk::Panel>
       <Auk::Panel class="auk-u-mt-4">
         <Auk::Panel::Header class="au-u-padding-left-small au-u-padding-right-small">
@@ -155,22 +158,25 @@
           {{/each}}
           </AuList>
         </Auk::Panel::Body>
-        {{#if this.isEditing }}
         <Auk::Panel::Body class="auk-u-p-2">
           <div class="auk-form-group">
             <AuLabel for="notificationComment">
               {{t "additional-information-for-ikw-group"}}
             </AuLabel>
-            <AuTextarea
-              @width="block"
-              rows="4"
-              value={{@notificationComment}}
-              id="notificationComment"
-              {{on "change" (pick "target.value" this.onChangeNotificationComment)}}
-            />
+            {{#if this.isEditing }}
+              <AuTextarea
+                @width="block"
+                rows="4"
+                value={{@notificationComment}}
+                id="notificationComment"
+                {{on "change" (pick "target.value" this.onChangeNotificationComment)}}
+              />
+            {{else}}
+              <hr class="auk-u-my-2"/>
+              <pre class="auk-u-text-pre-line">{{@notificationComment}}</pre>
+            {{/if}}
           </div>
         </Auk::Panel::Body>
-        {{/if}}
       </Auk::Panel>
     </Utils::LoadableContent>
   </Auk::Panel::Body>

--- a/app/components/submission/header.js
+++ b/app/components/submission/header.js
@@ -18,6 +18,7 @@ export default class SubmissionHeaderComponent extends Component {
   @service toaster;
   @service pieceUpload;
   @service subcaseService;
+  @service agendaitemAndSubcasePropertiesSync
 
   @tracked isOpenResubmitModal;
   @tracked isOpenCreateSubcaseModal;
@@ -208,13 +209,24 @@ export default class SubmissionHeaderComponent extends Component {
           mandatees,
           governmentAreas,
         });
+        await subcase.save();
       } else {
         await subcase.belongsTo('requestedBy')?.reload();
         await subcase.hasMany('mandatees')?.reload();
-        subcase.requestedBy = requestedBy;
-        subcase.mandatees = mandatees;
+        const propertiesToSetOnAgendaitem = {
+          mandatees: mandatees,
+        };
+        const propertiesToSetOnSubcase = {
+          mandatees: mandatees,
+          requestedBy: requestedBy,
+        };
+        await this.agendaitemAndSubcasePropertiesSync.saveChanges(
+          subcase,
+          propertiesToSetOnAgendaitem,
+          propertiesToSetOnSubcase,
+          true,
+        );
       }
-      await subcase.save();
 
       this.piecesMovedCounter = 0;
       const pieces = await Promise.all(

--- a/app/controllers/cases/case/subcases/subcase/new-submission.js
+++ b/app/controllers/cases/case/subcases/subcase/new-submission.js
@@ -205,12 +205,18 @@ export default class CasesCaseSubcasesSubcaseNewSubmissionController extends Con
     const requestedBy = await this.requestedBy;
     const governmentAreas = await this.model.governmentAreas;
 
-    const meeting = await this.originalSubmission?.meeting;
+    let meeting;
+    if (this.originalSubmission) {
+      // this fixes a cache issue that leaves meeting null for KDB
+      meeting = await this.store.queryOne('meeting', {
+        'filter[:has:plannedStart]': `date-added-for-cache-busting-${new Date().toISOString()}`,
+        'filter[submissions][:id:]': this.originalSubmission.id
+      });
+    }
 
     const status = this.originalSubmission ? updateSubmitted : submitted;
 
     const creator = await this.currentSession.user;
-    // TODO fix cache issue that leaves meeting null for KDB
     const plannedStart = meeting?.plannedStart || this.originalSubmission?.plannedStart;
 
     this.submission = this.store.createRecord('submission', {

--- a/app/controllers/cases/submissions/submission.js
+++ b/app/controllers/cases/submissions/submission.js
@@ -141,7 +141,13 @@ export default class CasesSubmissionsSubmissionController extends Controller {
       }
     }
     this.documentContainerIds = documentContainerIds;
-    this.newDraftPieces = newPieces;
+    for (const newPiece of newPieces) {
+      await newPiece.documentContainer;
+    }
+    const sortedNewPieces = newPieces?.slice().sort(
+      (p1, p2) => p1.documentContainer.get('position') - p2.documentContainer.get('position')
+    );
+    this.newDraftPieces = sortedNewPieces;
   });
 
   updateDraftPiecePositions = async () => {
@@ -156,7 +162,7 @@ export default class CasesSubmissionsSubmissionController extends Controller {
         }
       }
     }
-    this.reloadPieces.perform();
+    await this.reloadPieces.perform();
   };
 
   @action
@@ -209,10 +215,9 @@ export default class CasesSubmissionsSubmissionController extends Controller {
       }
     });
     await Promise.all(savePromises);
-
+    await this.updateDraftPiecePositions();
     this.isOpenPieceUploadModal = false;
     this.newPieces = new TrackedArray([]);
-    this.reloadPieces.perform();
   });
 
   savePiece = task(async (piece, index) => {

--- a/app/routes/cases/case/subcases/new-submission.js
+++ b/app/routes/cases/case/subcases/new-submission.js
@@ -10,6 +10,9 @@ export default class CasesCaseSubcasesNewSubmissionRoute extends Route {
   mandatees;
 
   async beforeModel(_transition) {
+    if (!this.currentSession.may('create-submissions')) {
+      this.router.transitionTo('cases.submissions');
+    }
     const linkedMandatees = await this.store.queryAll('mandatee', {
       'filter[user-organizations][:id:]': this.currentSession.organization.id,
       'filter[:has-no:end]': true,

--- a/app/routes/cases/case/subcases/subcase/new-submission.js
+++ b/app/routes/cases/case/subcases/subcase/new-submission.js
@@ -20,6 +20,9 @@ export default class CasesCaseSubcasesSubcaseNewSubmissionRoute extends Route {
   notificationComment;
 
   async beforeModel(_transition) {
+    if (!this.currentSession.may('create-submissions')) {
+      this.router.transitionTo('cases.submissions');
+    }
     const linkedMandatees = await this.store.queryAll('mandatee', {
       'filter[user-organizations][:id:]': this.currentSession.organization.id,
       'filter[:has-no:end]': true,


### PR DESCRIPTION
- positie bij toevoegen document in bestaande indiening niet goed herberekend, ook op de procedurestap is het dan niet OK en moet je manueel corrigeren

- Nieuwe BIS indiening blijft hangen op de pagina, zowel bij demo aan Kenny als bij test met kabinet Jambon. Ik kon ook nog op “annuleren” klikken. De “annuleren” knop moet uitgezet worden en de pagina moet redirecten naar de indiening

- Ministers na BIS indiening niet aangepast op agenda maar wel op procedurestap

- Kabinetsmedewerker ziet de nieuwe indiening (BIS) route. Die zal niet kunnen schrijven dankzij mu-auth, maar een redirect naar de dossiers/indieningen zou beter zijn.

- Bij de notificaties read-only view mogen toch de aanvullende opmerkingen getoond worden. Iedereen die toegang heeft tot de indieningen mag deze informatie zien.