### PR TITLE
KAS-4908 upgraded mock-login package to most recent

### DIFF
--- a/app/templates/mock-login.hbs
+++ b/app/templates/mock-login.hbs
@@ -30,12 +30,15 @@
                 {{/if}}
                 {{#if this.model.length}}
                   <AuList
-                    class="auk-u-mb"
+                    class="auk-u-mb auk-table--clickable-rows"
                     data-test-mock-login-list
                     as |Item|
                   >
-                    <login.each-account @accounts={{this.model}} as |account|>
-                      <Item class="auk-o-flex auk-o-flex--justify-between auk-o-flex--vertical-center au-u-padding-small">
+                    {{#each this.model as |account|}}
+                      <Item
+                        class="auk-o-flex auk-o-flex--justify-between auk-o-flex--vertical-center au-u-padding-small"
+                        {{on "click" (fn login.login account.id account.gebruiker.group.id)}}
+                      >
                         <div class="auk-u-mx-2">
                           <span>{{account.user.firstName}} {{account.user.lastName}}</span>
                         </div>
@@ -47,7 +50,7 @@
                           {{t "login"}}
                         </AuButton>
                       </Item>
-                    </login.each-account>
+                    {{/each}}
                   </AuList>
                 {{else}}
                   Geen accounts gevonden.

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -62,6 +62,11 @@ Cypress.Commands.overwrite("type", (originalFn, subject, text, options) => {
   return originalFn(subject, text, options);
 });
 
+// rapid succession of visits to multiple routes with "this.simpleAuthSession.requireAuthentication" seems to be failing unless we add a delay
+Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
+  return setTimeout(() => originalFn(url, options), 100)
+});
+
 
 
 // workaround for issue DOES NOT WORK!!

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -63,9 +63,9 @@ Cypress.Commands.overwrite("type", (originalFn, subject, text, options) => {
 });
 
 // rapid succession of visits to multiple routes with "this.simpleAuthSession.requireAuthentication" seems to be failing unless we add a delay
-Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
-  return setTimeout(() => originalFn(url, options), 100)
-});
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
+//   return setTimeout(() => originalFn(url, options), 100)
+// });
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@glimmer/tracking": "^1.1.2",
         "@kanselarij-vlaanderen/au-kaleidos-css": "3.22.0",
         "@lblod/ember-acmidm-login": "git+https://github.com/ValenberghsSven/ember-acmidm-login.git#75d8aab5839585201a68df4701a15bcfda42b32d",
-        "@lblod/ember-mock-login": "^0.10.0",
+        "@lblod/ember-mock-login": "^0.9.0",
         "@lblod/ember-rdfa-editor": "git+https://github.com/ValenberghsSven/ember-rdfa-editor.git#23ff47de32382f55c39207b8e3625c8842fc2dae",
         "@ljharb/eslint-config": "^21.0.1",
         "@nullvoxpopuli/ember-composable-helpers": "^5.1.1",
@@ -5914,15 +5914,16 @@
       "dev": true
     },
     "node_modules/@lblod/ember-mock-login": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-mock-login/-/ember-mock-login-0.10.0.tgz",
-      "integrity": "sha512-3Woc5671aKyGA4V90a7WKatJchNSW+sxKhH86mexWBnRUdc3TKW7ZkCfSVqUN8d66ls4Rkh8Fxd/WqTMGmjpSw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-mock-login/-/ember-mock-login-0.9.0.tgz",
+      "integrity": "sha512-4gvIXHh0YN5hdMeKAb0zBtL6AnLw3FKsJHDrew+8KaSV/zwuYT2ppNwnLcqFKehw4q+rOGZ2mkE0o18xIyX0uA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.23.2",
         "ember-auto-import": "^2.0.0",
         "ember-cli-babel": "^8.2.0",
-        "ember-cli-htmlbars": "^6.3.0"
+        "ember-cli-htmlbars": "^6.3.0",
+        "ember-fetch": "^8.0.4"
       },
       "engines": {
         "node": ">= 18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@glimmer/tracking": "^1.1.2",
         "@kanselarij-vlaanderen/au-kaleidos-css": "3.22.0",
         "@lblod/ember-acmidm-login": "git+https://github.com/ValenberghsSven/ember-acmidm-login.git#75d8aab5839585201a68df4701a15bcfda42b32d",
-        "@lblod/ember-mock-login": "^0.7.0",
+        "@lblod/ember-mock-login": "^0.10.0",
         "@lblod/ember-rdfa-editor": "git+https://github.com/ValenberghsSven/ember-rdfa-editor.git#23ff47de32382f55c39207b8e3625c8842fc2dae",
         "@ljharb/eslint-config": "^21.0.1",
         "@nullvoxpopuli/ember-composable-helpers": "^5.1.1",
@@ -5914,19 +5914,50 @@
       "dev": true
     },
     "node_modules/@lblod/ember-mock-login": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-mock-login/-/ember-mock-login-0.7.0.tgz",
-      "integrity": "sha512-wXtuYhbu6CDgxPecUcr7NM7S16hSHQgPnDtkySdn2yMQvMufnOxRMprjFC4fbpXYDZxPZC462MAxqzdZQgxYWA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-mock-login/-/ember-mock-login-0.10.0.tgz",
+      "integrity": "sha512-3Woc5671aKyGA4V90a7WKatJchNSW+sxKhH86mexWBnRUdc3TKW7ZkCfSVqUN8d66ls4Rkh8Fxd/WqTMGmjpSw==",
       "dev": true,
       "dependencies": {
-        "ember-cli-babel": "^7.26.3",
-        "ember-cli-htmlbars": "^5.7.1",
-        "ember-concurrency": "^1.0.0 || ^2.0.1",
-        "ember-fetch": "^8.0.4",
-        "ember-simple-auth": "^3.1.0 || ^4.2.1"
+        "@babel/core": "^7.23.2",
+        "ember-auto-import": "^2.0.0",
+        "ember-cli-babel": "^8.2.0",
+        "ember-cli-htmlbars": "^6.3.0"
       },
       "engines": {
-        "node": "10.* || >= 12"
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "ember-simple-auth": "^6.0.0",
+        "ember-source": ">= 4.0.0"
+      }
+    },
+    "node_modules/@lblod/ember-mock-login/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@lblod/ember-mock-login/node_modules/@babel/runtime": {
+      "version": "7.12.18",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
+      "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
       }
     },
     "node_modules/@lblod/ember-mock-login/node_modules/async-disk-cache": {
@@ -5945,6 +5976,50 @@
       },
       "engines": {
         "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/@lblod/ember-mock-login/node_modules/babel-plugin-module-resolver": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.2.tgz",
+      "integrity": "sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg==",
+      "dev": true,
+      "dependencies": {
+        "find-babel-config": "^2.1.1",
+        "glob": "^9.3.3",
+        "pkg-up": "^3.1.0",
+        "reselect": "^4.1.7",
+        "resolve": "^1.22.8"
+      }
+    },
+    "node_modules/@lblod/ember-mock-login/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@lblod/ember-mock-login/node_modules/broccoli-babel-transpiler": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-8.0.0.tgz",
+      "integrity": "sha512-3HEp3flvasUKJGWERcrPgM1SWvHJ0O/fmbEtY9L4kDyMSnqjY6hTYvNvgWCIgbwXAYAUlZP0vjAQsmyLNGLwFw==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-persistent-filter": "^3.0.0",
+        "clone": "^2.1.2",
+        "hash-for-dep": "^1.4.7",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.9",
+        "json-stable-stringify": "^1.0.1",
+        "rsvp": "^4.8.4",
+        "workerpool": "^6.0.2"
+      },
+      "engines": {
+        "node": "16.* || >= 18"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.17.9"
       }
     },
     "node_modules/@lblod/ember-mock-login/node_modules/broccoli-persistent-filter": {
@@ -6021,31 +6096,54 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/@lblod/ember-mock-login/node_modules/ember-cli-htmlbars": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-      "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
+    "node_modules/@lblod/ember-mock-login/node_modules/ember-cli-babel": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-8.2.0.tgz",
+      "integrity": "sha512-8H4+jQElCDo6tA7CamksE66NqBXWs7VNpS3a738L9pZCjg2kXIX4zoyHzkORUqCtr0Au7YsCnrlAMi1v2ALo7A==",
       "dev": true,
       "dependencies": {
-        "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-        "broccoli-debug": "^0.6.5",
-        "broccoli-persistent-filter": "^3.1.2",
-        "broccoli-plugin": "^4.0.3",
-        "common-tags": "^1.8.0",
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/plugin-proposal-class-properties": "^7.16.5",
+        "@babel/plugin-proposal-decorators": "^7.20.13",
+        "@babel/plugin-proposal-private-methods": "^7.16.5",
+        "@babel/plugin-proposal-private-property-in-object": "^7.20.5",
+        "@babel/plugin-transform-class-static-block": "^7.22.11",
+        "@babel/plugin-transform-modules-amd": "^7.20.11",
+        "@babel/plugin-transform-runtime": "^7.13.9",
+        "@babel/plugin-transform-typescript": "^7.20.13",
+        "@babel/preset-env": "^7.20.2",
+        "@babel/runtime": "7.12.18",
+        "amd-name-resolver": "^1.3.1",
+        "babel-plugin-debug-macros": "^0.3.4",
+        "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
+        "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
+        "babel-plugin-module-resolver": "^5.0.0",
+        "broccoli-babel-transpiler": "^8.0.0",
+        "broccoli-debug": "^0.6.4",
+        "broccoli-funnel": "^3.0.8",
+        "broccoli-source": "^3.0.1",
+        "calculate-cache-key-for-tree": "^2.0.0",
+        "clone": "^2.1.2",
         "ember-cli-babel-plugin-helpers": "^1.1.1",
         "ember-cli-version-checker": "^5.1.2",
-        "fs-tree-diff": "^2.0.1",
-        "hash-for-dep": "^1.5.1",
-        "heimdalljs-logger": "^0.1.10",
-        "json-stable-stringify": "^1.0.1",
-        "semver": "^7.3.4",
-        "silent-error": "^1.1.1",
-        "strip-bom": "^4.0.0",
-        "walk-sync": "^2.2.0"
+        "ensure-posix-path": "^1.0.2",
+        "resolve-package-path": "^4.0.3",
+        "semver": "^7.3.8"
       },
       "engines": {
-        "node": "10.* || >= 12.*"
+        "node": "16.* || 18.* || >= 20"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0"
+      }
+    },
+    "node_modules/@lblod/ember-mock-login/node_modules/find-babel-config": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-2.1.2.tgz",
+      "integrity": "sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^2.2.3"
       }
     },
     "node_modules/@lblod/ember-mock-login/node_modules/fs-tree-diff": {
@@ -6062,6 +6160,24 @@
       },
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/@lblod/ember-mock-login/node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@lblod/ember-mock-login/node_modules/istextorbinary": {
@@ -6081,16 +6197,28 @@
         "url": "https://bevry.me/fund"
       }
     },
-    "node_modules/@lblod/ember-mock-login/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+    "node_modules/@lblod/ember-mock-login/node_modules/minimatch": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
       "dev": true,
       "dependencies": {
-        "yallist": "^4.0.0"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@lblod/ember-mock-login/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@lblod/ember-mock-login/node_modules/mkdirp": {
@@ -6105,10 +6233,17 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/@lblod/ember-mock-login/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true
+    },
     "node_modules/@lblod/ember-mock-login/node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
@@ -6118,6 +6253,49 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@lblod/ember-mock-login/node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@lblod/ember-mock-login/node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@lblod/ember-mock-login/node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@lblod/ember-mock-login/node_modules/rsvp": {
@@ -6130,27 +6308,15 @@
       }
     },
     "node_modules/@lblod/ember-mock-login/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@lblod/ember-mock-login/node_modules/strip-bom": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@lblod/ember-mock-login/node_modules/sync-disk-cache": {
@@ -6168,27 +6334,6 @@
       "engines": {
         "node": "8.* || >= 10.*"
       }
-    },
-    "node_modules/@lblod/ember-mock-login/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/@lblod/ember-mock-login/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/@lblod/ember-rdfa-editor": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@glimmer/tracking": "^1.1.2",
     "@kanselarij-vlaanderen/au-kaleidos-css": "3.22.0",
     "@lblod/ember-acmidm-login": "git+https://github.com/ValenberghsSven/ember-acmidm-login.git#75d8aab5839585201a68df4701a15bcfda42b32d",
-    "@lblod/ember-mock-login": "^0.7.0",
+    "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-rdfa-editor": "git+https://github.com/ValenberghsSven/ember-rdfa-editor.git#23ff47de32382f55c39207b8e3625c8842fc2dae",
     "@ljharb/eslint-config": "^21.0.1",
     "@nullvoxpopuli/ember-composable-helpers": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@glimmer/tracking": "^1.1.2",
     "@kanselarij-vlaanderen/au-kaleidos-css": "3.22.0",
     "@lblod/ember-acmidm-login": "git+https://github.com/ValenberghsSven/ember-acmidm-login.git#75d8aab5839585201a68df4701a15bcfda42b32d",
-    "@lblod/ember-mock-login": "^0.10.0",
+    "@lblod/ember-mock-login": "^0.9.0",
     "@lblod/ember-rdfa-editor": "git+https://github.com/ValenberghsSven/ember-rdfa-editor.git#23ff47de32382f55c39207b8e3625c8842fc2dae",
     "@ljharb/eslint-config": "^21.0.1",
     "@nullvoxpopuli/ember-composable-helpers": "^5.1.1",


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4908

Upgraded minor version gradually.
Only real breaking change for us as v0.8 to v0.9 where some components were removed.
changing version to v0.7 to v0.8 warned about the deprecation and fixed it then.