### PR TITLE
Add approval and notification comments to mail on resubmit, they may have changed

### DIFF
--- a/app/services/cabinet-mail.js
+++ b/app/services/cabinet-mail.js
@@ -87,6 +87,8 @@ export default class CabinetMailService extends Service {
       submissionUrl: `${hostUrlPrefix}${submissionUrl}`,
       caseName: caseTitle,
       resubmitted: true,
+      approvalComment: submission.approvalComment,
+      notificationComment: submission.notificationComment,
       comment,
       submission,
       meeting,


### PR DESCRIPTION
No ticket, noticed during testing with Cabinet.
On first submission, no approval or notification comments were entered.
On resubmit the comments were changed but those comments were not visible in the sent emails.
The information was important "I added this document" 