### PR TITLE
KAS-4781: Ontbrekende padding binnen 'Bulk wijzingen' modal

### DIFF
--- a/app/components/documents/batch-details/document-details-row.hbs
+++ b/app/components/documents/batch-details/document-details-row.hbs
@@ -96,6 +96,7 @@
   <td class="auk-u-text-align--right">
     {{#if (or @row.hasSentSignFlow (not @isEditingEnabled) @disableDelete)}}
       <AuLinkExternal
+        @skin="button-naked"
         @icon="book"
         @hideText={{true}}
         href={{@row.piece.viewDocumentURL}}


### PR DESCRIPTION
**Tickets binnen Jira:** 
- https://kanselarij.atlassian.net/browse/KAS-4781

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.