### PR TITLE
KAS-4774: Only show Vertouwelijk/Intern Regering options for KB when uploading docs

### DIFF
--- a/app/components/cases/submissions/document-upload-panel.hbs
+++ b/app/components/cases/submissions/document-upload-panel.hbs
@@ -16,7 +16,7 @@
           @piece={{piece}}
           @allowDocumentContainerEdit={{true}}
           @allowEditPieceAccessLevel={{true}}
-          @disableInternSecretarie={{true}}
+          @simplifiedOptions={{true}}
           @onDelete={{perform this.deletePiece piece}}
         />
       {{/each}}

--- a/app/components/documents/uploaded-document.hbs
+++ b/app/components/documents/uploaded-document.hbs
@@ -33,7 +33,7 @@
             <Utils::AccessLevelSelector
               @selected={{@piece.accessLevel}}
               @allowClear={{false}}
-              @disableInternSecretarie={{@disableInternSecretarie}}
+              @simplifiedOptions={{@simplifiedOptions}}
               @onChange={{set @piece "accessLevel"}}
               @displayField="label"
               @sortField="position"

--- a/app/components/utils/access-level-selector.js
+++ b/app/components/utils/access-level-selector.js
@@ -15,16 +15,15 @@ export default class UtilsAccessLevelSelectorComponent extends Component {
    * @argument selected
    * @argument onChange
    * @argument filterOptions: a function that will filter out results from the dropwdown menu
+   * @argument simplifiedOptions: if true, only show Vertrouwelijk and Intern Regering
    */
   get filter() {
     let idFilter = {};
-    if (this.args.disableInternSecretarie) {
+    if (this.args.simplifiedOptions) {
       idFilter = {
         ':id:': [
           CONSTANTS.ACCESS_LEVEL_IDS.VERTROUWELIJK,
           CONSTANTS.ACCESS_LEVEL_IDS.INTERN_REGERING,
-          CONSTANTS.ACCESS_LEVEL_IDS.INTERN_OVERHEID,
-          CONSTANTS.ACCESS_LEVEL_IDS.PUBLIEK,
         ].join(',')
       }
     }

--- a/app/templates/cases/case/subcases/subcase/new-submission.hbs
+++ b/app/templates/cases/case/subcases/subcase/new-submission.hbs
@@ -173,7 +173,7 @@
             @piece={{piece}}
             @allowDocumentContainerEdit={{true}}
             @allowEditPieceAccessLevel={{true}}
-            @disableInternSecretarie={{true}}
+            @simplifiedOptions={{true}}
             @onDelete={{fn this.deletePiece piece}}
           />
         {{/each}}

--- a/app/templates/cases/submissions/submission.hbs
+++ b/app/templates/cases/submissions/submission.hbs
@@ -184,7 +184,7 @@
             @piece={{piece}}
             @allowDocumentContainerEdit={{true}}
             @allowEditPieceAccessLevel={{true}}
-            @disableInternSecretarie={{true}}
+            @simplifiedOptions={{true}}
             @onDelete={{fn this.deletePiece piece}}
           />
         {{/each}}


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4774

The `disableInternSecretarie` option is renamed to `simplifiedOptions` and it restricts everything except for `Vertrouwelijk` and `Intern Regering` now.