### PR TITLE
add stub to SH call in login to prevent errors in DB

### DIFF
--- a/ci/docker-compose.override.yml
+++ b/ci/docker-compose.override.yml
@@ -103,7 +103,7 @@ services:
       VP_API_CLIENT_SECRET: "yourVpApiClientSecret"
   digital-signing:
     environment:
-      - SIGNINGHUB_API_URL=<PUT_API_URL_HERE>
+      SIGNINGHUB_API_URL: "https://fake.api.url"
     user: ${HOST_UID_GID}
   document-stamping:
     user: ${HOST_UID_GID}

--- a/config/environment.js
+++ b/config/environment.js
@@ -81,6 +81,7 @@ module.exports = function (environment) {
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;
     ENV.APP.LOG_VIEW_LOOKUPS = false;
+    ENV.APP.ENABLE_IMPERSONATION = true;
     ENV.APP.ENABLE_VLAAMS_PARLEMENT = true;
     ENV.APP.ENABLE_CABINET_SUBMISSIONS = true;
     ENV.APP.ENABLE_DEBUG = false;

--- a/cypress/e2e/unit/shortlist-overview.cy.js
+++ b/cypress/e2e/unit/shortlist-overview.cy.js
@@ -474,7 +474,7 @@ context('signatures shortlist overview tests', () => {
     cy.intercept('POST', '/sign-signing-activities').as('postSigningActivities');
     cy.intercept('PATCH', '/sign-subcases/**').as('patchSignSubcases');
     cy.intercept('PATCH', '/sign-flows/**').as('patchSignFlows');
-    cy.intercept('POST', '/signing-flows/update-to-signinghub', {
+    cy.intercept('POST', '/signing-flows/upload-to-signinghub', {
       forceNetworkError: true,
     }).as('updateToSigningHubError');
     // no email set so forcing through disabled button
@@ -1006,7 +1006,7 @@ context('decisions and minutes shortlist overview tests', () => {
     cy.intercept('POST', '/sign-signing-activities').as('postSigningActivities');
     cy.intercept('PATCH', '/sign-subcases/**').as('patchSignSubcases');
     cy.intercept('PATCH', '/sign-flows/**').as('patchSignFlows');
-    cy.intercept('POST', '/signing-flows/update-to-signinghub', {
+    cy.intercept('POST', '/signing-flows/upload-to-signinghub', {
       forceNetworkError: true,
     }).as('updateToSigningHubError');
     // cy.intercept('DELETE', '/sign-signing-activities/**').as('deleteSigningActivities');

--- a/cypress/support/commands/authorizationAuthentication.commands.js
+++ b/cypress/support/commands/authorizationAuthentication.commands.js
@@ -57,6 +57,7 @@ function login(name, retries = 0) {
     });
   cy.wait('@getMembership');
   cy.wait('@loadConcepts');
+  stubSigninghubCallToURL();
   cy.log('/login');
 }
 
@@ -101,6 +102,7 @@ function loginFlow(name) {
     cy.contains(name).click()
       .wait('@mockLogin');
   });
+  stubSigninghubCallToURL();
   cy.log('/loginFlow');
 }
 
@@ -122,6 +124,15 @@ function logoutFlow() {
     .forceClick();
   cy.wait('@mockLogout');
   cy.log('/logoutFlow');
+}
+
+function stubSigninghubCallToURL() {
+  const staticResponse = {
+    statusCode: 500,
+    ok: false,
+  };
+  const stub = cy.stub(staticResponse);
+  cy.intercept('GET', '/signing-flows/**/pieces/**/signinghub**', stub).as('stubSigninghubCall');
 }
 
 Cypress.Commands.add('login', login);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test": "npm-run-all --print-name \"lint\" \"test:*\"",
     "test:cypress": "ember serve --environment=cypress-test --proxy=http://localhost",
     "test:ember": "ember test",
+    "start-cypress": "ember serve --environment=cypress-test --proxy=http://localhost:80",
     "cypress-local": "make open-cypress-tests",
     "cypress-dev": "./node_modules/.bin/cypress open --config baseUrl=https://kaleidos-dev.vlaanderen.be",
     "release": "release-it"


### PR DESCRIPTION
Digital-signing service on jenkins does not have connection to the actual API so errors are thrown when trying to setup a session.
Mainly because we pass a fake url. This results in errors in DB

![image](https://github.com/user-attachments/assets/70d0ad09-47b4-433c-abc8-31ac60a9f9b4)


Checking if this stubbing is enough.