### PR TITLE
KAS-4712: Better DOCX conversion error handling

### DIFF
--- a/app/services/file-conversion-service.js
+++ b/app/services/file-conversion-service.js
@@ -38,7 +38,7 @@ export default class FileConversionService extends Service {
       } else {
         console.warn(`Couldn't convert file with id ${sourceFile.id}`);
         let errorMessage = response.status;
-        if (response.headers.get('Content-Type') === 'application/vnd.api+json') {
+        if (response.headers.get('Content-Type').includes('application/vnd.api+json')) {
           const { errors } = await response.json();
           errorMessage = JSON.stringify(errors);
         }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4712

When getting the error message from the DOCX conversion service, we need to broaden the check for if the response is JSON (because sometimes, for some reason, the service adds `; charset=utf-8` to the Content-Type header).

Related PR:
- [ ] https://github.com/kanselarij-vlaanderen/docx-conversion-service/pull/6