### PR TITLE
Feature/kas 4764 submission status change user

### DIFF
--- a/app/components/agenda/agendaitem/agendaitem-controls.js
+++ b/app/components/agenda/agendaitem/agendaitem-controls.js
@@ -23,6 +23,7 @@ export default class AgendaitemControls extends Component {
   @service decisionReportGeneration;
   @service parliamentService;
   @service newsletterService;
+  @service draftSubmissionService;
 
   @tracked isVerifying = false;
   @tracked isVerifyingSendBack = false;
@@ -187,7 +188,9 @@ export default class AgendaitemControls extends Component {
   async verifySendBackToSubmitter(agendaitem) {
     this.isSendingBackToSubmitter = true;
     const submission = this.submissions.at(0);
-    await submission.updateStatus(CONSTANTS.SUBMISSION_STATUSES.TERUGGESTUURD);
+    // needs an option for a comment, Tom was doing this?
+    const comment = '' //placeholder
+    await this.draftSubmissionService.updateSubmissionStatus(submission, CONSTANTS.SUBMISSION_STATUSES.TERUGGESTUURD, comment);
     await this.deleteItem(agendaitem);
     const subcase = await submission.subcase;
     // If decisionmaking flow & case are new & they don't have other subcases

--- a/app/components/cases/new-submission.js
+++ b/app/components/cases/new-submission.js
@@ -26,6 +26,7 @@ export default class CasesNewSubmissionComponent extends Component {
   @service toaster;
   @service currentSession;
   @service documentService;
+  @service draftSubmissionService;
 
   @tracked selectedDecisionmakingFlow;
   @tracked decisionmakingFlowTitle;
@@ -183,7 +184,6 @@ export default class CasesNewSubmissionComponent extends Component {
   };
 
   createSubmission = dropTask(async (meeting, comment) => {
-    const now = new Date();
     this.showProposableAgendaModal = false;
     const submitted = await this.store.findRecordByUri(
       'concept',
@@ -195,17 +195,13 @@ export default class CasesNewSubmissionComponent extends Component {
       this.decisionmakingFlowTitle ??
       _case?.shortTitle ??
       '';
-    const creator = await this.currentSession.user;
     this.submission = this.store.createRecord('submission', {
-      created: now,
-      modified: now,
       shortTitle: trimText(this.shortTitle ?? decisionmakingFlowTitle),
       title: trimText(decisionmakingFlowTitle),
       confidential: this.confidential,
       type: this.type,
       agendaItemType: this.agendaItemType,
       decisionmakingFlow: this.selectedDecisionmakingFlow,
-      creator: creator,
       approvalAddresses: this.approvalAddresses,
       approvalComment: this.approvalComment,
       notificationAddresses:this.notificationAddresses,
@@ -225,16 +221,7 @@ export default class CasesNewSubmissionComponent extends Component {
     await this.savePieces.perform();
 
     // Create submission change
-    const submissionStatusChange = this.store.createRecord(
-      'submission-status-change-activity',
-      {
-        startedAt: now,
-        comment,
-        submission: this.submission,
-        status: submitted,
-      }
-    );
-    await submissionStatusChange.save();
+    await this.draftSubmissionService.createStatusChange(this.submission, submitted.uri, comment);
     this.createNotificationMailResources();
 
     if (meeting) {

--- a/app/components/cases/new-submission.js
+++ b/app/components/cases/new-submission.js
@@ -222,7 +222,7 @@ export default class CasesNewSubmissionComponent extends Component {
 
     // Create submission change
     await this.draftSubmissionService.createStatusChange(this.submission, submitted.uri, comment);
-    this.createNotificationMailResources();
+    await this.createNotificationMailResources();
 
     if (meeting) {
       try {
@@ -245,9 +245,9 @@ export default class CasesNewSubmissionComponent extends Component {
     }
   });
 
-  createNotificationMailResources() {
+  async createNotificationMailResources() {
     if (this.approvalAddresses.length && this.notificationAddresses.length) {
-      this.cabinetMail.sendFirstSubmissionMails(this.submission);
+      await this.cabinetMail.sendFirstSubmissionMails(this.submission);
     }
   }
 

--- a/app/components/submission/header.js
+++ b/app/components/submission/header.js
@@ -144,7 +144,7 @@ export default class SubmissionHeaderComponent extends Component {
       CONSTANTS.SUBMISSION_STATUSES.OPNIEUW_INGEDIEND,
       this.comment
     );
-    this.cabinetMail.sendResubmissionMails(this.args.submission, this.comment);
+    await this.cabinetMail.sendResubmissionMails(this.args.submission, this.comment);
     if (isPresent(this.args.onStatusUpdated)) {
       this.args.onStatusUpdated();
     }
@@ -333,7 +333,7 @@ export default class SubmissionHeaderComponent extends Component {
       CONSTANTS.SUBMISSION_STATUSES.TERUGGESTUURD,
       this.comment
     );
-    this.cabinetMail.sendBackToSubmitterMail(
+    await this.cabinetMail.sendBackToSubmitterMail(
       this.args.submission,
       this.comment
     );

--- a/app/components/submission/status-change-activity.js
+++ b/app/components/submission/status-change-activity.js
@@ -26,7 +26,8 @@ export default class SubmissionStatusChangeActivityComponent extends Component {
 
   get label() {
     const activity = this.args.activity;
-    const creatorName = this.args.creatorName;
+    const user = activity.belongsTo('startedBy').value();
+    const userName = `${user?.firstName} ${user?.lastName}`;
     const startedAt = activity.startedAt;
     const status = activity.belongsTo('status').value(); // Status should be loaded in parent
 
@@ -35,10 +36,6 @@ export default class SubmissionStatusChangeActivityComponent extends Component {
     const date = dateFormat(startedAt, `dd-MM-yyyy`);
     const hour = dateFormat(startedAt, `HH:mm`);
     const comment = activity.comment ? `: '${activity.comment}'` : '';
-    let userName = creatorName;
-    if (status.uri === IN_BEHANDELING) {
-      userName = this.args.beingTreatedByName;
-    }
 
     const intlKey = this.intlKeyMap[status.uri];
     const label = intlKey

--- a/app/components/submissions/overview-header.hbs
+++ b/app/components/submissions/overview-header.hbs
@@ -22,10 +22,10 @@
               @maxLength={{250}}
             />
           </h4>
-          {{#if @submission.beingTreatedBy}}
+          {{#if @beingTreatedBy}}
             <span class="auk-u-block">
               {{t "this-submission-is-being-treated-by-user"
-                  user=@submission.beingTreatedBy.fullName}}
+                  user=@beingTreatedBy.fullName}}
             </span>
           {{/if}}
         </div>

--- a/app/controllers/agenda/submissions.js
+++ b/app/controllers/agenda/submissions.js
@@ -5,6 +5,7 @@ import { PAGINATION_SIZES } from 'frontend-kaleidos/config/config';
 
 export default class AgendaSubmissionsController extends Controller {
   @service router;
+  @service draftSubmissionService;
 
   queryParams = [
     {
@@ -46,5 +47,9 @@ export default class AgendaSubmissionsController extends Controller {
         .map((mandatee) => mandatee.person)
     );
     return persons.map((person) => person.fullName);
+  };
+
+  getTreatedBy = async (submission) => {
+    return await this.draftSubmissionService.getLatestTreatedBy(submission);
   };
 }

--- a/app/controllers/cases/case/subcases/subcase/new-submission.js
+++ b/app/controllers/cases/case/subcases/subcase/new-submission.js
@@ -20,6 +20,7 @@ export default class CasesCaseSubcasesSubcaseNewSubmissionController extends Con
   @service currentSession;
   @service documentService;
   @service agendaService;
+  @service draftSubmissionService;
 
   defaultAccessLevel;
   originalSubmission;
@@ -186,7 +187,6 @@ export default class CasesCaseSubcasesSubcaseNewSubmissionController extends Con
   };
 
   createSubmission = dropTask(async () => {
-    const now = new Date();
     this.isOpenCreateSubmissionModal = false;
 
     const submitted = await this.store.findRecordByUri(
@@ -209,14 +209,10 @@ export default class CasesCaseSubcasesSubcaseNewSubmissionController extends Con
 
     const status = this.originalSubmission ? updateSubmitted : submitted;
 
-    const creator = await this.currentSession.user;
     // TODO fix cache issue that leaves meeting null for KDB
     const plannedStart = meeting?.plannedStart || this.originalSubmission?.plannedStart;
 
     this.submission = this.store.createRecord('submission', {
-      created: now,
-      creator,
-      modified: now,
       shortTitle: trimText(this.model.shortTitle),
       title: this.originalSubmission?.title,
       confidential: this.model.confidential,
@@ -246,16 +242,7 @@ export default class CasesCaseSubcasesSubcaseNewSubmissionController extends Con
     this.newDraftPieces = new TrackedArray([]);
 
     // Create submission change
-    const submissionStatusChange = this.store.createRecord(
-      'submission-status-change-activity',
-      {
-        startedAt: now,
-        comment: this.comment,
-        submission: this.submission,
-        status,
-      }
-    );
-    await submissionStatusChange.save();
+    await this.draftSubmissionService.createStatusChange(this.submission, status.uri, this.comment);
 
     if (meeting) {
       try {

--- a/app/controllers/cases/case/subcases/subcase/new-submission.js
+++ b/app/controllers/cases/case/subcases/subcase/new-submission.js
@@ -255,7 +255,7 @@ export default class CasesCaseSubcasesSubcaseNewSubmissionController extends Con
           meeting,
           this.submission
         );
-        this.cabinetMail.sendUpdateSubmissionMails(this.submission);
+        await this.cabinetMail.sendUpdateSubmissionMails(this.submission);
         this.router.transitionTo('cases.submissions.submission', this.submission.id);
       } catch (error) {
         this.toaster.error(

--- a/app/controllers/cases/submissions/submission.js
+++ b/app/controllers/cases/submissions/submission.js
@@ -20,6 +20,7 @@ export default class CasesSubmissionsSubmissionController extends Controller {
   @service intl;
   @service documentService;
   @service submissionService;
+  @service draftSubmissionService;
 
   @tracked isOpenPieceUploadModal = false;
   @tracked isOpenBatchDetailsModal = false;
@@ -34,6 +35,7 @@ export default class CasesSubmissionsSubmissionController extends Controller {
   @tracked notificationAddresses = new TrackedArray([]);
   @tracked approvalComment;
   @tracked notificationComment;
+  @tracked beingTreatedBy;
 
   currentLinkedMandatee;
 
@@ -113,12 +115,8 @@ export default class CasesSubmissionsSubmissionController extends Controller {
   }
 
   reloadHistory = task(async () => {
-    const statusChangeActivities = await this.model.statusChangeActivities.reload();
-    this.statusChangeActivities = statusChangeActivities
-      .slice()
-      .sort((a1, a2) => a1.startedAt.getTime() - a2.startedAt.getTime())
-      .reverse();
-    await Promise.all(this.statusChangeActivities.map((a) => a.status));
+    this.statusChangeActivities = await this.draftSubmissionService.getStatusChangeActivities(this.model);
+    this.beingTreatedBy = await this.draftSubmissionService.getLatestTreatedBy(this.model);
   });
 
   reloadPieces = task(async () => {

--- a/app/models/submission-status-change-activity.js
+++ b/app/models/submission-status-change-activity.js
@@ -5,6 +5,7 @@ export default class SubmissionStatusChangeActivityModel extends Model {
   @attr('datetime') startedAt;
   @attr comment;
 
-  @belongsTo('submission', { inverse: null, async: true }) submission;
+  @belongsTo('submission', { inverse: 'statusChangeActivities', async: true }) submission;
   @belongsTo('concept', { inverse: null, async: true }) status;
+  @belongsTo('user', { inverse: null, async: true }) startedBy;
 }

--- a/app/models/submission.js
+++ b/app/models/submission.js
@@ -1,7 +1,6 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { inject as service } from '@ember/service';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
-import { addObject } from 'frontend-kaleidos/utils/array-helpers';
 
 export default class SubmissionModel extends Model {
   @service currentSession;
@@ -32,11 +31,7 @@ export default class SubmissionModel extends Model {
   @belongsTo('mandatee', { inverse: null, async: true })
   requestedBy;
   @belongsTo('user', { inverse: null, async: true })
-  creator;
-  @belongsTo('user', { inverse: null, async: true })
   modifiedBy;
-  @belongsTo('user', { inverse: null, async: true })
-  beingTreatedBy;
   @belongsTo('meeting', { inverse: 'submissions', async: true })
   meeting;
 
@@ -44,7 +39,7 @@ export default class SubmissionModel extends Model {
   mandatees;
   @hasMany('submission-activity', { inverse: 'submission', async: true })
   submissionActivities;
-  @hasMany('submission-status-change-activity', { inverse: null, async: true })
+  @hasMany('submission-status-change-activity', { inverse: 'submission', async: true })
   statusChangeActivities;
   @hasMany('concept', { inverse: null, async: true })
   governmentAreas;
@@ -86,28 +81,19 @@ export default class SubmissionModel extends Model {
     );
   }
 
-  async updateStatus(statusUri, comment) {
-    const now = new Date();
+  save() {
+    const dirtyType = this.dirtyType;
     const currentUser = this.currentSession.user;
-    const newStatus = await this.store.findRecordByUri('concept', statusUri);
-
-    const submissionStatusChange = this.store.createRecord(
-      'submission-status-change-activity',
-      {
-        startedAt: now,
-        comment,
-        submission: this,
-        status: newStatus,
+    if (dirtyType != 'deleted') {
+      const now = new Date();
+      this.modified = now;
+      this.modifiedBy = currentUser;
+      if (dirtyType == 'created') {
+        // When saving a newly created record force the creation date to equal
+        // the modified date.
+        this.created = now;
       }
-    );
-    await submissionStatusChange.save();
-
-    this.status = newStatus;
-    this.modified = now;
-    this.modifiedBy = currentUser;
-    const statusChangeActivities = await this.statusChangeActivities;
-    addObject(statusChangeActivities, submissionStatusChange);
-
-    await this.save();
+    }
+    return super.save(...arguments);
   }
 }

--- a/app/routes/cases/submissions/submission.js
+++ b/app/routes/cases/submissions/submission.js
@@ -8,6 +8,7 @@ export default class CasesSubmissionsSubmissionRoute extends Route {
   @service router;
   @service store;
   @service submissionService;
+  @service draftSubmissionService;
 
   newPieces;
   pieces;
@@ -40,7 +41,7 @@ export default class CasesSubmissionsSubmissionRoute extends Route {
       params.submission_id
     );
 
-    const status = await submission.status;
+    const status = await submission.belongsTo('status').reload;
     const subcase = await submission.subcase;
     if (status.uri === CONSTANTS.SUBMISSION_STATUSES.AANVAARD) {
       if (subcase)  {
@@ -105,15 +106,8 @@ export default class CasesSubmissionsSubmissionRoute extends Route {
     );
     this.newDraftPieces = sortedNewPieces;
 
-    const statusChangeActivities = await submission.statusChangeActivities;
-    this.statusChangeActivities = statusChangeActivities
-      .slice()
-      .sort((a1, a2) => a1.startedAt.getTime() - a2.startedAt.getTime())
-      .reverse();
-    await Promise.all(this.statusChangeActivities.map((a) => a.status));
-
-    const creator = await submission.creator;
-    this.creatorName = `${creator?.firstName} ${creator?.lastName}`;
+    this.statusChangeActivities = await this.draftSubmissionService.getStatusChangeActivities(submission);
+    this.beingTreatedBy = await this.draftSubmissionService.getLatestTreatedBy(submission);
 
     return submission;
   }
@@ -127,7 +121,7 @@ export default class CasesSubmissionsSubmissionRoute extends Route {
     controller.statusChangeActivities = this.statusChangeActivities;
     controller.currentLinkedMandatee = this.currentLinkedMandatee;
     controller.previousSubcase = this.previousSubcase;
-    controller.creatorName = this.creatorName;
+    controller.beingTreatedBy = this.beingTreatedBy;
     controller.approvalAddresses = _model.approvalAddresses;
     controller.notificationAddresses = _model.notificationAddresses;
     controller.approvalComment = _model.approvalComment;

--- a/app/serializers/submission.js
+++ b/app/serializers/submission.js
@@ -2,6 +2,7 @@ import ApplicationSerializer from './application';
 
 const SKIP_SERIALIZED = [
   'meeting', // if design agenda A, this gets set to null by dossierbeheerder
+  'statusChangeActivities',
 ];
 
 const SKIP_ATTRIBUTES = [

--- a/app/services/cabinet-mail.js
+++ b/app/services/cabinet-mail.js
@@ -17,6 +17,7 @@ export default class CabinetMailService extends Service {
   @service router;
   @service toaster;
   @service intl;
+  @service draftSubmissionService;
 
   async loadSettings() {
     const [mailSettings, outbox] = await Promise.all([
@@ -55,7 +56,7 @@ export default class CabinetMailService extends Service {
       };
 
       const mail = caseSendBackEmail(params);
-      const creator = await submission.creator;
+      const creator = await this.draftSubmissionService.getCreator(submission);
       const mailResource = this.store.createRecord('email', {
         to: creator.email,
         from: mailSettings.defaultFromEmail,
@@ -96,7 +97,7 @@ export default class CabinetMailService extends Service {
           message: notificationEmail.message,
         })
       );
-      const creator = await submission.creator;
+      const creator = await this.draftSubmissionService.getCreator(submission);
       const submitterEmailResource = this.store.createRecord('email', {
         to: creator.email,
         from: mailSettings.defaultFromEmail,
@@ -151,7 +152,7 @@ export default class CabinetMailService extends Service {
         })
       );
 
-      const creator = await submission.creator;
+      const creator = await this.draftSubmissionService.getCreator(submission);
       const submitterMailResource = this.store.createRecord('email', {
         to: creator.email,
         from: mailSettings.defaultFromEmail,
@@ -207,7 +208,7 @@ export default class CabinetMailService extends Service {
         })
       );
 
-      const creator = await submission.creator;
+      const creator = await this.draftSubmissionService.getCreator(submission);
       const submitterMailResource = this.store.createRecord('email', {
         to: creator.email,
         from: mailSettings.defaultFromEmail,

--- a/app/services/draft-submission-service.js
+++ b/app/services/draft-submission-service.js
@@ -1,0 +1,65 @@
+import Service, { inject as service } from '@ember/service';
+import constants from 'frontend-kaleidos/config/constants';
+
+export default class DraftSubmissionService extends Service {
+  @service store;
+  @service currentSession;
+
+  updateSubmissionStatus = async(submission, statusUri, comment='') => {
+    const newStatus = await this.store.findRecordByUri('concept', statusUri);
+    await this.createStatusChange(submission, statusUri, comment);
+    submission.status = newStatus;
+    await submission.save(); // ember will update the inverse + we do reloads
+  };
+
+  createStatusChange = async(submission, statusUri, comment='') => {
+    const now = new Date();
+    const currentUser = this.currentSession.user;
+    const status = await this.store.findRecordByUri('concept', statusUri);
+
+    const submissionStatusChangeActivity = this.store.createRecord(
+      'submission-status-change-activity',
+      {
+        startedAt: now,
+        startedBy: currentUser,
+        comment,
+        submission,
+        status,
+
+      }
+    );
+    await submissionStatusChangeActivity.save();
+  };
+
+  getStatusChangeActivities = async(submission) => {
+    const statusChangeActivities = await submission.hasMany('statusChangeActivities').reload();
+    await Promise.all(statusChangeActivities.map((a) => a.status));
+    await Promise.all(statusChangeActivities.map((a) => a.startedBy));
+    return statusChangeActivities
+      .slice()
+      .sort((a1, a2) => a1.startedAt.getTime() - a2.startedAt.getTime())
+      .reverse();
+  };
+
+  getLatestTreatedBy = async(submission) => {
+    const statusChangeActivities = await this.getStatusChangeActivities(submission);
+    const treatedByActivity = statusChangeActivities?.filter((a) => a.status.get('uri') === constants.SUBMISSION_STATUSES.IN_BEHANDELING)
+      .at(0);
+    const user = await treatedByActivity?.startedBy;
+    return user;
+  };
+
+  getCreator = async(submission) => {
+    const statusChangeActivities = await this.getStatusChangeActivities(submission);
+    const creationActivity = statusChangeActivities
+      ?.filter(
+        (a) =>
+          a.status.get('uri') === constants.SUBMISSION_STATUSES.INGEDIEND ||
+          a.status.get('uri') === constants.SUBMISSION_STATUSES.UPDATE_INGEDIEND
+      )
+      .at(0);
+    // What if this is null (should never happen, mails depend on this to exist)
+    const user = await creationActivity?.startedBy;
+    return user;
+  };
+}

--- a/app/templates/agenda/submissions.hbs
+++ b/app/templates/agenda/submissions.hbs
@@ -94,11 +94,13 @@
                     {{/if}}
                   </td>
                   <td>
-                    {{#if submission.beingTreatedBy}}
-                      {{submission.beingTreatedBy.fullName}}
-                    {{else}}
-                      -
-                    {{/if}}
+                    {{#let (await (this.getTreatedBy submission)) as |beingTreatedBy|}}
+                      {{#if beingTreatedBy}}
+                        {{beingTreatedBy.fullName}}
+                      {{else}}
+                        -
+                      {{/if}}
+                    {{/let}}
                   </td>
                   <td class="auk-u-text-align--right">
                     <AuLink

--- a/app/templates/cases/submissions/submission.hbs
+++ b/app/templates/cases/submissions/submission.hbs
@@ -6,6 +6,7 @@
 
 <Submissions::OverviewHeader
   @submission={{@model}}
+  @beingTreatedBy={{this.beingTreatedBy}}
 />
 
 <Submission::Header
@@ -149,8 +150,6 @@
               {{#each this.statusChangeActivities as |activity|}}
                 <Submission::StatusChangeActivity
                   @activity={{activity}}
-                  @creatorName={{this.creatorName}}
-                  @beingTreatedByName={{@model.beingTreatedBy.fullName}}
                 />
               {{/each}}
             </ul>


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4764

- [x] https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/485


- added user to `status-change-activity`
- removed `creator` and `beingTreatedBy` from submission model
- fixed inverse between submission and `status-change-activity` so updates happen automatically
- made `submission.statusChangeActivities` read-only 
- Added a save on the `submission` to always set `modifed`, `modified-by` and `created`(once)
- implemented a service for reusable action on submissions
- replaced duplicate getting of statusChangeActivities with service call
- replaced submission model action with service call
- replaced duplicate creation of statusChangeActivities with service call
- replaced  `creator` and `beingTreatedBy` with service call
- added a cleanup of all statusChangeActivities when removing submission

note: some of the service calls could be just a util (no extra services needed) but I put them in the service for now.
