### PR TITLE
KAS-4795: Various fixes for Kabinet indieningen

### DIFF
--- a/app/components/documents/draft-document-card.hbs
+++ b/app/components/documents/draft-document-card.hbs
@@ -132,6 +132,21 @@
               </AuDropdown>
               {{!-- template-lint-enable require-context-role --}}
             </Group.Item>
+          {{else if this.mayShowAddNewVersion}}
+            <Group.Item
+              class="auk-o-flex auk-o-flex--vertical-center"
+            >
+              {{!-- template-lint-disable require-context-role --}}
+              <AuButton
+                @skin="link"
+                @icon="plus"
+                {{on "click" (toggle "isOpenUploadModal" this)}}
+                role="menuitem"
+              >
+                {{t "create-new-version"}}
+              </AuButton>
+              {{!-- template-lint-enable require-context-role --}}
+            </Group.Item>
           {{/if}}
         </Toolbar.Group>
       </Auk::Toolbar>
@@ -181,9 +196,36 @@
 {{/if}}
 
 <ConfirmationModal
+  @modalOpen={{this.isOpenUploadModal}}
+  @title={{t "new-document-piece"}}
+  @onConfirm={{perform this.addPiece}}
+  @onCancel={{perform this.cancelUploadPiece}}
+  @confirmMessage={{t "add"}}
+  @loading={{this.addPiece.isRunning}}
+  @disabled={{not this.newPiece}}
+>
+  <:body>
+    {{#if this.newPiece}}
+      <AuLabel>{{t "name"}}</AuLabel>
+      <AuInput
+        value={{this.newPiece.name}}
+        @width="block"
+        {{on "input" (pick "target.value" (set this "newPiece.name"))}}
+      />
+      <Documents::UploadedDocument
+        @piece={{this.newPiece}}
+        @onDelete={{perform this.deleteUploadedPiece}}
+      />
+    {{else}}
+      <Auk::FileUploader @isSubmission={{true}} @multiple={{false}} @onUpload={{perform this.uploadPiece}} />
+    {{/if}}
+  </:body>
+</ConfirmationModal>
+
+<ConfirmationModal
   @modalOpen={{this.isOpenVerifyDeleteModal}}
-  @title={{t "document-container-delete"}}
-  @message={{t "delete-document-container-message"}}
+  @title={{t "draft-piece-delete"}}
+  @message={{t "delete-draft-piece-message"}}
   @onConfirm={{this.verifyDeleteDocumentContainer}}
   @onCancel={{this.cancelDeleteDocumentContainer}}
   @confirmMessage={{t "delete"}}

--- a/app/components/documents/draft-document-card.js
+++ b/app/components/documents/draft-document-card.js
@@ -213,20 +213,20 @@ export default class DocumentsDraftDocumentCardComponent extends Component {
     });
   }
 
-    @task
-    *deleteUploadedPiece() {
-      if (this.newPiece) {
-        removeObject(this.pieces, this.newPiece);
-        yield deletePiece(this.newPiece);
-        this.newPiece = null;
-      }
+  @task
+  *deleteUploadedPiece() {
+    if (this.newPiece) {
+      removeObject(this.pieces, this.newPiece);
+      yield deletePiece(this.newPiece);
+      this.newPiece = null;
     }
+  }
 
-    @task
-    *cancelUploadPiece() {
-      yield this.deleteUploadedPiece.perform();
-      this.isOpenUploadModal = false;
-    }
+  @task
+  *cancelUploadPiece() {
+    yield this.deleteUploadedPiece.perform();
+    this.isOpenUploadModal = false;
+  }
 
   @action
   deleteDocumentContainer() {

--- a/app/components/documents/draft-document-card.js
+++ b/app/components/documents/draft-document-card.js
@@ -8,8 +8,9 @@ import { sortPieceVersions } from 'frontend-kaleidos/utils/documents';
 import { task, timeout } from 'ember-concurrency';
 import { isPresent } from '@ember/utils';
 import { DOCUMENT_DELETE_UNDO_TIME_MS } from 'frontend-kaleidos/config/config';
-import { deleteDocumentContainer } from 'frontend-kaleidos/utils/document-delete-helpers';
+import { deleteDocumentContainer, deletePiece } from 'frontend-kaleidos/utils/document-delete-helpers';
 import RevertActionToast from 'frontend-kaleidos/components/utils/toaster/revert-action-toast';
+import { removeObject } from 'frontend-kaleidos/utils/array-helpers';
 
 export default class DocumentsDraftDocumentCardComponent extends Component {
   /**
@@ -32,6 +33,7 @@ export default class DocumentsDraftDocumentCardComponent extends Component {
   @service intl;
   @service pieceAccessLevelService;
 
+  @tracked isOpenUploadModal = false;
   @tracked isOpenVerifyDeleteModal = false;
   @tracked isEditingPiece = false;
 
@@ -53,6 +55,10 @@ export default class DocumentsDraftDocumentCardComponent extends Component {
 
   get mayEdit() {
     return this.args.isEditable && this.args.piece.constructor.modelName === 'draft-piece';
+  }
+
+  get mayShowAddNewVersion() {
+    return this.args.isEditable && this.piece.constructor.modelName === 'piece';
   }
 
   get dateToShowLabel() {
@@ -167,6 +173,21 @@ export default class DocumentsDraftDocumentCardComponent extends Component {
   }
 
   @task
+  *addPiece() {
+    try {
+      this.newPiece.name = this.newPiece.name.trim();
+      yield this.args.onAddPiece?.(this.piece, this.newPiece);
+      this.loadVersionHistory.perform();
+      this.newPiece = null;
+      this.isOpenUploadModal = false;
+    } catch (error) {
+      yield this.deleteUploadedPiece.perform();
+      this.isOpenUploadModal = false;
+      throw error;
+    }
+  }
+
+  @task
   *uploadPiece(file) {
     yield this.loadVersionHistory.perform();
     const previousPiece = this.sortedPieces.at(-1);
@@ -174,15 +195,38 @@ export default class DocumentsDraftDocumentCardComponent extends Component {
     const newName = new VRDocumentName(
       previousPiece.name
     ).withOtherVersionSuffix(this.sortedPieces.length + 1);
+    const type = yield this.documentContainer.type;
+    const draftDocumentContainer = this.store.createRecord('draft-document-container', {
+      created: this.documentContainer.created,
+      position: this.documentContainer.position,
+      type,
+    });
+    const accessLevel = yield previousPiece.accessLevel;
     this.newPiece = this.store.createRecord('draft-piece', {
       name: newName,
       created: now,
       modified: now,
       file: file,
       previousPiece: previousPiece,
-      documentContainer: this.documentContainer,
+      documentContainer: draftDocumentContainer,
+      accessLevel,
     });
   }
+
+    @task
+    *deleteUploadedPiece() {
+      if (this.newPiece) {
+        removeObject(this.pieces, this.newPiece);
+        yield deletePiece(this.newPiece);
+        this.newPiece = null;
+      }
+    }
+
+    @task
+    *cancelUploadPiece() {
+      yield this.deleteUploadedPiece.perform();
+      this.isOpenUploadModal = false;
+    }
 
   @action
   deleteDocumentContainer() {

--- a/app/components/subcases/subcase-header.js
+++ b/app/components/subcases/subcase-header.js
@@ -30,6 +30,7 @@ export default class SubcasesSubcaseHeaderComponent extends Component {
   @tracked subcaseToDelete = null;
   @tracked canPropose = false;
   @tracked canDelete = false;
+  @tracked canSubmitNewDocuments = false;
   @tracked meetingIsClosed = false;
   @tracked currentSubmission;
 
@@ -45,7 +46,8 @@ export default class SubcasesSubcaseHeaderComponent extends Component {
       this.currentSession.may('create-submissions') &&
       this.submissions?.length > 0 &&
       !this.currentSubmission &&
-      !this.meetingIsClosed;
+      !this.meetingIsClosed &&
+      this.canSubmitNewDocuments;
   }
 
   @task
@@ -75,6 +77,18 @@ export default class SubcasesSubcaseHeaderComponent extends Component {
           this.meetingIsClosed = true;
         }
       }
+      const submissions = yield this.args.subcase.submissions;
+      let draftPieceWithoutAccepted = false;
+      for (const submission of submissions) {
+        const pieces = yield submission.pieces;
+        for (const piece of pieces) {
+          const actualPiece = yield piece.acceptedPiece;
+          if (!actualPiece) {
+            draftPieceWithoutAccepted = true;
+          }
+        }
+      }
+      this.canSubmitNewDocuments = !draftPieceWithoutAccepted;
     }
   }
 

--- a/app/components/subcases/subcase-header.js
+++ b/app/components/subcases/subcase-header.js
@@ -52,7 +52,7 @@ export default class SubcasesSubcaseHeaderComponent extends Component {
 
   @task
   *loadData() {
-    this.submissions = yield this.args.subcase.hasMany('submissions').reload();    
+    this.submissions = yield this.args.subcase.hasMany('submissions').reload();
     this.currentSubmission = yield this.draftSubmissionService.getOngoingSubmissionForSubcase(this.args.subcase);
     const activities = yield this.args.subcase.hasMany('agendaActivities').reload();
     this.canPropose = !(activities?.length || this.isAssigningToAgenda || this.isLoading);
@@ -85,10 +85,14 @@ export default class SubcasesSubcaseHeaderComponent extends Component {
           const actualPiece = yield piece.acceptedPiece;
           if (!actualPiece) {
             draftPieceWithoutAccepted = true;
+            break;
           }
         }
       }
       this.canSubmitNewDocuments = !draftPieceWithoutAccepted;
+      if (!this.canSubmitNewDocuments) {
+        this.currentSubmission = yield this.draftSubmissionService.getLatestSubmissionForSubcase(this.args.subcase);
+      }
     }
   }
 

--- a/app/components/submission/header.js
+++ b/app/components/submission/header.js
@@ -29,12 +29,14 @@ export default class SubmissionHeaderComponent extends Component {
 
   @tracked comment;
 
+  @tracked requestedByIsCurrentMandatee;
   @tracked selectedAgenda;
   @tracked selectedMeeting;
 
   constructor() {
     super(...arguments);
     this.loadAgenda.perform();
+    this.loadRequestedByIsCurrentMandatee.perform();
   }
 
   loadAgenda = task(async () => {
@@ -68,7 +70,18 @@ export default class SubmissionHeaderComponent extends Component {
         this.selectedAgenda = agenda;
         this.selectedMeeting = agenda.createdFor;
       }
-  }
+    }
+  });
+
+  loadRequestedByIsCurrentMandatee = task(async () => {
+    if (this.args.submission) {
+      const requestedBy = await this.args.submission.requestedBy;
+      const organization = await this.store.queryOne('user-organization', {
+        'filter[mandatees][:id:]': requestedBy.id,
+        'filter[:id:]': this.currentSession.organization.id,
+      });
+      this.requestedByIsCurrentMandatee = !!organization;
+    }
   });
 
   get items() {
@@ -91,7 +104,8 @@ export default class SubmissionHeaderComponent extends Component {
   get canResubmitSubmission() {
     return (
       this.args.submission?.isSentBack &&
-      this.currentSession.may('edit-sent-back-submissions')
+      this.currentSession.may('edit-sent-back-submissions') &&
+      this.requestedByIsCurrentMandatee
     );
   }
 

--- a/app/components/submission/header.js
+++ b/app/components/submission/header.js
@@ -113,7 +113,8 @@ export default class SubmissionHeaderComponent extends Component {
     return (
       (this.args.submission?.isSubmitted ||
         this.args.submission?.isUpdateSubmitted) &&
-      this.currentSession.may('edit-sent-back-submissions')
+      this.currentSession.may('edit-sent-back-submissions') &&
+      this.requestedByIsCurrentMandatee
     );
   }
 

--- a/app/controllers/cases/submissions/submission.js
+++ b/app/controllers/cases/submissions/submission.js
@@ -181,7 +181,7 @@ export default class CasesSubmissionsSubmissionController extends Controller {
     );
     const defaultAccessLevel = await this.store.findRecordByUri(
       'concept',
-      (this.confidential || parsed.confidential)
+      (confidential || parsed.confidential)
         ? CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK
         : CONSTANTS.ACCESS_LEVELS.INTERN_REGERING
     );

--- a/app/controllers/cases/submissions/submission.js
+++ b/app/controllers/cases/submissions/submission.js
@@ -4,10 +4,10 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { TrackedArray } from 'tracked-built-ins';
 import { task } from 'ember-concurrency';
-import { removeObject } from 'frontend-kaleidos/utils/array-helpers';
+import { addObject, removeObject } from 'frontend-kaleidos/utils/array-helpers';
 import VRCabinetDocumentName from 'frontend-kaleidos/utils/vr-cabinet-document-name';
 import { findDocType } from 'frontend-kaleidos/utils/document-type';
-import { sortPieces } from 'frontend-kaleidos/utils/documents';
+import { containsConfidentialPieces, sortPieces } from 'frontend-kaleidos/utils/documents';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 
 export default class CasesSubmissionsSubmissionController extends Controller {
@@ -64,6 +64,32 @@ export default class CasesSubmissionsSubmissionController extends Controller {
       return d1?.position - d2?.position || p1.created - p2.created;
     });
   }
+
+  checkConfidentiality = async () => {
+    this.hasConfidentialPieces = await containsConfidentialPieces(this.pieces);
+  };
+
+  onAddNewPieceVersion = async (piece, newVersion) => {
+    const documentContainer = await newVersion.documentContainer;
+    await documentContainer.save();
+    newVersion.submission = this.model;
+    await newVersion.save();
+    try {
+      const sourceFile = await newVersion.file;
+      await this.fileConversionService.convertSourceFile(sourceFile);
+    } catch (error) {
+      this.toaster.error(
+        this.intl.t('error-convert-file', { message: error.message }),
+        this.intl.t('warning-title'),
+      );
+    }
+    const index = this.pieces.indexOf(piece);
+    this.pieces[index] = newVersion;
+    this.pieces = [...this.pieces];
+    addObject(this.newDraftPieces, newVersion);
+    await this.checkConfidentiality();
+    await this.savePieces.perform();
+  };
 
   onNotificationDataChanged = async (newNotificationData) => {
     this.approvalAddresses = newNotificationData.approvalAddresses;

--- a/app/routes/cases/submissions/submission.js
+++ b/app/routes/cases/submissions/submission.js
@@ -51,12 +51,23 @@ export default class CasesSubmissionsSubmissionRoute extends Route {
     });
     if (status.uri === CONSTANTS.SUBMISSION_STATUSES.BEHANDELD) {
       if (this.subcase)  {
-        const decisionmakingFlow = await this.subcase.decisionmakingFlow;
-        return this.router.transitionTo(
-          'cases.case.subcases.subcase',
-          decisionmakingFlow.id,
-          this.subcase.id
-        );
+        let draftPieceWithoutAccepted = false;
+        const pieces = await submission.pieces;
+        for (const piece of pieces) {
+          const actualPiece = await piece.acceptedPiece;
+          if (!actualPiece) {
+            draftPieceWithoutAccepted = true;
+            break;
+          }
+        }
+        if (!draftPieceWithoutAccepted) {
+          const decisionmakingFlow = await this.subcase.decisionmakingFlow;
+          return this.router.transitionTo(
+            'cases.case.subcases.subcase',
+            decisionmakingFlow.id,
+            this.subcase.id
+          );
+        }
       }
     }
 

--- a/app/services/draft-submission-service.js
+++ b/app/services/draft-submission-service.js
@@ -77,19 +77,28 @@ export default class DraftSubmissionService extends Service {
       .at(0);
     return creationActivity ? true : false;
   };
-  
+
   getOngoingSubmissionForSubcase = async(subcase) => {
     // technically this should be a queryOne, but possible with concurrency to have more than 1 ongoing
-    const AllSubmissions = await this.store.query('submission', {
+    const allSubmissions = await this.store.query('submission', {
       'filter[subcase][:id:]': subcase.id,
       sort: 'created',
       include: 'status'
     });
-    const ongoingSubmission = AllSubmissions?.filter(
+    const ongoingSubmission = allSubmissions?.filter(
       (a) =>
         a.status.get('uri') !== constants.SUBMISSION_STATUSES.BEHANDELD
     );
     // if more than 1, we return the first created ongoing submission
     return ongoingSubmission?.at(0);
+  };
+
+  getLatestSubmissionForSubcase = async(subcase) => {
+    const allSubmissions = await this.store.query('submission', {
+      'filter[subcase][:id:]': subcase.id,
+      sort: '-created',
+      include: 'status'
+    });
+    return allSubmissions?.at(0);
   };
 }

--- a/app/templates/cases/submissions/submission.hbs
+++ b/app/templates/cases/submissions/submission.hbs
@@ -109,6 +109,7 @@
             <Documents::DraftDocumentCardList
               @pieces={{this.pieces}}
               @isEditable={{this.mayEdit}}
+              @onAddPiece={{this.onAddNewPieceVersion}}
               @hideAccessLevel={{false}}
               @highlightedPieces={{this.newDraftPieces}}
               @didDeleteContainer={{this.updateDraftPiecePositions}}

--- a/app/utils/document-delete-helpers.js
+++ b/app/utils/document-delete-helpers.js
@@ -49,6 +49,11 @@ export async function deletePiece(pieceOrPromise) {
   const piece = await pieceOrPromise;
   const documentContainer = await piece.documentContainer;
   if (piece) {
+    const draftPiece = await piece.draftPiece;
+    if (draftPiece) {
+      await deletePiece(draftPiece);
+    }
+
     const file = await piece.file;
     await deleteFile(file);
     await piece.destroyRecord();


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4795

Fixes for multiple bugs/remarks by users about the kabinet indieningen.

- Kabinetdossierbeheerder can't add documents to a submission unless submission "head" minister is part of their cabinet
- Show correct pop-up when deleting a BIS upload in a submission and allow for users to add new versions to existing submission (without having to create a new submission)
- Only show "Dien nieuwe documenten in" if the previous submission has been propagated
- Correctly set the confidentiality of documents on submission