### PR TITLE
KAS-4848: Update submission with latest info when taking into treatment

### DIFF
--- a/app/components/submission/header.js
+++ b/app/components/submission/header.js
@@ -393,7 +393,15 @@ export default class SubmissionHeaderComponent extends Component {
   );
 
   takeInTreatment = async () => {
-    // TODO update submission data? It could have been changed on subcase
+    const subcase = await this.args.submission.subcase;
+    if (subcase) {
+      const subcaseType = await subcase.type;
+      this.args.submission.shortTitle = subcase.shortTitle;
+      this.args.submission.title = subcase.title;
+      this.args.submission.type = subcaseType;
+      this.args.submission.subcaseName = subcase.subcaseName;
+      this.args.submission.confidential = subcase.confidential;
+    }
     await this._updateSubmission(CONSTANTS.SUBMISSION_STATUSES.IN_BEHANDELING);
     await this.createOrUpdateInternalReview();
     if (isPresent(this.args.onStatusUpdated)) {

--- a/app/components/submission/header.js
+++ b/app/components/submission/header.js
@@ -102,7 +102,7 @@ export default class SubmissionHeaderComponent extends Component {
     return (
       (this.args.submission?.isSubmitted ||
         this.args.submission?.isUpdateSubmitted ||
-        this.args.submission?.isResubmitted) && 
+        this.args.submission?.isResubmitted) &&
       this.currentSession.may('edit-sent-back-submissions') &&
       this.requestedByIsCurrentMandatee
     );
@@ -394,7 +394,7 @@ export default class SubmissionHeaderComponent extends Component {
 
   takeInTreatment = async () => {
     const subcase = await this.args.submission.subcase;
-    if (subcase) {
+    if (subcase?.id) {
       const subcaseType = await subcase.type;
       this.args.submission.shortTitle = subcase.shortTitle;
       this.args.submission.title = subcase.title;
@@ -423,15 +423,15 @@ export default class SubmissionHeaderComponent extends Component {
       internalReviewOfSubcase.submissions = submissions;
       return await internalReviewOfSubcase.save();
     }
-  
+
     if (!internalReviewOfSubmission?.id) {
       await this.agendaService.createInternalReview(this.args.subcase, [this.args.submission], CONSTANTS.PRIVATE_COMMENT_TEMPLATE);
     }
-    // else, update something? 
+    // else, update something?
     // is there a chance that subcase has no internalReview but submission does?
     // not if we connect it when creating the subcase initially
     // sounds possible only on old data. new data should be fine
-    // subcase should/will be connected on creation and is a read-only relation on subcase 
+    // subcase should/will be connected on creation and is a read-only relation on subcase
   };
 
   sendBackToSubmitter = task(async () => {


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4848

When we take in a submission for treatment, we first update it with the info coming from the subcase (since cabinet members cannot update this information, we're never overwriting their changes). This ensures that if the secretary has made changes to a subcase that will get a new submission, their changes aren't overwritten by stale data from the cabinets' submission.