### PR TITLE
Feature/kas 4895 cases filter definitive

### DIFF
--- a/app/components/cases/definitive-filter.hbs
+++ b/app/components/cases/definitive-filter.hbs
@@ -1,0 +1,15 @@
+<div class="au-c-card au-o-box au-o-box--small">
+  <AuFieldset as |Fieldset|>
+    <Fieldset.legend>{{capitalize (t "approval")}}</Fieldset.legend>
+    <Fieldset.content>
+      <AuCheckboxGroup> {{!-- Just use the group component here as a styling method as also using the included functionality would unnecessarily overcomplicate things --}}
+        <AuCheckbox
+          @checked={{@noDefinitivePresent}}
+          @onChange={{@onChange}}
+        >
+          {{t "show-definitive-cases-only"}}
+        </AuCheckbox>
+      </AuCheckboxGroup>
+    </Fieldset.content>
+  </AuFieldset>
+</div>

--- a/app/controllers/cases/index.js
+++ b/app/controllers/cases/index.js
@@ -47,6 +47,11 @@ export default class CasesIndexController extends Controller {
         type: 'array',
       },
     },
+    {
+      noDefinitivePresent: {
+        type: 'boolean',
+      },
+    }
   ];
 
   @tracked page = 0;

--- a/app/controllers/cases/index.js
+++ b/app/controllers/cases/index.js
@@ -63,6 +63,7 @@ export default class CasesIndexController extends Controller {
   @tracked caseFilter = null;
   @tracked isLoadingModel;
   @tracked filtersOpen = false;
+  @tracked noDefinitivePresent = false;
 
   constructor() {
     super(...arguments);

--- a/app/routes/cases/index.js
+++ b/app/routes/cases/index.js
@@ -4,7 +4,7 @@ import { inject as service } from '@ember/service';
 import { isPresent } from '@ember/utils';
 import { startOfDay, endOfDay } from 'date-fns';
 import parseDate from 'frontend-kaleidos/utils/parse-date-search-param';
-// import CONSTANTS from 'frontend-kaleidos/config/constants';
+import CONSTANTS from 'frontend-kaleidos/config/constants';
 
 export default class CasesIndexRoute extends Route {
   @service store;
@@ -43,7 +43,7 @@ export default class CasesIndexRoute extends Route {
     },
   };
 
-  model(params) {
+  async model(params) {
     const options = {
       include: 'decisionmaking-flow',
       sort: params.sort,
@@ -75,12 +75,12 @@ export default class CasesIndexRoute extends Route {
       ] = params.submitters.join(',');
     }
 
-    // We should filter on "not exists" of CONSTANTS.SUBCASE_TYPES.DEFINITIEVE_GOEDKEURING, which is not possible in ember I think.
-    // we would need post filtering (which will mess with the meta count and make pagination difficult) or do like a shortlist instead.
     if (params.noDefinitivePresent) {
-      // this could be it, but the problem is that the righthand value does not matter with a :has-no:. it will assume any text as
-      // "apply the filter 'FILTER NOT EXISTS ?subcase ?predicate ?type"
-      // options['filter[decisionmaking-flow][subcases][:has-no:type]'] = CONSTANTS.SUBCASE_TYPES.DEFINITIEVE_GOEDKEURING;
+      const definitiveType = await this.store.findRecordByUri(
+        'subcase-type',
+        CONSTANTS.SUBCASE_TYPES.DEFINITIEVE_GOEDKEURING
+      );
+      options['filter[decisionmaking-flow][subcases][type][:not:label]'] = definitiveType.label;
     }
 
     return this.store.query('case', options);

--- a/app/routes/cases/index.js
+++ b/app/routes/cases/index.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 import { isPresent } from '@ember/utils';
 import { startOfDay, endOfDay } from 'date-fns';
 import parseDate from 'frontend-kaleidos/utils/parse-date-search-param';
+// import CONSTANTS from 'frontend-kaleidos/config/constants';
 
 export default class CasesIndexRoute extends Route {
   @service store;
@@ -35,6 +36,10 @@ export default class CasesIndexRoute extends Route {
     submitters: {
       refreshModel: true,
       as: 'indieners'
+    },
+    noDefinitivePresent: {
+      refreshModel: true,
+      as: 'enkel_zonder_definitieve',
     },
   };
 
@@ -69,6 +74,12 @@ export default class CasesIndexRoute extends Route {
         'filter[decisionmaking-flow][subcases][requested-by][person][:id:]'
       ] = params.submitters.join(',');
     }
+
+    // We should filter on "not exists" of CONSTANTS.SUBCASE_TYPES.DEFINITIEVE_GOEDKEURING, which is not possible in ember I think.
+    // we would need post filtering (which will mess with the meta count and make pagination difficult) or do like a shortlist instead.
+    // if (params.noDefinitivePresent) {
+      // options['filter[decisionmaking-flow][subcases][type][:uri:]'] = CONSTANTS.SUBCASE_TYPES.PRINCIPIELE_GOEDKEURING;
+    // }
 
     return this.store.query('case', options);
   }

--- a/app/routes/cases/index.js
+++ b/app/routes/cases/index.js
@@ -77,9 +77,11 @@ export default class CasesIndexRoute extends Route {
 
     // We should filter on "not exists" of CONSTANTS.SUBCASE_TYPES.DEFINITIEVE_GOEDKEURING, which is not possible in ember I think.
     // we would need post filtering (which will mess with the meta count and make pagination difficult) or do like a shortlist instead.
-    // if (params.noDefinitivePresent) {
-      // options['filter[decisionmaking-flow][subcases][type][:uri:]'] = CONSTANTS.SUBCASE_TYPES.PRINCIPIELE_GOEDKEURING;
-    // }
+    if (params.noDefinitivePresent) {
+      // this could be it, but the problem is that the righthand value does not matter with a :has-no:. it will assume any text as
+      // "apply the filter 'FILTER NOT EXISTS ?subcase ?predicate ?type"
+      // options['filter[decisionmaking-flow][subcases][:has-no:type]'] = CONSTANTS.SUBCASE_TYPES.DEFINITIEVE_GOEDKEURING;
+    }
 
     return this.store.query('case', options);
   }

--- a/app/templates/cases/index.hbs
+++ b/app/templates/cases/index.hbs
@@ -37,6 +37,12 @@
                 @showPastMinisters={{true}}
               />
             </div>
+            {{#if (user-may "view-submissions")}}
+              <Cases::DefinitiveFilter
+                @noDefinitivePresent={{this.noDefinitivePresent}}
+                @onChange={{set this "noDefinitivePresent"}}
+              />
+            {{/if}}
           </div>
         </Auk::MobileFilters>
       </div>

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1484,5 +1484,6 @@
   "submission-internal-review": "Interne opmerking",
   "press-agenda": "Persagenda",
   "generate-press-agenda": "Genereer persagenda",
-  "login-text" : "Meld u aan"
+  "login-text" : "Meld u aan",
+  "show-definitive-cases-only": "Toon enkel dossiers zonder definitieve goedkeuring"
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4895

Thought the negative query filter was not possible out of the box, but there is an option we have not used anywhere namely `:not:`.
It has some limitations it seems. using it in combination with ID or URI does not work (406 from resource)
