### PR TITLE
KAS-4780: Ontbrekende witruimte na alerts

### DIFF
--- a/app/styles/au/_au-components.scss
+++ b/app/styles/au/_au-components.scss
@@ -481,6 +481,7 @@ $au-label-color: var(--au-gray-700);
 // Alert
 
 .au-c-alert {
+  margin-bottom: 0;
   font-size: 1.5rem;
 }
 
@@ -489,6 +490,10 @@ $au-label-color: var(--au-gray-700);
     height: 1.5rem;
     width: 1.6rem;
   }
+}
+
+.au-c-alert + * {
+  margin-top: $au-unit;
 }
 
 // Badge

--- a/app/styles/custom-application/cases.scss
+++ b/app/styles/custom-application/cases.scss
@@ -98,14 +98,6 @@
   scroll-margin-block: $au-unit-small;
 }
 
-.au-c-alert {
-  margin-bottom: 0;
-}
-
-.au-c-alert + * {
-  margin-bottom: $au-unit;
-}
-
 .vlc-status-timeline__item + .vlc-status-timeline__item {
   margin-top: $au-unit-tiny;
   padding-top: $au-unit-tiny;

--- a/app/styles/custom-components/_vlc-document-card.scss
+++ b/app/styles/custom-components/_vlc-document-card.scss
@@ -65,7 +65,6 @@
    ========================================================================== */
 
 .vlc-document-card-versions {
-  margin-top: 0;
   border-top: .1rem solid #CCD1D9;
 
   .auk-accordion__item .auk-accordion__content {


### PR DESCRIPTION
**Tickets binnen Jira:** 
- https://kanselarij.atlassian.net/browse/KAS-4780

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.