### PR TITLE
KAS-4814 improve internal review by making a component with editing f…

### DIFF
--- a/app/components/documents/document-details-panel.hbs
+++ b/app/components/documents/document-details-panel.hbs
@@ -41,17 +41,6 @@
           data-test-details-tab-edit-access-level
         />
       </Auk::KeyValue>
-      {{#if this.internalReview}}
-        <Auk::KeyValue @key={{t "private-comment-title"}}>
-          <AuTextarea
-            id="private-comment"
-            rows="7"
-            value={{this.internalReview.privateComment}}
-            @width="block"
-            {{on "input" (pick "target.value" (set this.internalReview "privateComment"))}}
-          />
-        </Auk::KeyValue>
-      {{/if}}
       <Auk::KeyValue
         data-test-document-details-panel-source-file
         @key={{capitalize (t (if @piece.file.derived "source-file" "file"))}}
@@ -217,12 +206,9 @@
         />
       </Auk::KeyValue>
       {{#if this.internalReview}}
-        <Auk::KeyValue
-          @icon="lock-closed"
-          @key={{t "private-comment-title"}}
-        >
-          {{this.internalReview.privateComment}}
-        </Auk::KeyValue>
+        <Submission::InternalReview
+          @internalReview={{this.internalReview}}
+        />
       {{/if}}
       <Auk::KeyValue
         data-test-document-details-panel-source-file

--- a/app/components/documents/document-details-panel.js
+++ b/app/components/documents/document-details-panel.js
@@ -133,9 +133,6 @@ export default class DocumentsDocumentDetailsPanel extends Component {
   @task
   *cancelEditDetails() {
     this.args.piece.rollbackAttributes(); // in case of piece name change
-    if (this.internalReview?.hasDirtyAttributes) {
-      this.internalReview.rollbackAttributes();
-    }
     yield this.loadDetailsData.perform();
     yield this.replacementSourceFile?.destroyRecord();
     yield this.addedSourceFile?.destroyRecord();
@@ -213,12 +210,6 @@ export default class DocumentsDocumentDetailsPanel extends Component {
       }
     } else {
       yield this.documentService.checkAndRestamp([this.args.piece]);
-    }
-    
-    if (this.internalReview?.hasDirtyAttributes) {
-      yield this.internalReview.belongsTo('subcase').reload();
-      yield this.internalReview.hasMany('submissions').reload();
-      yield this.internalReview.save();
     }
 
     this.isEditingDetails = false;

--- a/app/components/submission/description-panel/view.hbs
+++ b/app/components/submission/description-panel/view.hbs
@@ -80,9 +80,19 @@
       {{/if}}
     </div>
     {{#if (and (user-may "treat-and-accept-submissions") @submission.internalReview.privateComment)}}
-    <Submission::InternalReview
-          @internalReview={{@submission.internalReview}}
-        />
+      <Auk::Panel::Body
+        class="auk-u-mt-4 auk-u-p-2 auk-u-maximize-height auk-u-bg-alt"
+      >
+        <div
+          class="au-u-flex au-u-flex--spaced-tiny au-u-flex--vertical-center auk-u-text-bold"
+        >
+          <AuIcon @icon="lock-closed" />
+          <span>{{t "private-comment-title"}}:</span>
+        </div>
+        <pre class="auk-u-text-pre-line">
+          {{@submission.internalReview.privateComment}}
+        </pre>
+      </Auk::Panel::Body>
     {{/if}}
   </Auk::Panel::Body>
 </Auk::Panel>

--- a/app/components/submission/description-panel/view.hbs
+++ b/app/components/submission/description-panel/view.hbs
@@ -80,17 +80,9 @@
       {{/if}}
     </div>
     {{#if (and (user-may "treat-and-accept-submissions") @submission.internalReview.privateComment)}}
-      <Auk::Panel::Body class="auk-u-mt-4 auk-u-p-2 auk-u-maximize-height auk-u-bg-alt">
-        <div class="au-u-flex au-u-flex--spaced-tiny au-u-flex--vertical-center auk-u-text-bold">
-          <AuIcon @icon="lock-closed" />
-          <span>{{t "private-comment-title"}}:</span>
-        </div>
-        <pre
-          class="auk-u-text-pre-line"
-        >
-          {{@submission.internalReview.privateComment}}
-        </pre>
-      </Auk::Panel::Body>
+    <Submission::InternalReview
+          @internalReview={{@submission.internalReview}}
+        />
     {{/if}}
   </Auk::Panel::Body>
 </Auk::Panel>

--- a/app/components/submission/internal-review.hbs
+++ b/app/components/submission/internal-review.hbs
@@ -1,0 +1,42 @@
+<Auk::Panel::Body
+  class="auk-u-mt-4 auk-u-mb-4 auk-u-p-2 auk-u-maximize-height auk-u-bg-alt"
+>
+  <div
+    class="au-u-flex au-u-flex--spaced-small au-u-flex--vertical-center auk-u-text-bold"
+  >
+    <AuIcon @icon="lock-closed" />
+    <span>{{t "private-comment-title"}}:</span>
+    {{#if this.isEditing}}
+      <AuLink @icon="check" @hideText={{true}} {{on "click" this.save}}>
+        {{t "save"}}
+      </AuLink>
+      <AuLink @icon="x" @hideText={{true}} {{on "click" this.cancel}}>
+        {{t "cancel"}}
+      </AuLink>
+    {{else}}
+      <AuLink
+        @icon="pencil"
+        @hideText={{true}}
+        {{on "click" (toggle "isEditing" this)}}
+      >
+        {{t "edit"}}
+      </AuLink>
+    {{/if}}
+  </div>
+  {{#if this.isEditing}}
+    <AuTextarea
+      id="private-comment"
+      rows="7"
+      value={{this.internalReview.privateComment}}
+      @width="block"
+      {{on
+        "input"
+        (pick "target.value" (set this.internalReview "privateComment"))
+      }}
+    />
+  {{else}}
+    <pre class="auk-u-text-pre-line">
+      {{this.internalReview.privateComment}}
+    </pre>
+  {{/if}}
+</Auk::Panel::Body>

--- a/app/components/submission/internal-review.js
+++ b/app/components/submission/internal-review.js
@@ -1,0 +1,34 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { task } from 'ember-concurrency'
+
+export default class InternalReviewComponent extends Component {
+  @tracked isEditing;
+  @tracked internalReview;
+
+  constructor() {
+    super(...arguments);
+    this.loadInternalReviewPromise.perform();
+  }
+
+  loadInternalReviewPromise = task(async () => {
+    this.internalReview = await this.args.internalReview;
+  });
+
+  cancel = () => {
+    if (this.internalReview?.hasDirtyAttributes) {
+      this.internalReview.rollbackAttributes();
+    }
+    this.isEditing = false;
+  };
+
+  save = async() => {
+    if (this.internalReview?.hasDirtyAttributes) {
+      await this.internalReview.belongsTo('subcase').reload();
+      await this.internalReview.hasMany('submissions').reload();
+      await this.internalReview.save();
+    }
+    this.isEditing = false;
+  };
+
+}


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4814

see comments on 
https://kanselarij.atlassian.net/browse/KAS-4807

Document viewer comment is read-only on submissions docs. this is unwanted by users.
But we don't want to allow edits on draft pieces in that view.
Solution? A reusable component for that `interalReview`
Save and cancel is handled in the component. reduces duplication in the templates/javascript code.
