### PR TITLE
Feature/KAS-4811 resolve feedback 13/09

### DIFF
--- a/app/components/agenda/agendaitem/agendaitem-controls.hbs
+++ b/app/components/agenda/agendaitem/agendaitem-controls.hbs
@@ -63,7 +63,8 @@
           >
             {{t "delete-and-send-back-to-submitter"}}
           </AuButton>
-        {{else if (or (user-may "remove-approved-agendaitems") this.isDeletable)}}
+        {{/if}}
+        {{#if (or (user-may "remove-approved-agendaitems") this.isDeletable)}}
           <AuButton
             data-test-agendaitem-controls-action-delete
             @skin="link"
@@ -71,7 +72,7 @@
             role="menuitem"
             {{on "click" this.toggleIsVerifying}}
           >
-            {{t "delete"}}
+            {{t "delete-agendaitem-while-keeping-subcase"}}
           </AuButton>
         {{/if}}
       {{/if}}

--- a/app/controllers/cases/submissions/submission.js
+++ b/app/controllers/cases/submissions/submission.js
@@ -123,7 +123,7 @@ export default class CasesSubmissionsSubmissionController extends Controller {
   }
 
   disableMandatee = (mandatee) => {
-    return this.currentLinkedMandatee.id === mandatee.id;
+    return this.model.requestedBy?.get('id') === mandatee.id ;
   };
 
   saveMandateeData = async ({ submitter, mandatees }) => {

--- a/app/routes/cases/submissions/submission.js
+++ b/app/routes/cases/submissions/submission.js
@@ -78,14 +78,16 @@ export default class CasesSubmissionsSubmissionRoute extends Route {
 
     await submission.requestedBy;
 
-    if (!this.currentSession.may('view-all-submissions')) {
-      if (this.currentLinkedMandatee && this.mandatees.length) {
-        const mandateeUris = this.mandatees.map((mandatee) => mandatee.uri);
-        if (!mandateeUris.includes(this.currentLinkedMandatee.uri)) {
+    if (submission.confidential) {
+      if (!this.currentSession.may('view-all-submissions')) {
+        if (this.currentLinkedMandatee && this.mandatees.length) {
+          const mandateeUris = this.mandatees.map((mandatee) => mandatee.uri);
+          if (!mandateeUris.includes(this.currentLinkedMandatee.uri)) {
+            this.router.transitionTo('cases.submissions');
+          }
+        } else {
           this.router.transitionTo('cases.submissions');
         }
-      } else {
-        this.router.transitionTo('cases.submissions');
       }
     }
 

--- a/app/templates/cases/submissions/submission.hbs
+++ b/app/templates/cases/submissions/submission.hbs
@@ -217,6 +217,6 @@
     @onSave={{this.saveBatchDetails}}
     @disableDelete={{true}}
     @allowEditing={{this.mayEdit}}
-    @disableEditingPosition={{true}}
+    @disableEditingPosition={{this.isUpdate}}
   />
 {{/if}}

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -116,6 +116,7 @@
   "decisions-pdf-name": "BeslissingenVlaamseRegering_",
   "definite": "Definitief",
   "delete": "Verwijderen",
+  "delete-agendaitem-while-keeping-subcase": "Verwijder agendapunt en behoud procedurestap",
   "delete-comment": "Bericht verwijderen",
   "delete-comment-message": "Bent u zeker dat u het bericht wil verwijderen? Deze actie kan niet meer ongedaan gemaakt worden.",
   "delete-document-message": "Bent u zeker dat u het document wilt verwijderen? Deze actie kan niet meer ongedaan gemaakt worden.",


### PR DESCRIPTION
- Made sure only the submitting mandatee cannot be deleted from an existing submission, regardless of current mandatee (should always be the same except for admins on TEST)
- Corrected/weakened redirect for cabinet employees for non-confidential submissions
- Re-enable position editing in bulk edit for draft pieces on non-update submissions
- Re-enable second delete option for agendaitems while keeping subcase