### PR TITLE
KAS-4841: Date input component mist correct breedte (binnen aantal instanties)

### DIFF
--- a/app/components/search/date-range-filter.hbs
+++ b/app/components/search/date-range-filter.hbs
@@ -3,6 +3,7 @@
     <AuFormRow data-test-route-search-date-from>
       <AuLabel>{{t "from"}}</AuLabel>
       <Auk::Datepicker
+        class="auk-u-maximize-width"
         @date={{@dateFrom}}
         @onChange={{@onDateFromChange}}
         @enableClear={{@dateFrom}}
@@ -12,6 +13,7 @@
     <AuFormRow class="au-u-margin-top-small" data-test-route-search-date-to>
       <AuLabel>{{t "until-inclusive"}}</AuLabel>
       <Auk::Datepicker
+        class="auk-u-maximize-width"
         @date={{@dateTo}}
         @onChange={{@onDateToChange}}
         @enableClear={{@dateTo}}

--- a/app/templates/newsletters/search.hbs
+++ b/app/templates/newsletters/search.hbs
@@ -21,6 +21,7 @@
       <AuFormRow class="au-u-margin-top-none au-u-1-6" data-test-route-search-date-from>
         <AuLabel>{{t "from"}}</AuLabel>
         <Auk::Datepicker
+          class="auk-u-maximize-width"
           @date={{this.dateFromBuffer}}
           @onChange={{set this "dateFromBuffer"}}
           @enableClear={{this.dateFromBuffer}}
@@ -30,6 +31,7 @@
       <AuFormRow class="au-u-margin-top-none au-u-1-6" data-test-route-search-date-to>
         <AuLabel>{{t "until-inclusive"}}</AuLabel>
         <Auk::Datepicker
+          class="auk-u-maximize-width"
           @date={{this.dateToBuffer}}
           @onChange={{set this "dateToBuffer"}}
           @enableClear={{this.dateToBuffer}}


### PR DESCRIPTION
**Tickets binnen Jira:** 
- https://kanselarij.atlassian.net/browse/KAS-4841

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.