### PR TITLE
fix did-update from trying to get defaults before mailSettings are loaded

### DIFF
--- a/app/components/cases/submissions/notifications.hbs
+++ b/app/components/cases/submissions/notifications.hbs
@@ -26,8 +26,8 @@
     </Auk::Toolbar>
   </Auk::Panel::Header>
   <Auk::Panel::Body
-    {{did-update (perform this.updateDefaultAddresses) @confidential}}
-    {{did-update (perform this.updateDefaultAddresses) @hasConfidentialPieces}}
+    {{did-update (perform this.onDidUpdate) @confidential}}
+    {{did-update (perform this.onDidUpdate) @hasConfidentialPieces}}
   >
     <Utils::LoadableContent
       @isLoading={{this.loadEmailSettings.isRunning}}

--- a/app/components/cases/submissions/notifications.js
+++ b/app/components/cases/submissions/notifications.js
@@ -64,30 +64,30 @@ export default class CasesSubmissionsNotificationsComponent extends Component {
     for (const address of this.defaultNotificationAddresses) {
       this.addNotificationAddress(address, true);
     }
-    this.changeNotificationData();
+    this.changeNotificationData(true);
   };
 
   get defaultApprovalAddress() {
-    return this.emailSettings?.cabinetSubmissionsSecretaryEmail;
+    return this.emailSettings.cabinetSubmissionsSecretaryEmail;
   }
 
   get defaultNotificationAddresses() {
     if (this.args.confidential) {
-      return [this.emailSettings?.cabinetSubmissionsIkwConfidentialEmail];
+      return [this.emailSettings.cabinetSubmissionsIkwConfidentialEmail];
     } else if (this.args.hasConfidentialPieces) {
       return [
-        this.emailSettings?.cabinetSubmissionsIkwEmail,
-        this.emailSettings?.cabinetSubmissionsIkwConfidentialEmail
+        this.emailSettings.cabinetSubmissionsIkwEmail,
+        this.emailSettings.cabinetSubmissionsIkwConfidentialEmail
       ];
     }
-    return [this.emailSettings?.cabinetSubmissionsIkwEmail];
+    return [this.emailSettings.cabinetSubmissionsIkwEmail];
   }
 
   get unusedDefaultNotificationAddress() {
     if (this.args.confidential) {
-      return this.emailSettings?.cabinetSubmissionsIkwEmail;
+      return this.emailSettings.cabinetSubmissionsIkwEmail;
     } else {
-      return this.emailSettings?.cabinetSubmissionsIkwConfidentialEmail;
+      return this.emailSettings.cabinetSubmissionsIkwConfidentialEmail;
     }
   }
 
@@ -119,9 +119,7 @@ export default class CasesSubmissionsNotificationsComponent extends Component {
       } else {
         this.approvalAddresses.push(address);
       }
-      if (!this.updateDefaultAddresses.isRunning) {
-        this.changeNotificationData();
-      }
+      this.changeNotificationData();
     }
     this.showApprovalAddressModal = false;
   }
@@ -131,9 +129,7 @@ export default class CasesSubmissionsNotificationsComponent extends Component {
     const index = this.approvalAddresses.indexOf(address);
     if (index > -1) {
       this.approvalAddresses.splice(index, 1);
-      if (!this.updateDefaultAddresses.isRunning) {
-        this.changeNotificationData();
-      }
+      this.changeNotificationData();
     }
   }
 
@@ -145,9 +141,7 @@ export default class CasesSubmissionsNotificationsComponent extends Component {
       } else {
         this.notificationAddresses.push(address);
       }
-      if (!this.updateDefaultAddresses.isRunning) {
-        this.changeNotificationData();
-      }
+      this.changeNotificationData();
     }
     this.showNotificationAddressModal = false;
   }
@@ -157,9 +151,7 @@ export default class CasesSubmissionsNotificationsComponent extends Component {
     const index = this.notificationAddresses.indexOf(address);
     if (index > -1) {
       this.notificationAddresses.splice(index, 1);
-      if (!this.updateDefaultAddresses.isRunning) {
-        this.changeNotificationData();
-      }
+      this.changeNotificationData();
     }
   }
 
@@ -169,7 +161,10 @@ export default class CasesSubmissionsNotificationsComponent extends Component {
     this.isEditing = false;
   };
 
-  changeNotificationData = () => {
+  changeNotificationData = (fromUpdate) => {
+    // if init or update tasks are running we don't want to send to parent yet (or 3 calls will be made)
+    const areUpdateTasksRunning = this.onDidUpdate.isRunning || this.loadEmailSettings.isRunning;
+    if (areUpdateTasksRunning && !fromUpdate) return;
     // no submission - new submission form
     // submission - when not actually editing we are updating based on "did-update" and should call parent
     if (!this.args.submission || this.args.submission && !this.isEditing) {


### PR DESCRIPTION
No ticket, trying to fix a bug in the notificationPanel of submissions where it was possible that the `did-update` was called before the `mailSettings` were fully loaded, resulting in lists with undefined entries which caused the save of the submission model to throw errors.

By making the `did-update` check for the `mailSettings` and running the restartable task again if not, we can ensure we never try to get the defaults before the `mailSettings` are fully loaded

Perhaps the getters (now using `this.emailSettings?.`) should not have that optional. If we attempt to call the getters at that stage we should stop instead of setting `[undefined]`