### PR TITLE
Feature/kas 4690 new submission notifications

### DIFF
--- a/app/components/agenda/agendaitem/agendaitem-controls.js
+++ b/app/components/agenda/agendaitem/agendaitem-controls.js
@@ -196,7 +196,8 @@ export default class AgendaitemControls extends Component {
     );
     await this.cabinetMail.sendBackToSubmitterMail(
       submission,
-      this.sendBackToSubmitterComment
+      this.sendBackToSubmitterComment,
+      this.args.meeting,
     );
     await this.deleteItem(agendaitem);
     const subcase = await submission.subcase;

--- a/app/components/cases/new-submission.js
+++ b/app/components/cases/new-submission.js
@@ -230,7 +230,7 @@ export default class CasesNewSubmissionComponent extends Component {
 
     // Create submission change
     await this.draftSubmissionService.createStatusChange(this.submission, submitted.uri, comment);
-    await this.createNotificationMailResources();
+    await this.createNotificationMailResources(meeting);
 
     if (meeting) {
       try {
@@ -253,9 +253,9 @@ export default class CasesNewSubmissionComponent extends Component {
     }
   });
 
-  async createNotificationMailResources() {
+  async createNotificationMailResources(meeting) {
     if (this.approvalAddresses.length && this.notificationAddresses.length) {
-      await this.cabinetMail.sendFirstSubmissionMails(this.submission);
+      await this.cabinetMail.sendFirstSubmissionMails(this.submission, meeting);
     }
   }
 

--- a/app/components/subcases/subcase-header.hbs
+++ b/app/components/subcases/subcase-header.hbs
@@ -6,7 +6,7 @@
       </Auk::Toolbar::Item>
     </Auk::Toolbar::Group>
     <Auk::Toolbar::Group @position="right">
-      {{#if (and this.loadData.isIdle this.maySubmitNewDocuments)}}
+      {{#if this.maySubmitNewDocuments}}
         <Auk::Toolbar::Item>
           <AuLink
             @skin="button-secondary"

--- a/app/components/submission/header.js
+++ b/app/components/submission/header.js
@@ -37,43 +37,35 @@ export default class SubmissionHeaderComponent extends Component {
   }
 
   loadAgenda = task(async () => {
-    const meeting = await this.args.submission.meeting;
-    if (meeting?.id) {
-      this.selectedMeeting = meeting;
-      this.selectedAgenda = await this.store.queryOne('agenda', {
-        'filter[created-for][:id:]': meeting.id,
-        'filter[:has-no:next-version]': true,
-      });
-    } else {
-      const proposableAgendas = (await this.agendaService.getOpenMeetings()).data.map(
-        (meeting) => ({
-          id: meeting.attributes.agendaId,
-          uri: meeting.attributes.agenda,
-          serialnumber: meeting.attributes.serialnumber,
-          createdFor: {
-            id: meeting.id,
-            uri: meeting.attributes.uri,
-            plannedStart: new Date(meeting.attributes.plannedStart),
-            kind: {
-              label: meeting.attributes.type,
-            }
-          },
-        })
-      );
-      if (proposableAgendas?.length) {
-        // TODO: we should somehow be able to get the intended meeting here more easily and accurately.
-        // However, we don't store the meeting kind anywhere,
-        // so this could be any of the meetings on the submission.plannedStart date.
-        // most likely this will mean we have to store the meeting kind in the submission data model,
-        // or even better, the actual meeting uuid.
-        for (const proposableAgenda of proposableAgendas) {
-          if (proposableAgenda.createdFor.plannedStart.getTime() === this.args.submission.plannedStart?.getTime()) {
-            this.selectedAgenda = proposableAgenda;
-            break;
-          }
-        }
+    if (this.args.submission) {
+      const meeting = await this.args.submission.meeting;
+      if (meeting?.id) {
+        this.selectedMeeting = meeting;
+        this.selectedAgenda = await this.store.queryOne('agenda', {
+          'filter[created-for][:id:]': meeting.id,
+          'filter[:has-no:next-version]': true,
+        });
+      } else {
+        // get meeting when not propagated yet
+        const meetingData = await this.agendaService.getMeetingForSubmission(this.args.submission);
+        const agenda = {
+            id: meetingData.data.attributes.agendaId,
+            uri: meetingData.data.attributes.agenda,
+            serialnumber: meetingData.data.attributes.serialnumber,
+            createdFor: {
+              id: meetingData.data.id,
+              uri: meetingData.data.attributes.uri,
+              plannedStart: new Date(meetingData.data.attributes.plannedStart),
+              kind: {
+                label: meetingData.data.attributes.type,
+              }
+            },
+          };
+
+        this.selectedAgenda = agenda;
+        this.selectedMeeting = agenda.createdFor;
       }
-    }
+  }
   });
 
   get items() {
@@ -90,35 +82,35 @@ export default class SubmissionHeaderComponent extends Component {
   }
 
   get isUpdate() {
-    return !!this.args.submission.subcase?.get('id');
+    return !!this.args.subcase?.id;
   }
 
   get canResubmitSubmission() {
     return (
-      this.args.submission.isSentBack &&
+      this.args.submission?.isSentBack &&
       this.currentSession.may('edit-sent-back-submissions')
     );
   }
 
   get canCreateSubcase() {
     return (
-      this.args.submission.isInTreatment &&
+      this.args.submission?.isInTreatment &&
       this.currentSession.may('create-subcases-from-submissions')
     );
   }
 
   get canTakeInTreatment() {
     return (
-      (this.args.submission.isSubmitted ||
-        this.args.submission.isResubmitted ||
-        this.args.submission.isUpdateSubmitted) &&
+      (this.args.submission?.isSubmitted ||
+        this.args.submission?.isResubmitted ||
+        this.args.submission?.isUpdateSubmitted) &&
       this.currentSession.may('edit-in-treatment-submissions')
     );
   }
 
   get canSendBackToSubmitter() {
     return (
-      this.args.submission.isInTreatment &&
+      this.args.submission?.isInTreatment &&
       this.currentSession.may('edit-in-treatment-submissions')
     );
   }
@@ -173,7 +165,7 @@ export default class SubmissionHeaderComponent extends Component {
       CONSTANTS.SUBMISSION_STATUSES.OPNIEUW_INGEDIEND,
       this.comment
     );
-    await this.cabinetMail.sendResubmissionMails(this.args.submission, this.comment, this.selectedAgenda?.createdFor);
+    await this.cabinetMail.sendResubmissionMails(this.args.submission, this.comment, this.selectedMeeting);
     if (isPresent(this.args.onStatusUpdated)) {
       this.args.onStatusUpdated();
     }

--- a/app/components/submission/header.js
+++ b/app/components/submission/header.js
@@ -39,7 +39,8 @@ export default class SubmissionHeaderComponent extends Component {
   loadAgenda = task(async () => {
     if (this.args.submission) {
       const meeting = await this.args.submission.meeting;
-      if (meeting?.id) {
+      if (meeting?.id && this.currentSession.may('create-subcases-from-submissions')) {
+        // only editors can use the store if not propagated yet
         this.selectedMeeting = meeting;
         this.selectedAgenda = await this.store.queryOne('agenda', {
           'filter[created-for][:id:]': meeting.id,

--- a/app/components/submission/header.js
+++ b/app/components/submission/header.js
@@ -57,6 +57,7 @@ export default class SubmissionHeaderComponent extends Component {
               uri: meetingData.data.attributes.uri,
               plannedStart: new Date(meetingData.data.attributes.plannedStart),
               kind: {
+                uri: meetingData.data.attributes.kind,
                 label: meetingData.data.attributes.type,
               }
             },

--- a/app/components/submission/header.js
+++ b/app/components/submission/header.js
@@ -359,7 +359,8 @@ export default class SubmissionHeaderComponent extends Component {
     );
     await this.cabinetMail.sendBackToSubmitterMail(
       this.args.submission,
-      this.comment
+      this.comment,
+      this.selectedMeeting,
     );
     if (isPresent(this.args.onStatusUpdated)) {
       this.args.onStatusUpdated();

--- a/app/controllers/cases/case/subcases/subcase/new-submission.js
+++ b/app/controllers/cases/case/subcases/subcase/new-submission.js
@@ -278,7 +278,7 @@ export default class CasesCaseSubcasesSubcaseNewSubmissionController extends Con
           meeting,
           this.submission
         );
-        await this.cabinetMail.sendUpdateSubmissionMails(this.submission);
+        await this.cabinetMail.sendUpdateSubmissionMails(this.submission, meeting);
         this.router.transitionTo('cases.submissions.submission', this.submission.id);
       } catch (error) {
         this.toaster.error(

--- a/app/controllers/cases/submissions/submission.js
+++ b/app/controllers/cases/submissions/submission.js
@@ -117,11 +117,10 @@ export default class CasesSubmissionsSubmissionController extends Controller {
   });
 
   reloadPieces = task(async () => {
-    const subcase = await this.model.subcase;
     const newPieces = await this.model.pieces;
     let pieces = [];
-    if (subcase) {
-      pieces = await this.submissionService.loadSubmissionPieces(subcase, newPieces);
+    if (this.subcase) {
+      pieces = await this.submissionService.loadSubmissionPieces(this.subcase, newPieces);
     } else {
       pieces = newPieces.slice();
     }
@@ -169,9 +168,8 @@ export default class CasesSubmissionsSubmissionController extends Controller {
     const now = new Date();
     const confidential = this.model.confidential || false;
     const numberOfContainers = this.documentContainerIds.length;
-    const position = parsed.index || (numberOfContainers + 1);
     // uploading a new doc on an update results in double numbering. fe uploading doc 2 results in doc 1, 2, 2, 3
-    // const position = this.isUpdate ? (numberOfContainers + 1) : parsed.index || (numberOfContainers + 1);
+    const position = this.isUpdate ? (numberOfContainers + 1) : parsed.index || (numberOfContainers + 1);
     const documentContainer = this.store.createRecord(
       'draft-document-container',
       {

--- a/app/models/email-notification-setting.js
+++ b/app/models/email-notification-setting.js
@@ -15,4 +15,5 @@ export default class EmailNotificationSetting extends Model {
   @attr('string') cabinetSubmissionsSecretaryEmail;
   @attr('string') cabinetSubmissionsIkwEmail;
   @attr('string') cabinetSubmissionsIkwConfidentialEmail;
+  @attr('string') cabinetSubmissionsReplyToEmail;
 }

--- a/app/routes/cases/submissions/submission.js
+++ b/app/routes/cases/submissions/submission.js
@@ -44,17 +44,17 @@ export default class CasesSubmissionsSubmissionRoute extends Route {
 
     const status = await submission.belongsTo('status').reload();
     // querying here to get around cache issue.
-    const subcase = await this.store.queryOne('subcase', {
+    this.subcase = await this.store.queryOne('subcase', {
       'filter[:has:created]': `date-added-for-cache-busting-${new Date().toISOString()}`,
       'filter[submissions][:id:]': submission.id
     });
     if (status.uri === CONSTANTS.SUBMISSION_STATUSES.BEHANDELD) {
-      if (subcase)  {
-        const decisionmakingFlow = await subcase.decisionmakingFlow;
+      if (this.subcase)  {
+        const decisionmakingFlow = await this.subcase.decisionmakingFlow;
         return this.router.transitionTo(
           'cases.case.subcases.subcase',
           decisionmakingFlow.id,
-          subcase.id
+          this.subcase.id
         );
       }
     }
@@ -79,8 +79,8 @@ export default class CasesSubmissionsSubmissionRoute extends Route {
 
     const newPieces = await submission.pieces;
     let pieces = [];
-    if (subcase) {
-      pieces = await this.submissionService.loadSubmissionPieces(subcase, newPieces);
+    if (this.subcase) {
+      pieces = await this.submissionService.loadSubmissionPieces(this.subcase, newPieces);
     } else {
       pieces = newPieces.slice();
     }
@@ -124,6 +124,7 @@ export default class CasesSubmissionsSubmissionRoute extends Route {
     controller.currentLinkedMandatee = this.currentLinkedMandatee;
     controller.beingTreatedBy = this.beingTreatedBy;
     controller.isUpdate = this.isUpdate;
+    controller.subcase = this.subcase;
     controller.approvalAddresses = _model.approvalAddresses;
     controller.notificationAddresses = _model.notificationAddresses;
     controller.approvalComment = _model.approvalComment;

--- a/app/services/agenda-service.js
+++ b/app/services/agenda-service.js
@@ -220,6 +220,33 @@ export default class AgendaService extends Service {
     return json;
   }
 
+  async getMeetingForSubmission(submission) {
+    const url = `/submissions/${submission.id}/for-meeting`;
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { 'Accept': 'application/vnd.api+json' },
+    });
+    let json;
+    try {
+      json = await response.json();      
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        throw new Error(
+          `Backend response contained an error (status: ${response.status})`
+        );
+      } else {
+        throw error;
+      }
+    }
+    if (!response.ok) {
+      throw new Error(
+        `Backend response contained an error (status: ${
+          response.status
+        }): ${JSON.stringify(json)}`);
+    }
+    return json;
+  }
+
   /* No API */
 
   async setAgendaitemsGroupname(agendaitems) {

--- a/app/services/cabinet-mail.js
+++ b/app/services/cabinet-mail.js
@@ -11,6 +11,7 @@ import {
   caseUpdateSubmissionIkwEmail,
   caseUpdateSubmissionSubmitterEmail,
 } from 'frontend-kaleidos/utils/cabinet-submission-email';
+import CopyErrorToClipboardToast from 'frontend-kaleidos/components/utils/toaster/copy-error-to-clipboard-toast';
 
 export default class CabinetMailService extends Service {
   @service store;
@@ -43,187 +44,143 @@ export default class CabinetMailService extends Service {
   }
 
   async sendBackToSubmitterMail(submission, comment) {
-    const { mailSettings, outbox } = await this.loadSettings();
-    if (mailSettings && outbox) {
-      const hostUrlPrefix = `${window.location.protocol}//${window.location.host}`;
-      const submissionUrl = this.getSubmissionUrl(submission);
-      const meeting = await submission.meeting;
+    const hostUrlPrefix = `${window.location.protocol}//${window.location.host}`;
+    const submissionUrl = this.getSubmissionUrl(submission);
+    const meeting = await submission.meeting;
 
-      const params = {
-        submissionUrl: `${hostUrlPrefix}${submissionUrl}`,
-        caseName: submission.decisionmakingFlowTitle || "geen titel WIP",
-        comment,
-        meeting,
-        submission
-      };
+    const params = {
+      submissionUrl: `${hostUrlPrefix}${submissionUrl}`,
+      caseName: submission.decisionmakingFlowTitle || "geen titel WIP",
+      comment,
+      meeting,
+      submission
+    };
 
-      const mail = await caseSendBackEmail(params);
-      const creator = await this.draftSubmissionService.getCreator(submission);
-      const mailResource = this.store.createRecord('email', {
-        to: creator.email,
-        from: mailSettings.defaultFromEmail,
-        folder: outbox,
-        subject: mail.subject,
-        message: mail.message,
-      });
+    const submitterEmail = await caseSendBackEmail(params);
+    const creator = await this.draftSubmissionService.getCreator(submission);
+    const submitterEmailResource = await this.createMailRecord(creator.email, submitterEmail);
 
-      await mailResource.save();
-    }
+    await submitterEmailResource?.save();
   }
 
   async sendResubmissionMails(submission, comment, meeting) {
-    const { mailSettings, outbox } = await this.loadSettings();
-    if (mailSettings && outbox) {
-      const hostUrlPrefix = `${window.location.protocol}//${window.location.host}`;
-      const submissionUrl = this.getSubmissionUrl(submission);
+    const hostUrlPrefix = `${window.location.protocol}//${window.location.host}`;
+    const submissionUrl = this.getSubmissionUrl(submission);
 
-      const params = {
-        submissionUrl: `${hostUrlPrefix}${submissionUrl}`,
-        caseName: submission.decisionmakingFlowTitle || "geen titel WIP",
-        comment,
-        submission,
-        meeting
-      };
+    const params = {
+      submissionUrl: `${hostUrlPrefix}${submissionUrl}`,
+      caseName: submission.decisionmakingFlowTitle || "geen titel WIP",
+      comment,
+      submission,
+      meeting
+    };
 
-      const notificationEmail = await caseResubmittedEmail(params);
-      const submitterEmail = await caseResubmittedSubmitterEmail(params);
+    // same mail for approvers and notification
+    const notificationEmail = await caseResubmittedEmail(params);
+    const approversMailResource = await this.createMailRecord(submission.approvalAddresses.join(','), notificationEmail);
+    const notificationEmailResource = await this.createMailRecord(submission.notificationAddresses.join(','), notificationEmail); 
 
-      const approversMailResource = this.store.createRecord('email', {
-        to: submission.approvalAddresses.join(','),
-        from: mailSettings.defaultFromEmail,
-        folder: outbox,
-        subject: notificationEmail.subject,
-        message: notificationEmail.message,
-      });
+    const submitterEmail = await caseResubmittedSubmitterEmail(params);
+    const creator = await this.draftSubmissionService.getCreator(submission);
+    const submitterEmailResource = await this.createMailRecord(creator.email, submitterEmail);
 
-      const notificationEmailResource = this.store.createRecord('email', {
-        to: submission.notificationAddresses.join(','),
-        from: mailSettings.defaultFromEmail,
-        folder: outbox,
-        subject: notificationEmail.subject,
-        message: notificationEmail.message,
-      });
-
-      const creator = await this.draftSubmissionService.getCreator(submission);
-      const submitterEmailResource = this.store.createRecord('email', {
-        to: creator.email,
-        from: mailSettings.defaultFromEmail,
-        folder: outbox,
-        subject: submitterEmail.subject,
-        message: submitterEmail.message,
-      });
-
-      await Promise.all([
-        approversMailResource.save(),
-        notificationEmailResource.save(),
-        submitterEmailResource.save(),
-      ]);
-    }
+    await Promise.all([
+      approversMailResource?.save(),
+      notificationEmailResource?.save(),
+      submitterEmailResource?.save(),
+    ]);
   }
 
   async sendFirstSubmissionMails(submission, meeting) {
-    const { mailSettings } = await this.loadSettings();
-    const { outbox } = await this.loadSettings();
-    if (outbox) {
-      const hostUrlPrefix = `${window.location.protocol}//${window.location.host}`;
-      const submissionUrl = this.getSubmissionUrl(submission);
+    const hostUrlPrefix = `${window.location.protocol}//${window.location.host}`;
+    const submissionUrl = this.getSubmissionUrl(submission);
 
-      const params = {
-        submissionUrl: `${hostUrlPrefix}${submissionUrl}`,
-        caseName: submission.decisionmakingFlowTitle || "geen titel WIP",
-        approvalComment: submission.approvalComment,
-        notificationComment: submission.notificationComment,
-        meeting,
-        submission
-      };
+    const params = {
+      submissionUrl: `${hostUrlPrefix}${submissionUrl}`,
+      caseName: submission.decisionmakingFlowTitle || "geen titel WIP",
+      approvalComment: submission.approvalComment,
+      notificationComment: submission.notificationComment,
+      meeting,
+      submission
+    };
 
-      const approversMail = await caseSubmittedApproversEmail(params);
-      const ikwMail = await caseSubmittedIkwEmail(params);
-      const submitterMail = await caseSubmittedSubmitterEmail(params);
+    const approversMail = await caseSubmittedApproversEmail(params);
+    const approversMailResource = await this.createMailRecord(submission.approvalAddresses.join(','), approversMail);
 
-      const approversMailResource = this.store.createRecord('email', {
-        to: submission.approvalAddresses.join(','),
-        from: mailSettings.defaultFromEmail,
-        folder: outbox,
-        subject: approversMail.subject,
-        message: approversMail.message,
-      });
+    const ikwMail = await caseSubmittedIkwEmail(params);
+    const ikwMailResource = await this.createMailRecord(submission.notificationAddresses.join(','), ikwMail);
 
-      const notificationEmailResource = this.store.createRecord('email', {
-        to: submission.notificationAddresses.join(','),
-        from: mailSettings.defaultFromEmail,
-        folder: outbox,
-        subject: ikwMail.subject,
-        message: ikwMail.message,
-      });
+    const submitterMail = await caseSubmittedSubmitterEmail(params);
+    const creator = await this.draftSubmissionService.getCreator(submission);
+    const submitterMailResource = await this.createMailRecord(creator.email, submitterMail);
 
-      const creator = await this.draftSubmissionService.getCreator(submission);
-      const submitterMailResource = this.store.createRecord('email', {
-        to: creator.email,
-        from: mailSettings.defaultFromEmail,
-        folder: outbox,
-        subject: submitterMail.subject,
-        message: submitterMail.message,
-      });
-
-      await Promise.all([
-        approversMailResource.save(),
-        notificationEmailResource.save(),
-        submitterMailResource.save(),
-      ]);
-    }
+    await Promise.all([
+      approversMailResource?.save(),
+      ikwMailResource?.save(),
+      submitterMailResource?.save(),
+    ]);
   }
 
   async sendUpdateSubmissionMails(submission, meeting) {
+    const hostUrlPrefix = `${window.location.protocol}//${window.location.host}`;
+    const submissionUrl = this.getSubmissionUrl(submission);
+
+    const params = {
+      submissionUrl: `${hostUrlPrefix}${submissionUrl}`,
+      caseName: submission.decisionmakingFlowTitle || "geen titel WIP",
+      approvalComment: submission.approvalComment,
+      notificationComment: submission.notificationComment,
+      submission,
+      meeting
+    };
+
+    const approversMail = await caseUpdateSubmissionApproversEmail(params);
+    const approversMailResource = await this.createMailRecord(submission.approvalAddresses.join(','), approversMail);
+
+    const ikwMail = await caseUpdateSubmissionIkwEmail(params);
+    const ikwMailResource = await this.createMailRecord(submission.notificationAddresses.join(','), ikwMail);
+
+    const submitterMail = await caseUpdateSubmissionSubmitterEmail(params);
+    const creator = await this.draftSubmissionService.getCreator(submission);
+    const submitterMailResource = await this.createMailRecord(creator.email, submitterMail);
+
+    await Promise.all([
+      approversMailResource?.save(),
+      ikwMailResource?.save(),
+      submitterMailResource?.save(),
+    ]);
+  }
+
+  async createMailRecord(to, mailObject) {
     const { mailSettings, outbox } = await this.loadSettings();
-
     if (mailSettings && outbox) {
-      const hostUrlPrefix = `${window.location.protocol}//${window.location.host}`;
-      const submissionUrl = this.getSubmissionUrl(submission);
+      // just in case there is no "to" (like a creator without an email address).
+      if (to?.length) {
+        return this.store.createRecord('email', {
+          to,
+          from: mailSettings.defaultFromEmail,
+          replyTo: mailSettings.cabinetSubmissionsReplyToEmail,
+          folder: outbox,
+          subject: mailObject.subject,
+          message: mailObject.message,
+        });
+      }
+      let message = "to: " + to + "\t\n";
+      message += "replyTo: " + mailSettings.cabinetSubmissionsReplyToEmail + "\t\n";
+      message += "subject: " + mailObject.subject + "\t\n";
+      message += "message: " + mailObject.message + "\t\n";
 
-      const params = {
-        submissionUrl: `${hostUrlPrefix}${submissionUrl}`,
-        caseName: submission.decisionmakingFlowTitle || "geen titel WIP",
-        approvalComment: submission.approvalComment,
-        notificationComment: submission.notificationComment,
-        submission,
-        meeting
+      const mailErrorOptions = {
+        title: this.intl.t('warning-title'),
+        message: this.intl.t('mail-could-not-be-sent'),
+        errorContent: message,
+        showDatetime: true,
+        options: {
+          timeOut: 60 * 10 * 1000,
+        },
       };
-
-      const approversMail = await caseUpdateSubmissionApproversEmail(params);
-      const ikwMail = await caseUpdateSubmissionIkwEmail(params);
-      const submitterMail = await caseUpdateSubmissionSubmitterEmail(params);
-
-      const approversMailResource = this.store.createRecord('email', {
-        to: submission.approvalAddresses.join(','),
-        from: mailSettings.defaultFromEmail,
-        folder: outbox,
-        subject: approversMail.subject,
-        message: approversMail.message,
-      });
-
-      const notificationEmailResource = this.store.createRecord('email', {
-        to: submission.notificationAddresses.join(','),
-        from: mailSettings.defaultFromEmail,
-        folder: outbox,
-        subject: ikwMail.subject,
-        message: ikwMail.message,
-      });
-
-      const creator = await this.draftSubmissionService.getCreator(submission);
-      const submitterMailResource = this.store.createRecord('email', {
-        to: creator.email,
-        from: mailSettings.defaultFromEmail,
-        folder: outbox,
-        subject: submitterMail.subject,
-        message: submitterMail.message,
-      });
-
-      await Promise.all([
-        approversMailResource.save(),
-        notificationEmailResource.save(),
-        submitterMailResource.save(),
-      ]);
+      this.toaster.show(CopyErrorToClipboardToast, mailErrorOptions);
+      return;
     }
   }
 }

--- a/app/services/cabinet-mail.js
+++ b/app/services/cabinet-mail.js
@@ -46,6 +46,7 @@ export default class CabinetMailService extends Service {
   async sendBackToSubmitterMail(submission, comment) {
     const hostUrlPrefix = `${window.location.protocol}//${window.location.host}`;
     const submissionUrl = this.getSubmissionUrl(submission);
+    // should only be done by editors so ok to not cache-bust here
     const meeting = await submission.meeting;
 
     const params = {

--- a/app/services/cabinet-mail.js
+++ b/app/services/cabinet-mail.js
@@ -43,11 +43,9 @@ export default class CabinetMailService extends Service {
     );
   }
 
-  async sendBackToSubmitterMail(submission, comment) {
+  async sendBackToSubmitterMail(submission, comment, meeting) {
     const hostUrlPrefix = `${window.location.protocol}//${window.location.host}`;
     const submissionUrl = this.getSubmissionUrl(submission);
-    // should only be done by editors so ok to not cache-bust here
-    const meeting = await submission.meeting;
 
     const params = {
       submissionUrl: `${hostUrlPrefix}${submissionUrl}`,

--- a/app/services/cabinet-mail.js
+++ b/app/services/cabinet-mail.js
@@ -165,10 +165,10 @@ export default class CabinetMailService extends Service {
           message: mailObject.message,
         });
       }
-      let message = "to: " + to + "\t\n";
-      message += "replyTo: " + mailSettings.cabinetSubmissionsReplyToEmail + "\t\n";
-      message += "subject: " + mailObject.subject + "\t\n";
-      message += "message: " + mailObject.message + "\t\n";
+      let message = "to: " + to + "\n";
+      message += "replyTo: " + mailSettings.cabinetSubmissionsReplyToEmail + "\n";
+      message += "subject: " + mailObject.subject + "\n";
+      message += "message: " + mailObject.message + "\n";
 
       const mailErrorOptions = {
         title: this.intl.t('warning-title'),

--- a/app/services/draft-submission-service.js
+++ b/app/services/draft-submission-service.js
@@ -77,4 +77,6 @@ export default class DraftSubmissionService extends Service {
       .at(0);
     return creationActivity ? true : false;
   };
+
+  // getHasConfidentialPieces async(submission) queryOny and filter on accesslevel uri for mails
 }

--- a/app/templates/cases/case/subcases/subcase/new-submission.hbs
+++ b/app/templates/cases/case/subcases/subcase/new-submission.hbs
@@ -29,7 +29,8 @@
 </Auk::Navbar>
 
 <Submission::Header
-  @submission={{@model}}
+  @submission={{null}}
+  @subcase={{@model}}
   @disableHistory={{true}}
 />
 

--- a/app/templates/cases/submissions/submission.hbs
+++ b/app/templates/cases/submissions/submission.hbs
@@ -11,6 +11,7 @@
 
 <Submission::Header
   @submission={{@model}}
+  @subcase={{this.subcase}}
   @hasActions={{this.mayEdit}}
   @onStatusUpdated={{this.onStatusUpdated}}
 />

--- a/app/templates/settings/emails.hbs
+++ b/app/templates/settings/emails.hbs
@@ -145,6 +145,15 @@
                 {{on "input" (pick "target.value" (set this "model.cabinetSubmissionsIkwConfidentialEmail"))}}
               />
             </AuFormRow>
+            <AuFormRow @alignment="inline">
+              <AuLabel class="au-u-2-6 au-u-max-width-tiny au-u-max-width-tiny">
+                {{t "email-reply-to"}}
+              </AuLabel>
+              <AuInput
+                value={{this.model.cabinetSubmissionsReplyToEmail}}
+                {{on "input" (pick "target.value" (set this "model.cabinetSubmissionsReplyToEmail"))}}
+              />
+            </AuFormRow>
           </div>
         </div>
       </Auk::Panel::Body>

--- a/app/utils/cabinet-submission-email.js
+++ b/app/utils/cabinet-submission-email.js
@@ -7,27 +7,97 @@
 // line breaks are not removed.""
 // 2. no mulitline string:
 // => ensure exact representation
+import { dateFormat } from 'frontend-kaleidos/utils/date-format';
+import CONSTANTS from 'frontend-kaleidos/config/constants';
 
 const footer = '';
 
-function caseSubmittedEmail(params) {
-  let message = '';
-  message +=
-    'Beste,\n' +
-    '\n' +
-    `Er is een nieuwe indiening "${params.submissionTitle}" in het dossier "${params.caseName}"\n` +
-    `U kunt deze hier bekijken: ${params.submissionUrl}`;
+async function getSubject(params) {
+  const meetingKind = await params.meeting.kind;
+  let meetingDate = dateFormat(params.meeting.plannedStart, 'dd-MM-yyyy');
+  const resubmitted = params.resubmitted ? ' aanpassing indiening' : '';
+  let suffix = ''
+  const mandatees = await params.submission.mandatees;
+  if (mandatees?.length > 1) {
+    suffix += ' – co-agendering';
+  }
+  if (params.submission.confidential) {
+    suffix += ' – vertrouwelijk';
+  }
+  return `${meetingKind.label} VR ${meetingDate}:${resubmitted} ${params.submission.shortTitle}${suffix}`;
+}
 
+async function caseSubmittedEmail(params) {
+  const submitter = await params.submission.requestedBy;
+  const submitterPerson = await submitter.person;
+  let message = `Beste,
+`;
+  if (params.forSubmitter) {
+    message += `
+  Uw ${params.resubmitted ? 'aangepaste ': ''}indiening is goed ontvangen. De volgende notificatie werd verstuurd:
+`;
+  }
+
+  if (params.resubmitted) {
+    message += `
+  Er werd een aanpassing gedaan aan het eerder ingediende "${params.submission.shortTitle}" door kabinet ${submitterPerson.lastName}.
+`;
+  } else {
+    message += `
+  Er werd een nieuwe indiening "${params.submission.shortTitle}" gedaan door kabinet ${submitterPerson.lastName}.
+`;
+  }
+
+  let additionalMandateeNames = [];
+  const mandatees = await params.submission.mandatees;
+  for (const mandatee of mandatees) {
+    if (mandatee.id !== submitter.id) {
+      const mandateePerson = await mandatee.person;
+      additionalMandateeNames.push('minister ' + mandateePerson.lastName);
+    }
+  }
+  if (additionalMandateeNames.length > 1) {
+    const additionalMandateeString = additionalMandateeNames.slice(0, -1).join(', ') + ' en ' + additionalMandateeNames.slice(-1);
+    message += `
+  Het betreft een co-agendering met ${additionalMandateeString}.
+  Kunnen de betrokken kabinetschefs hun akkoord geven via allen beantwoorden aub?
+`;
+} else if (additionalMandateeNames.length === 1) {
+    const additionalMandateeString = additionalMandateeNames[0];
+    message += `
+  Het betreft een co-agendering met ${additionalMandateeString}.
+  Kan de betrokken kabinetschef haar/zijn akkoord geven via allen beantwoorden aub?
+`;
+  }
+
+  if (params.submission.confidential) {
+    message += `
+  Het betreft een vertrouwelijke indiening.
+  `;
+  }
+
+  const meetingKind = await params.meeting.kind;
+  if (meetingKind?.uri === CONSTANTS.MEETING_KINDS.PVV) {
+    message += `
+  Het betreft een indiening in het kader van het Plan Vlaamse Veerkracht.
+  `;
+  }
+
+  message += `
+  U kan alle informatie en documenten hier terugvinden: ${params.submissionUrl}
+`;
   return message;
 }
 
-function caseSubmittedApproversEmail(params) {
-  const subject = `Nieuwe indiening in dossier "${params.caseName}"`;
+async function caseSubmittedApproversEmail(params) {
+  const subject = await getSubject(params);
 
-  let message = caseSubmittedEmail(params);
+  let message = await caseSubmittedEmail(params);
   if (params.approvalComment) {
-    message +=
-      `\t\n` + `Aanvullende informatie: "${params.approvalComment}"\t\n`;
+    message += `
+    Aanvullende informatie:
+    ${params.approvalComment}
+`;
   }
 
   return {
@@ -36,13 +106,22 @@ function caseSubmittedApproversEmail(params) {
   };
 }
 
-function caseSubmittedIkwEmail(params) {
-  const subject = `Nieuwe indiening in dossier "${params.caseName}"`;
+async function caseSubmittedIkwEmail(params) {
+  const subject = await getSubject(params);
 
-  let message = caseSubmittedEmail(params);
+  let message = await caseSubmittedEmail(params);
+
+  if (params.hasConfidentialPieces) {
+    message += `
+  Deze ${params.resubmitted ? 'aangepaste ': ''}indiening wordt ter informatie aan de KC-groep bezorgd omdat deze één of meer vertrouwelijke documenten bevat.
+  `;
+  }
 
   if (params.notificationComment) {
-    message += `\t\n` + `Aanvullende informatie: "${params.notificationComment}"\t\n`;
+    message += `
+    Aanvullende informatie:
+    ${params.notificationComment}
+`;
   }
 
   return {
@@ -51,20 +130,19 @@ function caseSubmittedIkwEmail(params) {
   };
 }
 
-function caseSubmittedSubmitterEmail(params) {
-  const subject = `Nieuwe indiening in dossier "${params.caseName}"`;
+async function caseSubmittedSubmitterEmail(params) {
+  const subject = await getSubject(params);
 
-  let message = '';
-  message +=
-    'Beste,\n' +
-    '\n' +
-    `Uw nieuwe indiening "${params.submissionTitle}" in het dossier: ${params.caseName}, is goed ontvangen.\n` +
-    `U kunt deze hier bekijken: ${params.submissionUrl}\t\n`;
+  let message = await caseSubmittedEmail({ ...params, ...{ forSubmitter: true }});
   if (params.approvalComment) {
-    message += `Aanvullende informatie voor goedkeuring: ${params.approvalComment}\t\n`;
+    message += `
+  Aanvullende informatie voor de secretarie en kabinetschefs: ${params.approvalComment}
+`;
   }
   if (params.notificationComment) {
-    message += `\t\nAanvullende informatie voor IKW-groep: ${params.notificationComment}\t\n`;
+    message += `
+  Aanvullende informatie voor de IKW/KC-groep: ${params.notificationComment}
+`;
   }
 
   return {
@@ -73,20 +151,26 @@ function caseSubmittedSubmitterEmail(params) {
   };
 }
 
-function caseSendBackEmail(params) {
-  const subject = `Indiening voor het dossier ${params.caseName} werd teruggestuurd.`;
+async function caseSendBackEmail(params) {
+  let subject = 'Teruggestuurd: ';
+  subject += await getSubject(params);
 
   let message = '';
-  message +=
-    'Beste,\n' +
-    '\n';
+  message += `Beste
+`;
   if (params.comment) {
-    message += `Uw indiening "${params.submissionTitle}" in het dossier: ${params.caseName}, werd teruggestuurd met volgende opmerking:"\n` +
-      `${params.comment}\n`;
+    message += `
+  Uw indiening "${params.submission.shortTitle}" werd teruggestuurd met volgende opmerking:
+  ${params.comment}
+`;
   } else {
-    message += `Uw indiening "${params.submissionTitle}" in het dossier: ${params.caseName}, werd teruggestuurd.\n`;
+    message += `
+  Uw indiening "${params.submission.shortTitle}" werd teruggestuurd.
+`;
   }
-  message += `U kunt de indiening hier bekijken: ${params.submissionUrl}`;
+  message += `
+  U kunt de indiening hier bekijken: ${params.submissionUrl}
+`;
 
   return {
     subject,
@@ -94,15 +178,10 @@ function caseSendBackEmail(params) {
   };
 }
 
-function caseResubmittedSubmitterEmail(params) {
-  const subject = `Herindiening in het dossier "${params.caseName}"`;
+async function caseResubmittedSubmitterEmail(params) {
+  const subject = await getSubject({ ...params, ...{ resubmitted: true }});
 
-  let message = '';
-  message +=
-    'Beste,\n' +
-    '\n' +
-    `Uw herindiening "${params.submissionTitle}" in het dossier "${params.caseName}" is goed ontvangen.\n` +
-    `U kunt deze hier bekijken: ${params.submissionUrl}\t\n`;
+  let message = await caseSubmittedEmail({ ...params, ...{ resubmitted: true, forSubmitter: true }});
 
   return {
     subject,
@@ -110,15 +189,10 @@ function caseResubmittedSubmitterEmail(params) {
   };
 }
 
-function caseResubmittedEmail(params) {
-  const subject = `Herindiening in het dossier "${params.caseName}"`;
+async function caseResubmittedEmail(params) {
+  const subject = await getSubject({ ...params, ...{ resubmitted: true }});
 
-  let message = '';
-  message +=
-    'Beste,\n' +
-    '\n' +
-    `Er is een herindiening "${params.submissionTitle}" in het dossier "${params.caseName}".\n` +
-    `U kunt deze hier bekijken: ${params.submissionUrl}\t\n`;
+  let message = await caseSubmittedEmail({ ...params, ...{ resubmitted: true }});
 
   return {
     subject,
@@ -126,18 +200,14 @@ function caseResubmittedEmail(params) {
   };
 }
 
-function caseUpdateSubmissionApproversEmail(params) {
-  // TODO: fix message content
-  const subject = `Herindiening in het dossier "${params.caseName}"`;
+async function caseUpdateSubmissionApproversEmail(params) {
+  const subject = await getSubject({ ...params, ...{ resubmitted: true }});
 
-  let message = '';
-  message +=
-    'Beste,\n' +
-    '\n' +
-    `Er is een herindiening "${params.submissionTitle}" in het dossier "${params.caseName}".\n` +
-    `U kunt deze hier bekijken: ${params.submissionUrl}\t\n`;
+  let message = await caseSubmittedEmail({ ...params, ...{ resubmitted: true }});
   if (params.approvalComment) {
-    message += `Aanvullende informatie voor goedkeuring: ${params.approvalComment}\t\n`;
+    message += `
+  Aanvullende informatie voor goedkeuring: ${params.approvalComment}
+`;
   }
 
   return {
@@ -146,19 +216,15 @@ function caseUpdateSubmissionApproversEmail(params) {
   };
 }
 
-function caseUpdateSubmissionIkwEmail(params) {
-  // TODO: fix message content
-  const subject = `Herindiening in het dossier "${params.caseName}"`;
+async function caseUpdateSubmissionIkwEmail(params) {
+  const subject = await getSubject({ ...params, ...{ resubmitted: true }});
 
-  let message = '';
-  message +=
-    'Beste,\n' +
-    '\n' +
-    `Er is een herindiening "${params.submissionTitle}" in het dossier "${params.caseName}".\n` +
-    `U kunt deze hier bekijken: ${params.submissionUrl}\t\n`;
+  let message = await caseSubmittedEmail({ ...params, ...{ resubmitted: true }});
 
   if (params.notificationComment) {
-    message += `\t\nAanvullende informatie voor IKW-groep: ${params.notificationComment}\t\n`;
+    message += `
+  Aanvullende informatie voor IKW-groep: ${params.notificationComment}
+`;
   }
 
   return {
@@ -167,21 +233,19 @@ function caseUpdateSubmissionIkwEmail(params) {
   };
 }
 
-function caseUpdateSubmissionSubmitterEmail(params) {
-  // TODO: fix message content
-  const subject = `Herindiening in het dossier "${params.caseName}"`;
+async function caseUpdateSubmissionSubmitterEmail(params) {
+  const subject = await getSubject({ ...params, ...{ resubmitted: true }});
 
-  let message = '';
-  message +=
-    'Beste,\n' +
-    '\n' +
-    `Uw herindiening "${params.submissionTitle}" in het dossier "${params.caseName}" werd goed ontvangen.\n` +
-    `U kunt deze hier bekijken: ${params.submissionUrl}\t\n`;
+  let message = await caseSubmittedEmail({ ...params, ...{ resubmitted: true, forSubmitter: true }});
   if (params.approvalComment) {
-    message += `Aanvullende informatie voor goedkeuring: ${params.approvalComment}\t\n`;
+    message += `
+  Aanvullende informatie voor goedkeuring: ${params.approvalComment}
+`;
   }
   if (params.notificationComment) {
-    message += `\t\nAanvullende informatie voor IKW-groep: ${params.notificationComment}\t\n`;
+    message += `
+  Aanvullende informatie voor IKW/KC-groep: ${params.notificationComment}
+`;
   }
 
   return {

--- a/app/utils/cabinet-submission-email.js
+++ b/app/utils/cabinet-submission-email.js
@@ -50,10 +50,19 @@ async function caseSubmittedEmail(params) {
 
   let additionalMandateeNames = [];
   const mandatees = await params.submission.mandatees;
-  for (const mandatee of mandatees) {
+  const sortedMandatees = mandatees.slice().sort(
+    (m1, m2) => m1.priority - m2.priority
+  );
+  for (const mandatee of sortedMandatees) {
     if (mandatee.id !== submitter.id) {
       const mandateePerson = await mandatee.person;
-      additionalMandateeNames.push('minister ' + mandateePerson.lastName);
+      const mandate = await mandatee.mandate;
+      const role = await mandate.role;
+      if (role.uri === CONSTANTS.MANDATE_ROLES.MINISTER_PRESIDENT) {
+        additionalMandateeNames.push('minister-president ' + mandateePerson.lastName);
+      } else {
+        additionalMandateeNames.push('minister ' + mandateePerson.lastName);
+      }
     }
   }
   if (additionalMandateeNames.length > 1) {

--- a/app/utils/cabinet-submission-email.js
+++ b/app/utils/cabinet-submission-email.js
@@ -7,6 +7,8 @@
 // line breaks are not removed.""
 // 2. no mulitline string:
 // => ensure exact representation
+
+// ! do not use auto formatters on this file. Any whitespaces are used in the eventual text.
 import { dateFormat } from 'frontend-kaleidos/utils/date-format';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 
@@ -104,8 +106,8 @@ async function caseSubmittedApproversEmail(params) {
   let message = await caseSubmittedEmail(params);
   if (params.approvalComment) {
     message += `
-    Aanvullende informatie:
-    ${params.approvalComment}
+  Aanvullende informatie:
+  ${params.approvalComment}
 `;
   }
 
@@ -120,6 +122,7 @@ async function caseSubmittedIkwEmail(params) {
 
   let message = await caseSubmittedEmail(params);
 
+  // this param does not exist yet
   if (params.hasConfidentialPieces) {
     message += `
   Deze ${params.resubmitted ? 'aangepaste ': ''}indiening wordt ter informatie aan de KC-groep bezorgd omdat deze één of meer vertrouwelijke documenten bevat.
@@ -128,8 +131,8 @@ async function caseSubmittedIkwEmail(params) {
 
   if (params.notificationComment) {
     message += `
-    Aanvullende informatie:
-    ${params.notificationComment}
+  Aanvullende informatie:
+  ${params.notificationComment}
 `;
   }
 

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1447,5 +1447,6 @@
   "this-submission-is-an-update-title": "Deze indiening betreft een update",
   "this-submission-is-an-update": "Bij aanvaarding zullen de documenten en ministers van de bestaande procedurestap worden aangepast.",
   "draft-piece-delete": "Ingediend document verwijderen",
-  "delete-draft-piece-message": "Bent u zeker dat u dit document wilt verwijderen? Deze actie verwijdert enkel het nieuwe document, eventuele vorige versies blijven ongewijzigd."
+  "delete-draft-piece-message": "Bent u zeker dat u dit document wilt verwijderen? Deze actie verwijdert enkel het nieuwe document, eventuele vorige versies blijven ongewijzigd.",
+  "mail-could-not-be-sent": "De volgende mail kan niet worden verzonden omdat er geen mail adres is gevonden."
 }


### PR DESCRIPTION
See https://kanselarij.atlassian.net/browse/KAS-4690?focusedCommentId=19012 for the requested template for the emails.

One known issue with this PR that would need to be solved, perhaps in a separate ticket:  see `loadAgenda` in `SubmissionHeaderComponent`:  https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/2184/files#diff-ac71f19bd3e036fec04c6915614a649504a625e1494d029f24613b41553eb423R47-R75

We should somehow be able to get the intended meeting here more easily and accurately.
However, we don't store the meeting kind anywhere, so this could be any of the meetings on the submission.plannedStart date.
Most likely this will mean we have to store the meeting kind in the submission data model, or even better, the actual meeting uuid.

Tested locally for new submission, send back, resubmit, and BIS update submission. The true test will be on acceptance.