### PR TITLE
KAS-4734: Add default text to internal comment

### DIFF
--- a/app/components/cases/subcases/proposable-agendas-modal.hbs
+++ b/app/components/cases/subcases/proposable-agendas-modal.hbs
@@ -19,7 +19,7 @@
         <AuLabel for="remarks">{{t "private-comments-title"}}</AuLabel>
         <AuTextarea
           id="remarks"
-          rows="4"
+          rows="7"
           value={{this.privateComment}}
           @width="block"
           {{on "input" (pick "target.value" (set this "privateComment"))}}

--- a/app/components/cases/subcases/proposable-agendas-modal.js
+++ b/app/components/cases/subcases/proposable-agendas-modal.js
@@ -15,8 +15,14 @@ export default class ProposableAgendasModal extends Component {
 
   @tracked agendas;
   @tracked selectedAgenda;
-  @tracked privateComment;
   @tracked isFormallyOk;
+  @tracked privateComment = `IF: 
+BA: 
+BZ: 
+WT: 
+Co-agendering: 
+
+Def. check: `;
 
   constructor() {
     super(...arguments);


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4734

Adds a default text when submitting an agendaitem for a meeting:

> IF:
> BA:
> BZ:
> WT:
> Co-agendering:
>
> Def. check: