### PR TITLE
fix: use piece.modified in yellow banner in Kort Bestek

### DIFF
--- a/app/routes/agenda/agendaitems/agendaitem/news-item.js
+++ b/app/routes/agenda/agendaitems/agendaitem/news-item.js
@@ -47,7 +47,7 @@ export default class NewsitemAgendaitemAgendaitemsAgendaRoute extends Route {
       }
     });
 
-    this.notaModifiedTime = latestNotaVersion?.created;
+    this.notaModifiedTime = latestNotaVersion?.modified;
     // It is possible to concurrently create multiple newsItems
     // While searching for a proper fix, we inform the users of this problem
     const hasMultipleNewsItems = (await this.store.count('news-item', {


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4744

Johan noticed that this was not working for the banner in the Kort Bestek tab of an agendaitem in the agenda view. I didn't know that banner existed :stuck_out_tongue:.

This PR makes us use the `piece.modified` date in that banner, which contains the correct date.