### PR TITLE
attempt to investigate flaky spec

### DIFF
--- a/Jenkinsfile.ci
+++ b/Jenkinsfile.ci
@@ -69,6 +69,8 @@ pipeline {
         sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName} exec -T document-stamping chmod 777 -R /share"
         sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName} exec -T draft-file chmod 777 -R /share"
         sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName} exec -T draft-file-mover chmod 777 -R /share"
+        sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName} exec -T pdf-signature-remover chmod 777 -R /share"
+        sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName} exec -T pdf-flattener chmod 777 -R /share"
 
         sh "cp ${WORKSPACE}/ci/.env.cypress ${WORKSPACE}/.env.cypress"
 
@@ -81,7 +83,7 @@ pipeline {
         // Reset the contents of DB an search
         sh "cd ${WORKSPACE}/kaleidos-project && docker-compose  -p ${projectName} kill elasticsearch search"
         sh "cd ${WORKSPACE}/kaleidos-project && docker-compose  -p ${projectName} rm -fs elasticsearch search"
-        sh "cd ${WORKSPACE}/kaleidos-project && docker-compose  -p ${projectName} kill triplestore file docx-conversion forever-cache cache resource cache-warmup yggdrasil migrations publication-report decision-extraction decision-report-generation file-bundling minutes-report-generation document-stamping draft-file draft-file-mover"
+        sh "cd ${WORKSPACE}/kaleidos-project && docker-compose  -p ${projectName} kill triplestore file docx-conversion forever-cache cache resource cache-warmup yggdrasil migrations publication-report decision-extraction decision-report-generation file-bundling minutes-report-generation document-stamping draft-file draft-file-mover pdf-signature-remover pdf-flattener"
         sh "cd ${WORKSPACE}/kaleidos-project && rm -rf testdata && rm -rf testdata-elasticsearch"
         sh "cd ${WORKSPACE}/kaleidos-project && unzip -o testdata.zip -d ${WORKSPACE}/kaleidos-project"
         sh "cd ${WORKSPACE}/kaleidos-project && unzip -o testdata-elasticsearch.zip -d ${WORKSPACE}/kaleidos-project"

--- a/JenkinsfileParemeterized.ci
+++ b/JenkinsfileParemeterized.ci
@@ -64,6 +64,8 @@ pipeline {
                 sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName}  exec -T document-stamping chmod 777 -R /share"
                 sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName} exec -T draft-file chmod 777 -R /share"
                 sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName} exec -T draft-file-mover chmod 777 -R /share"
+                sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName} exec -T pdf-signature-remover chmod 777 -R /share"
+                sh "cd ${WORKSPACE}/kaleidos-project && docker-compose -p ${projectName} exec -T pdf-flattener chmod 777 -R /share"
 
                 sh "cp ${WORKSPACE}/ci/.env.cypress ${WORKSPACE}/.env.cypress"
 
@@ -73,7 +75,7 @@ pipeline {
                 // Reset the contents of DB an search
                 sh "cd ${WORKSPACE}/kaleidos-project && docker-compose  -p ${projectName} kill elasticsearch  search"
                 sh "cd ${WORKSPACE}/kaleidos-project && docker-compose  -p ${projectName} rm -fs elasticsearch  search"
-                sh "cd ${WORKSPACE}/kaleidos-project && docker-compose  -p ${projectName} kill triplestore file docx-conversion forever-cache cache resource cache-warmup yggdrasil migrations publication-report decision-extraction decision-report-generation file-bundling minutes-report-generation document-stamping draft-file draft-file-mover"
+                sh "cd ${WORKSPACE}/kaleidos-project && docker-compose  -p ${projectName} kill triplestore file docx-conversion forever-cache cache resource cache-warmup yggdrasil migrations publication-report decision-extraction decision-report-generation file-bundling minutes-report-generation document-stamping draft-file draft-file-mover pdf-signature-remover pdf-flattener"
                 sh "cd ${WORKSPACE}/kaleidos-project && rm -rf testdata && rm -rf testdata-elasticsearch"
                 sh "cd ${WORKSPACE}/kaleidos-project && unzip -o testdata.zip -d ${WORKSPACE}/kaleidos-project"
                 sh "cd ${WORKSPACE}/kaleidos-project && unzip -o testdata-elasticsearch.zip -d ${WORKSPACE}/kaleidos-project"

--- a/ci/docker-compose.override.yml
+++ b/ci/docker-compose.override.yml
@@ -107,6 +107,10 @@ services:
     user: ${HOST_UID_GID}
   document-stamping:
     user: ${HOST_UID_GID}
+  pdf-signature-remover:
+    user: ${HOST_UID_GID}
+  pdf-flattener:
+    user: ${HOST_UID_GID}
   agenda-approve:
     environment:
       SERVER_BUSY_TIMEOUT: 10

--- a/cypress/e2e/unit/news-item.cy.js
+++ b/cypress/e2e/unit/news-item.cy.js
@@ -488,6 +488,22 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
       // If we only get 1, something happened here
       cy.get(newsletter.tableRow.titleContent).should('have.length', 2);
 
+      // test modified sorting before patching (is it broken before we patch?)
+      cy.get(route.newsletter.header.latestModified).click();
+      cy.get(appuniversum.loader);
+      cy.get(appuniversum.loader).should('not.exist');
+      cy.get(newsletter.tableRow.titleContent).should('have.length', 2);
+      cy.get(newsletter.tableRow.titleContent).eq(1)
+        .contains(subcaseTitleShort);
+
+      cy.get(route.newsletter.header.latestModified).click();
+      cy.get(appuniversum.loader);
+      cy.get(appuniversum.loader).should('not.exist');
+      cy.get(newsletter.tableRow.titleContent).should('have.length', 2);
+      cy.get(newsletter.tableRow.titleContent).eq(0)
+        .contains(subcaseTitleShort);
+
+      // set "in kort bestek"
       cy.intercept('PATCH', '/news-items/**').as('patchNewsItem1');
       cy.get(newsletter.tableRow.titleContent).contains(subcaseTitleShort)
         .parents(newsletter.tableRow.newsletterRow)
@@ -495,6 +511,7 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
         .parent()
         .click()
         .wait('@patchNewsItem1');
+      cy.wait(1500); // flaky spec, does waiting help?
 
       // test sort inNewsletter
       cy.get(route.newsletter.header.inNewsletter).click();
@@ -537,9 +554,10 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
           cy.log('second agendaitem id of response', responseBody.response.body.data[1]?.id);
           cy.log('third agendaitem id of response', responseBody.response.body.data[2]?.id);
           expect(responseBody.response.body.meta.count).to.equal(3);
-          // expect(responseBody.response.body.data[0].id).to.equal('6374FA9CD9A98BD0A2288581');
-          // expect(responseBody.response.body.data[1].id).to.equal('6374FA89D9A98BD0A228857D');
-          // expect(responseBody.response.body.data[2].id).to.equal('6374FAB4D9A98BD0A2288586');
+          // this succeeds locally. The meta is 3. The first should always be this id (of number 2 which doesn't show)
+          expect(responseBody.response.body.data[0].id).to.equal('6374FA9CD9A98BD0A2288581');
+          expect(responseBody.response.body.data[1].id).to.equal('6374FA89D9A98BD0A228857D');
+          expect(responseBody.response.body.data[2].id).to.equal('6374FAB4D9A98BD0A2288586');
         });
       cy.get(appuniversum.loader);
       cy.get(appuniversum.loader).should('not.exist');
@@ -561,6 +579,7 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
         .parent()
         .click()
         .wait('@patchNewsItem2');
+      cy.wait(1500); // flaky spec, does waiting help?
     });
   });
 


### PR DESCRIPTION
Newsitem.cy sorting test has gone from flaky to consistently broke.
It doesn't seem to make sense.
Test succeeds locally, in full spec or .only, with UI or headless.
The call to agendaitems has a meta of 3, but not all 3 are found in the data attributes.
Wondering if this has anything to do with the sorting.
We are sorting on a datetime via `treatment.news-item.modified` so from agenda > treatment > news-item > modified.

In this scenario
2 of the agendaitems have no news-item, all have a treatment.
In the call for data with meta 3
On 1 should be the agendaitem without newsitem   <--- this one is missing from the data received, but only on jenkins runs.
On 2 should be the agendaitem that is an approval (will be filtered from the list)
On 3 should be the agendaitem with a newsitem that was recently modified.

I thought it might be fixed with the new mu-auth. it's not
So something is going on there.
I thought maybe cross spec interference, but it really doesn't seem possible.
The tests fail halfway through the sorting
Checking the "in newsletter" box works, sorting on "in newsletter" directly works, sorting on number after that works. Sorting in modified > breaks, 1 is missing. 
This is a pain to debug because I can't get it to fail locally. 

Now I am attempting to sort on modified before checking "in newsletter" to identify if the sorting breaks because we check the box (maybe hit a cache invalidation somewhere)
And I have added a small wait right after checking the box and saving the news-item.

The fact that it seems impossible to break locally is somewhat good news, it means there is no immediate issue that would occur with users. But having a near green jenkins run is bothersome.
If all else fails, I might move that sorting test in a separate spec and run in before everything else (all-flaky-tests folder) to see if that helps


sidenote: I noticed pdf-signature-remover could not access files and was throwing errors on jenkins, gave it permissions to write and access to share folder.
I should add a spec that tests that pdf-stripping feature so we will need this eventually