### PR TITLE
remove deprecated fix in favor of warp-drive import

### DIFF
--- a/app/services/system-alert.js
+++ b/app/services/system-alert.js
@@ -5,6 +5,7 @@ import { startOfDay } from 'date-fns';
 import { tracked } from '@glimmer/tracking';
 import { later } from '@ember/runloop';
 import { action } from '@ember/object';
+import { set } from '@ember/object';
 
 export default class SystemAlertService extends Service {
   @service store;
@@ -68,7 +69,10 @@ export default class SystemAlertService extends Service {
     const prevConfirmedAlerts = alerts.filter((alert) =>
       confirmedAlertIds.includes(alert.id)
     );
-    prevConfirmedAlerts.setEach('confirmed', true);
+    // setEach might be deprecated, test this
+    prevConfirmedAlerts.forEach(alert => {
+      set(alert, 'confirmed', true);
+    });
 
     this.alerts = alerts;
   }

--- a/app/templates/settings/users/index.hbs
+++ b/app/templates/settings/users/index.hbs
@@ -37,15 +37,11 @@
         </div>
       </div>
       <div class="au-c-card au-o-box au-o-box--small">
-        {{#if this.loadSelectedRoles.isRunning}}
-          <Auk::Loader />
-        {{else}}
-          <UserRoleFilter
-            @selected={{this.selectedRoles}}
-            @onChange={{perform this.setRoles}}
-            @defaultEnableAllRoles={{is-empty this.selectedRoles}}
-          />
-        {{/if}}
+        <UserRoleFilter
+          @selected={{this.selectedRoles}}
+          @onChange={{perform this.setRoles}}
+          @defaultEnableAllRoles={{is-empty this.selectedRoles}}
+        />
       </div>
       <div class="au-c-card au-o-box au-o-box--small">
         <AuFieldset as |Fieldset|>

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,8 @@
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 const webpack = require('webpack');
 
-module.exports = function (defaults) {
+module.exports = async function (defaults) {
+  const { setConfig } = await import('@warp-drive/build-config');
   const app = new EmberApp(defaults, {
     autoprefixer: {
       enabled: true,
@@ -42,9 +43,6 @@ module.exports = function (defaults) {
     'ember-test-selectors': {
       strip: false
     },
-    emberData: {
-      polyfillUUID: true,
-    },
     //polyfill for insecure context (like cypress on jenkins) https://github.com/emberjs/data/tree/v5.0.0?tab=readme-ov-file#randomuuid-polyfill
     '@embroider/macros': {
       setConfig: {
@@ -65,6 +63,11 @@ module.exports = function (defaults) {
       //   'ember-changeset',
       // ],
     },
+  });
+
+  setConfig(app, __dirname, {
+    polyfillUUID: true
+    // WarpDrive/EmberData settings go here (if any)
   });
 
   app.import('node_modules/sanitize-filename/index.js', {


### PR DESCRIPTION
the recent fix for polyfillUuid is deprecated. Checking if it works via the suggested way (cypress shouldn't fail on missing `random.polyfillUUID`