### PR TITLE
KAS-4684 fix flags

### DIFF
--- a/app/components/agenda/agendaitem/agendaitem-controls.js
+++ b/app/components/agenda/agendaitem/agendaitem-controls.js
@@ -192,7 +192,7 @@ export default class AgendaitemControls extends Component {
     const subcase = await submission.subcase;
     // If decisionmaking flow & case are new & they don't have other subcases
     //  → Delete
-    if (submission.title) {
+    if (submission.decisionmakingFlowTitle) {
       const decisionmakingFlow = await submission.decisionmakingFlow;
       const subcases = await decisionmakingFlow.hasMany('subcases').reload();
       if (subcases.length === 1 && subcases.at(0).id === subcase.id) {

--- a/app/components/agenda/agendaitem/agendaitem-postponed.js
+++ b/app/components/agenda/agendaitem/agendaitem-postponed.js
@@ -16,6 +16,7 @@ export default class AgendaitemPostponed extends Component {
   @service agendaService;
   @service toaster;
   @service intl;
+  @service router;
 
   @tracked modelsForProposedAgenda;
   @tracked latestMeeting;

--- a/app/components/cases/new-case.hbs
+++ b/app/components/cases/new-case.hbs
@@ -1,6 +1,6 @@
 <ConfirmationModal
   @modalOpen={{true}}
-  @title={{t "new-case"}}
+  @title={{t "create-case"}}
   @onConfirm={{perform this.createCase}}
   @onCancel={{@onCancel}}
   @confirmMessage={{t "create-case"}}

--- a/app/components/cases/new-submission.hbs
+++ b/app/components/cases/new-submission.hbs
@@ -121,7 +121,7 @@
           {{on "click" (perform this.openProposableAgendaModal)}}
         >
           {{#if this.selectedDecisionmakingFlow}}
-            {{t "submit-new-subcase"}}
+            {{t "submit-new-agendaitem"}}
           {{else}}
             {{t "submit-new-case"}}
           {{/if}}

--- a/app/components/cases/new-submission.js
+++ b/app/components/cases/new-submission.js
@@ -33,6 +33,8 @@ export default class CasesNewSubmissionComponent extends Component {
   @tracked agendaItemType;
   @tracked confidential = false;
   @tracked shortTitle;
+  @tracked title;
+  @tracked subcaseName;
 
   @tracked type;
 
@@ -72,6 +74,8 @@ export default class CasesNewSubmissionComponent extends Component {
       this.confidential = this.latestSubcase.confidential;
       this.shortTitle = this.latestSubcase.shortTitle;
       this.type = await this.latestSubcase.type;
+      this.title = this.latestSubcase.title;
+      this.subcaseName = this.latestSubcase.subcaseName;
       this.governmentAreas = await this.latestSubcase.governmentAreas;
       for (const governmentArea of this.governmentAreas) {
         await governmentArea.broader;
@@ -200,10 +204,13 @@ export default class CasesNewSubmissionComponent extends Component {
       created: now,
       modified: now,
       shortTitle: trimText(this.shortTitle ?? decisionmakingFlowTitle),
-      title: trimText(decisionmakingFlowTitle),
+      title: trimText(this.title),
+      subcaseName: this.subcaseName,
       confidential: this.confidential,
       type: this.type,
       agendaItemType: this.agendaItemType,
+      // either we set the decisionmakingFlowTitle or the decisionmakingFlow, never both
+      decisionmakingFlowTitle: this.selectedDecisionmakingFlow ? '' : trimText(decisionmakingFlowTitle),
       decisionmakingFlow: this.selectedDecisionmakingFlow,
       creator: creator,
       approvalAddresses: this.approvalAddresses,

--- a/app/components/submission/description-panel/edit.hbs
+++ b/app/components/submission/description-panel/edit.hbs
@@ -63,6 +63,19 @@
           {{on "input" (pick "target.value" (set @submission "shortTitle"))}}
         />
       </AuFormRow>
+      {{#if (user-may "view-submissions-on-agenda")}}
+        <AuFormRow>
+          <AuLabel for="title-submission">
+            {{t "title-subcase"}}</AuLabel>
+          <AuTextarea
+            id="title-submission"
+            rows="2"
+            value={{@submission.title}}
+            @width="block"
+            {{on "input" (pick "target.value" (set @submission "title"))}}
+          />
+        </AuFormRow>
+      {{/if}}
       <AuFormRow>
         <AuLabel>{{t "subcase-type-dropdown"}}</AuLabel>
         <Utils::ModelSelector
@@ -74,6 +87,61 @@
           @filterOptions={{this.filterSubcaseTypes}}
         />
       </AuFormRow>
+      {{#if (user-may "view-submissions-on-agenda")}}
+        <AuFormRow>
+          <AuLabel>{{t "subcase-name"}}</AuLabel>
+          <div
+            class="auk-o-flex auk-o-flex--vertical-center auk-o-flex-gap--small au-u-maximize-width"
+          >
+            {{#if (not this.isEditingSubcaseName)}}
+              <Utils::ModelSelector
+                class="auk-u-maximize-width"
+                @modelName="shortcut"
+                @searchField="label"
+                @sortField="label"
+                @filter={{this.filter}}
+                @selected={{this.selectedShortcut}}
+                @onChange={{this.selectSubcaseName}}
+                as |model|
+              >
+                {{capitalize model.label}}
+              </Utils::ModelSelector>
+              <AuButton
+                @skin="naked"
+                @icon="pencil"
+                @hideText={{true}}
+                {{on "click" (toggle "isEditingSubcaseName" this)}}
+              >
+                {{t "edit"}}
+              </AuButton>
+            {{else}}
+              <AuInput
+                id="subcaseNameId"
+                value={{this.subcaseName}}
+                @width="block"
+                {{on "input" (pick "target.value" (set this "subcaseName"))}}
+              />
+              <AuButton
+                @skin="naked"
+                @icon="x"
+                @hideText={{true}}
+                {{on "click" (toggle "isEditingSubcaseName" this)}}
+              >
+                {{t "cancel"}}
+              </AuButton>
+            {{/if}}
+            <AuButton
+              @skin="naked"
+              @icon="trash"
+              @alert={{true}}
+              @hideText={{true}}
+              {{on "click" this.clearSubcaseName}}
+            >
+              {{t "cancel"}}
+            </AuButton>
+          </div>
+        </AuFormRow>
+      {{/if}}
     </div>
   </Auk::Panel::Body>
   <Auk::Panel::Footer>

--- a/app/components/submission/description-panel/edit.js
+++ b/app/components/submission/description-panel/edit.js
@@ -22,7 +22,9 @@ export default class SubmissionDescriptionPanelEditComponent extends Component {
   @tracked filter = Object.freeze({
     type: 'subcase-name',
   });
+  @tracked isEditingSubcaseName = false;
   @tracked selectedShortcut;
+  @tracked subcaseName;
   @tracked subcaseType;
   @tracked agendaItemType;
   @tracked agendaItemTypes;
@@ -35,6 +37,8 @@ export default class SubmissionDescriptionPanelEditComponent extends Component {
 
   constructor() {
     super(...arguments);
+    this.subcaseName = this.args.submission.subcaseName;
+    this.isEditingSubcaseName = this.subcaseName?.length;
     this.loadDecisionmakingFlow.perform();
     this.loadSubcaseType.perform();
     this.loadAgendaItemType.perform();
@@ -45,7 +49,7 @@ export default class SubmissionDescriptionPanelEditComponent extends Component {
   *loadDecisionmakingFlow() {
     this.decisionmakingFlow = yield this.args.submission.decisionmakingFlow;
     yield this.decisionmakingFlow?.case;
-    this.decisionmakingFlowTitle = yield this.args.submission.title;
+    this.decisionmakingFlowTitle = this.args.submission.decisionmakingFlowTitle;
   }
 
   @task
@@ -63,6 +67,18 @@ export default class SubmissionDescriptionPanelEditComponent extends Component {
     this.agendaItemTypes = yield this.conceptStore.queryAllByConceptScheme(
       CONSTANTS.CONCEPT_SCHEMES.AGENDA_ITEM_TYPES
     );
+  }
+
+  @action
+  selectSubcaseName(shortcut) {
+    this.selectedShortcut = shortcut;
+    this.subcaseName = shortcut.label;
+  }
+
+  @action
+  clearSubcaseName() {
+    this.selectedShortcut = null;
+    this.subcaseName = null;
   }
 
   @action
@@ -87,11 +103,14 @@ export default class SubmissionDescriptionPanelEditComponent extends Component {
   async saveChanges() {
     this.isSaving = true;
     this.args.submission.decisionmakingFlow = this.decisionmakingFlow;
-    this.args.submission.title = this.decisionmakingFlowTitle;
+    this.args.submission.decisionmakingFlowTitle = this.decisionmakingFlowTitle;
 
     const trimmedShortTitle = trimText(this.args.submission.shortTitle);
+    const trimmedTitle = trimText(this.args.submission.title);
 
     this.args.submission.shortTitle = trimmedShortTitle;
+    this.args.submission.title = trimmedTitle;
+    this.args.submission.subcaseName = this.subcaseName;
     this.args.submission.type = this.subcaseType;
     this.args.submission.agendaItemType = this.agendaItemType;
     await this.args.submission.save();

--- a/app/components/submission/description-panel/view.hbs
+++ b/app/components/submission/description-panel/view.hbs
@@ -51,6 +51,9 @@
         {{/if}}
       </div>
     </div>
+    {{#if (user-may "view-submissions-on-agenda")}}
+      <p>{{capitalize @submission.title}}</p>
+    {{/if}}
   </Auk::Panel::Body>
   <Auk::Panel::Body>
     <div class="au-o-grid au-o-grid--small au-u-1-1">
@@ -64,6 +67,14 @@
           {{/if}}
         </p>
       </div>
+      {{#if (user-may "view-submissions-on-agenda")}}
+        <div class="au-o-grid__item au-u-1-2 au-u-1-4@medium">
+          <AuHeading @level="4" @skin="6">{{t "subcase-name"}}</AuHeading>
+          <p>
+            {{if @submission.subcaseName @submission.subcaseName '-'}}
+          </p>
+        </div>
+      {{/if}}
     </div>
   </Auk::Panel::Body>
 </Auk::Panel>

--- a/app/components/submission/header.js
+++ b/app/components/submission/header.js
@@ -169,7 +169,7 @@ export default class SubmissionHeaderComponent extends Component {
       let decisionmakingFlow = await this.args.submission.decisionmakingFlow;
       if (!decisionmakingFlow) {
         decisionmakingFlow = this.store.createRecord('decisionmaking-flow', {
-          title: this.args.submission.title,
+          title: this.args.submission.decisionmakingFlowTitle,
           opened: this.args.submission.created,
           governmentAreas,
           submissions: [this.args.submission],
@@ -177,7 +177,7 @@ export default class SubmissionHeaderComponent extends Component {
         await decisionmakingFlow.save();
 
         const _case = this.store.createRecord('case', {
-          shortTitle: this.args.submission.title,
+          shortTitle: this.args.submission.decisionmakingFlowTitle,
           created: this.args.submission.created,
           decisionmakingFlow,
         });
@@ -198,6 +198,8 @@ export default class SubmissionHeaderComponent extends Component {
         }
         subcase = this.store.createRecord('subcase', {
           shortTitle: this.args.submission.shortTitle,
+          title: this.args.submission.title,
+          subcaseName: this.args.submission.subcaseName,
           created: this.args.submission.created,
           modified: now,
           confidential: this.args.submission.confidential,

--- a/app/components/submission/header.js
+++ b/app/components/submission/header.js
@@ -312,7 +312,7 @@ export default class SubmissionHeaderComponent extends Component {
       }
 
       this.args.submission.subcase = subcase;
-      await this._updateSubmission(CONSTANTS.SUBMISSION_STATUSES.AANVAARD);
+      await this._updateSubmission(CONSTANTS.SUBMISSION_STATUSES.BEHANDELD);
 
       this.router.transitionTo(
         'cases.case.subcases.subcase',

--- a/app/components/submission/status-change-activity.js
+++ b/app/components/submission/status-change-activity.js
@@ -9,7 +9,7 @@ const {
   OPNIEUW_INGEDIEND,
   UPDATE_INGEDIEND,
   TERUGGESTUURD,
-  AANVAARD,
+  BEHANDELD,
 } = CONSTANTS.SUBMISSION_STATUSES;
 
 export default class SubmissionStatusChangeActivityComponent extends Component {
@@ -21,7 +21,7 @@ export default class SubmissionStatusChangeActivityComponent extends Component {
     [TERUGGESTUURD]: 'sent-back-on',
     [IN_BEHANDELING]: 'in-treatment-by-user-on',
     [UPDATE_INGEDIEND]: 'update-submitted-on',
-    [AANVAARD]: 'accepted-on',
+    [BEHANDELD]: 'treated-on',
   };
 
   get label() {

--- a/app/components/submissions/overview-header.hbs
+++ b/app/components/submissions/overview-header.hbs
@@ -13,21 +13,33 @@
       </Auk::Toolbar::Item>
       <Auk::Toolbar::Item class="au-u-padding-top-tiny au-u-padding-bottom-tiny">
         <div>
-          <span class="auk-overline auk-u-block">
-            {{t "submission"}}
-          </span>
-          <h4 class="auk-toolbar-complex__title au-u-padding-none">
-            <Auk::AbbreviatedText
-              @text={{or @submission.shortTitle "-"}}
-              @maxLength={{250}}
-            />
-          </h4>
-          {{#if @submission.beingTreatedBy}}
-            <span class="auk-u-block">
-              {{t "this-submission-is-being-treated-by-user"
-                  user=@submission.beingTreatedBy.fullName}}
+          {{#unless this.loadData.isRunning}}
+            <span class="auk-overline auk-u-block">
+              {{t (if this.case "submission-existing-case" "submission-new-case")}}
             </span>
-          {{/if}}
+            <h4 class="auk-toolbar-complex__title au-u-padding-none">
+              {{#if this.case}}
+                <AuLink
+                  class="au-u-padding-none card-link"
+                  @route="cases.case.subcases"
+                  @model={{this.decisionmakingFlow.id}}
+                >
+                  {{or this.case.shortTitle this.case.title}}
+                </AuLink>
+              {{else}}
+                <Auk::AbbreviatedText
+                  @text={{or @submission.decisionmakingFlowTitle}}
+                  @maxLength={{250}}
+                />
+              {{/if}}
+            </h4>
+            {{#if @submission.beingTreatedBy}}
+              <span class="auk-u-block">
+                {{t "this-submission-is-being-treated-by-user"
+                    user=@submission.beingTreatedBy.fullName}}
+              </span>
+            {{/if}}
+          {{/unless}}
         </div>
       </Auk::Toolbar::Item>
     </Auk::Toolbar::Group>

--- a/app/components/submissions/overview-header.js
+++ b/app/components/submissions/overview-header.js
@@ -1,9 +1,24 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { task } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 
 export default class SubmissionsOverviewHeaderComponent extends Component {
   @service router;
+
+  @tracked decisionmakingFlow;
+  @tracked case;
+
+  constructor() {
+    super(...arguments);
+    this.loadData.perform();
+  }
+
+  loadData = task(async () => {
+    this.decisionmakingFlow = await this.args.submission.decisionmakingFlow;
+    this.case = await this.decisionmakingFlow?.case;
+  });
 
   @action
   transitionBack() {

--- a/app/config/constants.js
+++ b/app/config/constants.js
@@ -204,7 +204,7 @@ export default {
     TERUGGESTUURD: "http://themis.vlaanderen.be/id/indieningstatus/b6e33771-665b-4af2-9f1d-41405d1a24d3",
     OPNIEUW_INGEDIEND: "http://themis.vlaanderen.be/id/indieningstatus/b27cd825-72ae-44b0-b1ea-9dafdebe4e85",
     UPDATE_INGEDIEND: "http://themis.vlaanderen.be/id/indieningstatus/11c6fd4b-c4d9-4cd4-9a8a-2fa2820e9353",
-    AANVAARD: "http://themis.vlaanderen.be/id/indieningstatus/dd4f1819-a70d-453f-95cb-ab5ade98563e",
+    BEHANDELD: "http://themis.vlaanderen.be/id/indieningstatus/dd4f1819-a70d-453f-95cb-ab5ade98563e",
   },
   // TODO replace harcoded strings with constants for plausible
   PLAUSIBLE_EVENTS: {

--- a/app/controllers/cases/case/subcases/subcase/new-submission.js
+++ b/app/controllers/cases/case/subcases/subcase/new-submission.js
@@ -215,6 +215,8 @@ export default class CasesCaseSubcasesSubcaseNewSubmissionController extends Con
     }
 
     const status = this.originalSubmission ? updateSubmitted : submitted;
+    const title = this.originalSubmission ? this.originalSubmission.title : this.model.title;
+    const subcaseName = this.originalSubmission ? this.originalSubmission.subcaseName : this.model.subcaseName;
 
     const creator = await this.currentSession.user;
     const plannedStart = meeting?.plannedStart || this.originalSubmission?.plannedStart;
@@ -224,7 +226,8 @@ export default class CasesCaseSubcasesSubcaseNewSubmissionController extends Con
       creator,
       modified: now,
       shortTitle: trimText(this.model.shortTitle),
-      title: this.originalSubmission?.title,
+      title: trimText(title),
+      subcaseName,
       confidential: this.model.confidential,
       subcase: this.model,
       type,

--- a/app/controllers/cases/index.js
+++ b/app/controllers/cases/index.js
@@ -10,6 +10,7 @@ export default class CasesIndexController extends Controller {
   // Services
   @service router;
   @service store;
+  @service currentSession;
 
   queryParams = [
     {
@@ -83,7 +84,8 @@ export default class CasesIndexController extends Controller {
   }
 
   get mayShowSubmissionsTab() {
-    return isEnabledCabinetSubmissions();
+    const canView = this.currentSession.may('view-submissions');
+    return isEnabledCabinetSubmissions() && canView;
   }
 
   setCaseFilter = (value) => (this.caseFilter = value);

--- a/app/models/submission.js
+++ b/app/models/submission.js
@@ -10,7 +10,9 @@ export default class SubmissionModel extends Model {
   @attr uri;
   @attr shortTitle;
   @attr title;
+  @attr decisionmakingFlowTitle;
   @attr('boolean') confidential;
+  @attr subcaseName;
   @attr('datetime') plannedStart;
   @attr('datetime') created;
   @attr('datetime') modified;

--- a/app/routes/agenda/submissions.js
+++ b/app/routes/agenda/submissions.js
@@ -42,7 +42,7 @@ export default class AgendaSubmissionsRoute extends Route{
     const options = {
       'filter[meeting][:id:]': meeting.id,
       'filter[status][:id:]': statusIds.join(','),
-      include: 'type,status,mandatees.person,mandatees.person.organization,being-treated-by,decisionmaking-flow',
+      include: 'type,status,mandatees.person,mandatees.person.organization,decisionmaking-flow',
       sort: params.sort,
       page: {
         number: params.page,

--- a/app/routes/agenda/submissions.js
+++ b/app/routes/agenda/submissions.js
@@ -42,7 +42,7 @@ export default class AgendaSubmissionsRoute extends Route{
     const options = {
       'filter[meeting][:id:]': meeting.id,
       'filter[status][:id:]': statusIds.join(','),
-      include: 'type,status,mandatees.person,mandatees.person.organization,being-treated-by',
+      include: 'type,status,mandatees.person,mandatees.person.organization,being-treated-by,decisionmaking-flow',
       sort: params.sort,
       page: {
         number: params.page,

--- a/app/routes/cases/case/subcases/new-submission.js
+++ b/app/routes/cases/case/subcases/new-submission.js
@@ -12,7 +12,10 @@ export default class CasesCaseSubcasesNewSubmissionRoute extends Route {
 
   async beforeModel(_transition) {
     if (!this.currentSession.may('create-submissions')) {
-      this.router.transitionTo('cases.submissions');
+      if (this.currentSession.may('view-submissions')) {
+        return this.router.transitionTo('cases.submissions');
+      }
+      return this.router.transitionTo('cases');
     }
     const linkedMandatees = await this.store.queryAll('mandatee', {
       'filter[user-organizations][:id:]': this.currentSession.organization.id,

--- a/app/routes/cases/case/subcases/new-submission.js
+++ b/app/routes/cases/case/subcases/new-submission.js
@@ -5,6 +5,7 @@ import CONSTANTS from 'frontend-kaleidos/config/constants';
 export default class CasesCaseSubcasesNewSubmissionRoute extends Route {
   @service currentSession;
   @service store;
+  @service router;
 
   submitter;
   mandatees;

--- a/app/routes/cases/case/subcases/subcase/new-submission.js
+++ b/app/routes/cases/case/subcases/subcase/new-submission.js
@@ -8,6 +8,7 @@ import { TrackedArray } from 'tracked-built-ins';
 export default class CasesCaseSubcasesSubcaseNewSubmissionRoute extends Route {
   @service store;
   @service currentSession;
+  @service router;
 
   pieces;
   defaultAccessLevel;

--- a/app/routes/cases/case/subcases/subcase/new-submission.js
+++ b/app/routes/cases/case/subcases/subcase/new-submission.js
@@ -22,7 +22,10 @@ export default class CasesCaseSubcasesSubcaseNewSubmissionRoute extends Route {
 
   async beforeModel(_transition) {
     if (!this.currentSession.may('create-submissions')) {
-      this.router.transitionTo('cases.submissions');
+      if (this.currentSession.may('view-submissions')) {
+        return this.router.transitionTo('cases.submissions');
+      }
+      return this.router.transitionTo('cases');
     }
     const linkedMandatees = await this.store.queryAll('mandatee', {
       'filter[user-organizations][:id:]': this.currentSession.organization.id,

--- a/app/routes/cases/new-submission.js
+++ b/app/routes/cases/new-submission.js
@@ -12,7 +12,10 @@ export default class CasesNewSubmissionRoute extends Route {
 
   async beforeModel(_transition) {
     if (!this.currentSession.may('create-submissions')) {
-      this.router.transitionTo('cases.submissions');
+      if (this.currentSession.may('view-submissions')) {
+        return this.router.transitionTo('cases.submissions');
+      }
+      return this.router.transitionTo('cases');
     }
     const linkedMandatees = await this.store.queryAll('mandatee', {
       'filter[user-organizations][:id:]': this.currentSession.organization.id,

--- a/app/routes/cases/submissions/index.js
+++ b/app/routes/cases/submissions/index.js
@@ -51,7 +51,7 @@ export default class CasesSubmissionsIndexRoute extends Route {
       'filter[:has:created]': `date-added-for-cache-busting-${new Date().toISOString()}`,
       'filter[:or:][pieces][:has-no:accepted-piece]': 't',
       'filter[:or:][pieces][accepted-piece][:has-no:agendaitems]': 't',
-      include: 'type,status,requested-by,mandatees.person,being-treated-by,submission-activities',
+      include: 'type,status,requested-by,mandatees.person,being-treated-by,submission-activities,decisionmaking-flow',
       sort: params.sort + (params.sort ? ',' : '') + '-modified',
       page: {
         number: params.page,

--- a/app/routes/cases/submissions/index.js
+++ b/app/routes/cases/submissions/index.js
@@ -52,7 +52,7 @@ export default class CasesSubmissionsIndexRoute extends Route {
       'filter[:or:][pieces][:has-no:accepted-piece]': 't',
       'filter[:or:][pieces][accepted-piece][:has-no:agendaitems]': 't',
       include: 'type,status,requested-by,mandatees.person,being-treated-by,submission-activities',
-      sort: params.sort + ',-modified',
+      sort: params.sort + (params.sort ? ',' : '') + '-modified',
       page: {
         number: params.page,
         size: params.size,

--- a/app/routes/cases/submissions/index.js
+++ b/app/routes/cases/submissions/index.js
@@ -10,6 +10,7 @@ export default class CasesSubmissionsIndexRoute extends Route {
   @service currentSession;
   @service conceptStore;
   @service store;
+  @service router;
 
   queryParams = {
     page: {
@@ -37,6 +38,12 @@ export default class CasesSubmissionsIndexRoute extends Route {
       as: 'indieners',
     },
   };
+
+  async beforeModel() {
+    if (!this.currentSession.may('view-submissions')) {
+      this.router.transitionTo('cases');
+    }
+  }
 
   async model(params) {
     // *note: the cache busting delays the loading a bit, even locally with only 2 submissions it take half a second

--- a/app/routes/cases/submissions/index.js
+++ b/app/routes/cases/submissions/index.js
@@ -51,7 +51,7 @@ export default class CasesSubmissionsIndexRoute extends Route {
       'filter[:has:created]': `date-added-for-cache-busting-${new Date().toISOString()}`,
       'filter[:or:][pieces][:has-no:accepted-piece]': 't',
       'filter[:or:][pieces][accepted-piece][:has-no:agendaitems]': 't',
-      include: 'type,status,requested-by,mandatees.person,being-treated-by,submission-activities,decisionmaking-flow',
+      include: 'type,status,requested-by,mandatees.person,submission-activities,decisionmaking-flow',
       sort: params.sort + (params.sort ? ',' : '') + '-modified',
       page: {
         number: params.page,

--- a/app/routes/cases/submissions/submission.js
+++ b/app/routes/cases/submissions/submission.js
@@ -17,7 +17,7 @@ export default class CasesSubmissionsSubmissionRoute extends Route {
 
   async beforeModel(_transition) {
     if (!this.currentSession.may('view-submissions')) {
-      this.router.transitionTo('index');
+      this.router.transitionTo('cases');
     }
     const linkedMandatees = await this.store.queryAll('mandatee', {
       'filter[user-organizations][:id:]': this.currentSession.organization.id,

--- a/app/routes/cases/submissions/submission.js
+++ b/app/routes/cases/submissions/submission.js
@@ -42,7 +42,7 @@ export default class CasesSubmissionsSubmissionRoute extends Route {
 
     const status = await submission.status;
     const subcase = await submission.subcase;
-    if (status.uri === CONSTANTS.SUBMISSION_STATUSES.AANVAARD) {
+    if (status.uri === CONSTANTS.SUBMISSION_STATUSES.BEHANDELD) {
       if (subcase)  {
         const decisionmakingFlow = await subcase.decisionmakingFlow;
         return this.router.transitionTo(

--- a/app/routes/signatures/decisions.js
+++ b/app/routes/signatures/decisions.js
@@ -6,6 +6,7 @@ import Snapshot from 'frontend-kaleidos/utils/snapshot';
 export default class SignaturesDecisionsRoute extends Route {
   @service store;
   @service currentSession;
+  @service router;
 
   queryParams = {
     pageSignaturesDecisions: {

--- a/app/routes/signatures/ongoing-decisions.js
+++ b/app/routes/signatures/ongoing-decisions.js
@@ -10,6 +10,7 @@ import endOfDay from 'date-fns/endOfDay';
 export default class SignaturesOngoingDecisionsRoute extends Route {
   @service currentSession;
   @service store;
+  @service router;
 
   queryParams = {
     page: {

--- a/app/routes/signatures/ongoing-ratifications.js
+++ b/app/routes/signatures/ongoing-ratifications.js
@@ -11,6 +11,7 @@ import CONSTANTS from 'frontend-kaleidos/config/constants';
 export default class SignaturesOngoingRatificationsRoute extends Route {
   @service currentSession;
   @service store;
+  @service router;
 
   queryParams = {
     page: {

--- a/app/routes/signatures/ratifications.js
+++ b/app/routes/signatures/ratifications.js
@@ -6,6 +6,7 @@ import Snapshot from 'frontend-kaleidos/utils/snapshot';
 export default class SignaturesRatificationsRoute extends Route {
   @service store;
   @service currentSession;
+  @service router;
 
   queryParams = {
     pageSignaturesRatifications: {

--- a/app/services/cabinet-mail.js
+++ b/app/services/cabinet-mail.js
@@ -50,7 +50,7 @@ export default class CabinetMailService extends Service {
       const params = {
         submissionUrl: `${hostUrlPrefix}${submissionUrl}`,
         submissionTitle: submission.shortTitle,
-        caseName: submission.title,
+        caseName: submission.decisionmakingFlowTitle,
         comment,
       };
 
@@ -77,7 +77,7 @@ export default class CabinetMailService extends Service {
       const params = {
         submissionUrl: `${hostUrlPrefix}${submissionUrl}`,
         submissionTitle: submission.shortTitle,
-        caseName: submission.title,
+        caseName: submission.decisionmakingFlowTitle,
         comment,
       };
 
@@ -122,7 +122,7 @@ export default class CabinetMailService extends Service {
       const params = {
         submissionUrl: `${hostUrlPrefix}${submissionUrl}`,
         submissionTitle: submission.shortTitle,
-        caseName: submission.title,
+        caseName: submission.decisionmakingFlowTitle,
         approvalComment: submission.approvalComment,
         notificationComment: submission.notificationComment,
       };
@@ -178,7 +178,7 @@ export default class CabinetMailService extends Service {
       const params = {
         submissionUrl: `${hostUrlPrefix}${submissionUrl}`,
         submissionTitle: submission.shortTitle,
-        caseName: submission.title,
+        caseName: submission.decisionmakingFlowTitle,
         approvalComment: submission.approvalComment,
         notificationComment: submission.notificationComment,
       };

--- a/app/templates/agenda/submissions.hbs
+++ b/app/templates/agenda/submissions.hbs
@@ -61,6 +61,12 @@
                       {{else}}
                         -
                       {{/if}}
+                      {{#if (not submission.decisionmakingFlow.id)}}
+                        <span class="auk-u-text-small au-u-muted auk-u-text-nowrap auk-u-mr-2">
+                          <Auk::ColorBadge @skin="success" />
+                          {{t "new-case"}}
+                        </span>
+                      {{/if}}
                       {{#if submission.confidential}}
                         <AuPill
                           @size="small"

--- a/app/templates/agenda/submissions.hbs
+++ b/app/templates/agenda/submissions.hbs
@@ -61,6 +61,15 @@
                       {{else}}
                         -
                       {{/if}}
+                      {{#if submission.confidential}}
+                        <AuPill
+                          @size="small"
+                          @skin="warning"
+                          @icon="lock-closed"
+                        >
+                          {{t "limited-access"}} 
+                        </AuPill>
+                      {{/if}}
                     </p>
                   </td>
                   <td>

--- a/app/templates/cases/index.hbs
+++ b/app/templates/cases/index.hbs
@@ -19,22 +19,23 @@
           <AuHeading @level="3" @skin="6" class="au-u-hidden-visually">
             {{t "content"}}
           </AuHeading>
-          <Auk::Tabs @responsive={{true}} @vertical={{true}} @responsiveBreakpoint="small">
-            <Auk::Tab
-              @route="cases"
-              @current-when="cases.index"
-            >
-              {{t "cases"}}
-            </Auk::Tab>
-            {{#if this.mayShowSubmissionsTab}}
+          {{#if this.mayShowSubmissionsTab}}
+          {{! if viewing submissions is not allowed, it doesn't make sense to add a singular tab for cases}}
+            <Auk::Tabs @responsive={{true}} @vertical={{true}} @responsiveBreakpoint="small">
+              <Auk::Tab
+                @route="cases"
+                @current-when="cases.index"
+              >
+                {{t "cases"}}
+              </Auk::Tab>
               <Auk::Tab
                 @route="cases.submissions"
                 @current-when="cases.submissions"
               >
                 {{t "submissions"}}
               </Auk::Tab>
-            {{/if}}
-          </Auk::Tabs>
+            </Auk::Tabs>
+          {{/if}}
         </nav>
         <Auk::MobileFilters
           @toggleLabel="Filters"

--- a/app/templates/cases/submissions/index.hbs
+++ b/app/templates/cases/submissions/index.hbs
@@ -126,6 +126,12 @@
                             {{else}}
                               -
                             {{/if}}
+                            {{#if (not submission.decisionmakingFlow.id)}}
+                              <span class="auk-u-text-small au-u-muted auk-u-text-nowrap auk-u-mr-2">
+                                <Auk::ColorBadge @skin="success" />
+                                {{t "new-case"}}
+                              </span>
+                            {{/if}}
                             {{#if submission.confidential}}
                               <AuPill
                                 @size="small"

--- a/app/templates/cases/submissions/index.hbs
+++ b/app/templates/cases/submissions/index.hbs
@@ -126,6 +126,15 @@
                             {{else}}
                               -
                             {{/if}}
+                            {{#if submission.confidential}}
+                              <AuPill
+                                @size="small"
+                                @skin="warning"
+                                @icon="lock-closed"
+                              >
+                                {{t "limited-access"}}
+                              </AuPill>
+                            {{/if}}
                           </p>
                         </td>
                         <td>

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1424,7 +1424,7 @@
   "delete-and-send-back-to-submitter": "Verwijder en terug naar indiener sturen",
   "submit-new-documents": "Dien nieuwe documenten in",
   "submit-new-case": "Nieuw dossier indienen",
-  "submit-new-subcase": "Nieuwe procedurestap indienen",
+  "submit-new-agendaitem": "Nieuw agendapunt indienen",
   "delete-submission-confirmation": "Bent u zeker dat u de indiening wilt verwijderen?",
   "document-naming--toast-generating--message": "De VR nummers worden toegepast.",
   "error-while-fetching-document-naming-mapping": "Er ging iets fout tijdens het berekenen van de VR nummers.",

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1422,7 +1422,7 @@
   "sent-back-on": "Teruggestuurd op {date} om {hour}",
   "in-treatment-by-user-on": "In behandeling genomen door {userName} op {date} om {hour}",
   "update-submitted-on": "Update ingediend door {userName} op {date} om {hour}",
-  "accepted-on": "Aanvaard op {date} om {hour}",
+  "treated-on": "Behandeld op {date} om {hour}",
   "delete-and-send-back-to-submitter": "Verwijder en terug naar indiener sturen",
   "submit-new-documents": "Dien nieuwe documenten in",
   "submit-new-case": "Nieuw dossier indienen",

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1407,6 +1407,8 @@
   "remarks-for-secretary-about-submission": "Opmerkingen voor de secretarie over de indiening",
   "date-put-on-agenda": "Datum agendering",
   "submission": "Indiening",
+  "submission-new-case": "Indiening voor nieuw dossier",
+  "submission-existing-case": "Indiening voor bestaand dossier",
   "all-submissions": "Alle indieningen",
   "take-in-treatment": "Neem in behandeling",
   "create-subcase-and-put-on-agenda": "Maak procedurestap en agendeer",

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -237,7 +237,7 @@
   "name-subcase": "Korte titel",
   "nav-title": "Historiek",
   "new-agenda": "Nieuwe agenda aanmaken",
-  "new-case": "Dossier aanmaken",
+  "new-case": "Nieuw dossier",
   "new-document-piece": "Nieuwe documentversie uploaden",
   "new-person": "Nieuwe bevoegde persoon toekennen",
   "new-session": "Nieuwe zitting",


### PR DESCRIPTION
Fixes for multiple tickets
https://kanselarij.atlassian.net/browse/KAS-4684

- [ ] https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/486

- [x] Label “Nieuwe procedurestap indienen” zou beter “Nieuw agendapunt indienen”
- [x] Lange titel en procedurestapnaam moeten wél in het datamodel zitten en overgenomen worden van een eventuele vorige procedurestap, maar deze velden mogen niet bewerkbaar zijn door de kabinetten
- [x] Het is ook niet duidelijk of een indiening op een bestaand of nieuw dossier is, daarvoor tonen we een groene markering oid voor nieuwe dossiers, analoog aan “nieuw document”
- [x]  Bij een bestaand dossier willen we er naar linken vanuit het overzicht.  (in het scherm van de indiening zelf)
- [x] Ook bovenaan wordt de korte titel nog eens getoond. Hier moet eigenlijk de titel van het bestaand dossier getoond worden. een link naar een bestaand dossier zou goed zijn, tekst afhankelijk van "bestaand dossier" of "nieuw dossier"

https://kanselarij.atlassian.net/browse/KAS-4688
- [x] Overheid kan de tab “indieningen” zien bij dossier. Deze permission moet dus afgecheckt worden.
- [x] In de lijst met indieningen zou best een badge “vertrouwelijk” naast de naam van indieningen met submission.confidential === true komen te staan 


https://kanselarij.atlassian.net/browse/KAS-4685
- [x] “Aanvaard” zou beter “Behandeld” heten, dat is een minder beladen term


side tracking > missende router injecties gefixt (aparte commit kan eventueel worden gecherrypicked naar DEV om de change log te verkleinen)