### PR TITLE
KAS-4925: email settings validation

### DIFF
--- a/app/components/signatures/email-modal.js
+++ b/app/components/signatures/email-modal.js
@@ -1,13 +1,12 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { EMAIL_VALIDATION_REGEX } from 'frontend-kaleidos/config/config';
 
 export default class SignaturesEmailModalComponent extends Component {
   @tracked emailBuffer;
 
   get isValid() {
-    // this regex allows for dotless emails fe: admin@example . Change the last * to + if that is not ok.
-    const regex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
     return this.emailBuffer?.length <= 254
-      && regex.test(this.emailBuffer);
+      && EMAIL_VALIDATION_REGEX.test(this.emailBuffer);
   }
 }

--- a/app/config/config.js
+++ b/app/config/config.js
@@ -62,4 +62,7 @@ export const BREAKPOINTS = {
   BIG_SCREEN: '(min-width: 1601px)',
 }
 
-export const EMAIL_VALIDATION_REGEX = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+$/;
+const mailValidationRegex = "[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)+"; // need the "\." here so escape with "\" is needed for RegExp
+export const EMAIL_VALIDATION_REGEX = new RegExp(`^${mailValidationRegex}$`);
+// the above, but an optional komma separated list of them is possible
+export const EMAIL_VALIDATION_REGEX_MULTIPLE = new RegExp(`^((${mailValidationRegex})([,]${mailValidationRegex})*)$`, 'g');

--- a/app/config/config.js
+++ b/app/config/config.js
@@ -63,6 +63,6 @@ export const BREAKPOINTS = {
 }
 
 const mailValidationRegex = "[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)+"; // need the "\." here so escape with "\" is needed for RegExp
-export const EMAIL_VALIDATION_REGEX = new RegExp(`^${mailValidationRegex}$`);
+export const EMAIL_VALIDATION_REGEX = new RegExp(`^(${mailValidationRegex})$`);
 // the above, but an optional komma separated list of them is possible
-export const EMAIL_VALIDATION_REGEX_MULTIPLE = new RegExp(`^((${mailValidationRegex})([,]${mailValidationRegex})*)$`, 'g');
+export const EMAIL_VALIDATION_REGEX_MULTIPLE = new RegExp(`^(${mailValidationRegex})([,]${mailValidationRegex})*$`);

--- a/app/config/config.js
+++ b/app/config/config.js
@@ -61,3 +61,5 @@ export const BREAKPOINTS = {
   DESKTOP: '(min-width: 1024px) and (max-width: 1600px)',
   BIG_SCREEN: '(min-width: 1601px)',
 }
+
+export const EMAIL_VALIDATION_REGEX = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+$/;

--- a/app/controllers/settings/emails.js
+++ b/app/controllers/settings/emails.js
@@ -4,7 +4,7 @@ import { inject as service } from '@ember/service';
 import { isBlank, isEmpty } from '@ember/utils';
 import { task } from 'ember-concurrency';
 import { EMAIL_VALIDATION_REGEX_MULTIPLE } from 'frontend-kaleidos/config/config';
-import { set } from '@ember/object';
+import { set, get } from '@ember/object';
 import {
   ValidatorSet, Validator
 } from 'frontend-kaleidos/utils/validators';
@@ -41,7 +41,7 @@ export default class SettingsEmailController extends Controller {
 
   onInputProperty = (property, value) => {
     set(this.model, property, value);
-    this.validators[`${property}`].enableError();
+    get(this.validators, property).enableError();
   };
 
   @task
@@ -53,7 +53,7 @@ export default class SettingsEmailController extends Controller {
   }
 
   validateEmail = (emailProp) => {
-    const empty = isEmpty(emailProp)
+    const empty = isEmpty(emailProp);
     const valid = EMAIL_VALIDATION_REGEX_MULTIPLE.test(emailProp);
     return empty || valid;
   };

--- a/app/controllers/settings/emails.js
+++ b/app/controllers/settings/emails.js
@@ -1,9 +1,10 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { isBlank } from '@ember/utils';
+import { isBlank, isEmpty } from '@ember/utils';
 import { task } from 'ember-concurrency';
-import { EMAIL_VALIDATION_REGEX } from 'frontend-kaleidos/config/config';
+import { EMAIL_VALIDATION_REGEX_MULTIPLE } from 'frontend-kaleidos/config/config';
+import { set } from '@ember/object';
 import {
   ValidatorSet, Validator
 } from 'frontend-kaleidos/utils/validators';
@@ -20,14 +21,15 @@ export default class SettingsEmailController extends Controller {
   }
 
   initValidators = () => {
+    // Maybe no email should be allowed empty besides the CC ones, but for local and DEV it's fine.
     this.validators = new ValidatorSet({
       translationRequestCcEmail: new Validator(() => this.validateEmail(this.model.translationRequestCcEmail)),
-      translationRequestToEmail: new Validator(() => this.validateEmail(this.model.translationRequestToEmail)),
+      translationRequestToEmail: new Validator(() => this.validateEmail(this.model.translationRequestToEmail) && !isBlank(this.model.translationRequestToEmail)),
       translationRequestReplyToEmail: new Validator(() => this.validateEmail(this.model.translationRequestReplyToEmail)),
-      proofRequestToEmail: new Validator(() => this.validateEmail(this.model.proofRequestToEmail)),
+      proofRequestToEmail: new Validator(() => this.validateEmail(this.model.proofRequestToEmail) && !isBlank(this.model.proofRequestToEmail)),
       proofRequestCcEmail: new Validator(() => this.validateEmail(this.model.proofRequestCcEmail)),
       proofRequestReplyToEmail: new Validator(() => this.validateEmail(this.model.proofRequestReplyToEmail)),
-      publicationRequestToEmail: new Validator(() => this.validateEmail(this.model.publicationRequestToEmail)),
+      publicationRequestToEmail: new Validator(() => this.validateEmail(this.model.publicationRequestToEmail) && !isBlank(this.model.publicationRequestToEmail)),
       publicationRequestCcEmail: new Validator(() => this.validateEmail(this.model.publicationRequestCcEmail)),
       publicationRequestReplyToEmail: new Validator(() => this.validateEmail(this.model.publicationRequestReplyToEmail)),
       cabinetSubmissionsSecretaryEmail: new Validator(() => this.validateEmail(this.model.cabinetSubmissionsSecretaryEmail)),
@@ -37,49 +39,23 @@ export default class SettingsEmailController extends Controller {
     });
   };
 
-  onInputProperty = (property) => {
-   
-    // this.model.get(`${property}`) = event.target.value;
+  onInputProperty = (property, value) => {
+    set(this.model, property, value);
     this.validators[`${property}`].enableError();
   };
 
   @task
   *save() {
-    const errors = this.validateAllEmails();
-    if (errors.length) {
-      errors.map((error) => this.toaster.error(error))
-      
-    } else {
+    if (this.validators.areValid) {
       yield this.model.save();
       this.router.transitionTo('settings');
     }
   }
 
-  validateAllEmails = () => {
-    const propertiesToValidate = [
-      'translationRequestCcEmail',
-      'translationRequestToEmail',
-      'translationRequestReplyToEmail',
-      'proofRequestToEmail',
-      'proofRequestCcEmail',
-      'proofRequestReplyToEmail',
-      'publicationRequestToEmail',
-      'publicationRequestCcEmail',
-      'publicationRequestReplyToEmail',
-      'cabinetSubmissionsSecretaryEmail',
-      'cabinetSubmissionsIkwEmail',
-      'cabinetSubmissionsIkwConfidentialEmail',
-      'cabinetSubmissionsReplyToEmail',
-    ]
-    const allResults = propertiesToValidate.map((prop) => this.validateEmail(this.model.get(`${prop}`)));
-    return allResults.filter((result) => !!result);
-  };
-
   validateEmail = (emailProp) => {
-    return !!emailProp?.length || EMAIL_VALIDATION_REGEX.test(emailProp);
-    // if (emailProp?.length && !EMAIL_VALIDATION_REGEX.test(emailProp)) {
-    //   return `${emailProp} is niet aanvaardbaar`;
-    // }
+    const empty = isEmpty(emailProp)
+    const valid = EMAIL_VALIDATION_REGEX_MULTIPLE.test(emailProp);
+    return empty || valid;
   };
 
   @action
@@ -90,9 +66,7 @@ export default class SettingsEmailController extends Controller {
 
   get isDisabled() {
     return (
-      isBlank(this.model.translationRequestToEmail) ||
-      isBlank(this.model.proofRequestToEmail) ||
-      isBlank(this.model.publicationRequestToEmail) ||
+      !this.validators.areValid ||
       this.save.isRunning
     );
   }

--- a/app/controllers/settings/emails.js
+++ b/app/controllers/settings/emails.js
@@ -3,15 +3,84 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { isBlank } from '@ember/utils';
 import { task } from 'ember-concurrency';
+import { EMAIL_VALIDATION_REGEX } from 'frontend-kaleidos/config/config';
+import {
+  ValidatorSet, Validator
+} from 'frontend-kaleidos/utils/validators';
 
 export default class SettingsEmailController extends Controller {
   @service router;
+  @service toaster;
+
+  validators;
+  
+  constructor() {
+    super(...arguments);
+    this.initValidators();
+  }
+
+  initValidators = () => {
+    this.validators = new ValidatorSet({
+      translationRequestCcEmail: new Validator(() => this.validateEmail(this.model.translationRequestCcEmail)),
+      translationRequestToEmail: new Validator(() => this.validateEmail(this.model.translationRequestToEmail)),
+      translationRequestReplyToEmail: new Validator(() => this.validateEmail(this.model.translationRequestReplyToEmail)),
+      proofRequestToEmail: new Validator(() => this.validateEmail(this.model.proofRequestToEmail)),
+      proofRequestCcEmail: new Validator(() => this.validateEmail(this.model.proofRequestCcEmail)),
+      proofRequestReplyToEmail: new Validator(() => this.validateEmail(this.model.proofRequestReplyToEmail)),
+      publicationRequestToEmail: new Validator(() => this.validateEmail(this.model.publicationRequestToEmail)),
+      publicationRequestCcEmail: new Validator(() => this.validateEmail(this.model.publicationRequestCcEmail)),
+      publicationRequestReplyToEmail: new Validator(() => this.validateEmail(this.model.publicationRequestReplyToEmail)),
+      cabinetSubmissionsSecretaryEmail: new Validator(() => this.validateEmail(this.model.cabinetSubmissionsSecretaryEmail)),
+      cabinetSubmissionsIkwEmail: new Validator(() => this.validateEmail(this.model.cabinetSubmissionsIkwEmail)),
+      cabinetSubmissionsIkwConfidentialEmail: new Validator(() => this.validateEmail(this.model.cabinetSubmissionsIkwConfidentialEmail)),
+      cabinetSubmissionsReplyToEmail: new Validator(() => this.validateEmail(this.model.cabinetSubmissionsReplyToEmail)),
+    });
+  };
+
+  onInputProperty = (property) => {
+   
+    // this.model.get(`${property}`) = event.target.value;
+    this.validators[`${property}`].enableError();
+  };
 
   @task
   *save() {
-    yield this.model.save();
-    this.router.transitionTo('settings');
+    const errors = this.validateAllEmails();
+    if (errors.length) {
+      errors.map((error) => this.toaster.error(error))
+      
+    } else {
+      yield this.model.save();
+      this.router.transitionTo('settings');
+    }
   }
+
+  validateAllEmails = () => {
+    const propertiesToValidate = [
+      'translationRequestCcEmail',
+      'translationRequestToEmail',
+      'translationRequestReplyToEmail',
+      'proofRequestToEmail',
+      'proofRequestCcEmail',
+      'proofRequestReplyToEmail',
+      'publicationRequestToEmail',
+      'publicationRequestCcEmail',
+      'publicationRequestReplyToEmail',
+      'cabinetSubmissionsSecretaryEmail',
+      'cabinetSubmissionsIkwEmail',
+      'cabinetSubmissionsIkwConfidentialEmail',
+      'cabinetSubmissionsReplyToEmail',
+    ]
+    const allResults = propertiesToValidate.map((prop) => this.validateEmail(this.model.get(`${prop}`)));
+    return allResults.filter((result) => !!result);
+  };
+
+  validateEmail = (emailProp) => {
+    return !!emailProp?.length || EMAIL_VALIDATION_REGEX.test(emailProp);
+    // if (emailProp?.length && !EMAIL_VALIDATION_REGEX.test(emailProp)) {
+    //   return `${emailProp} is niet aanvaardbaar`;
+    // }
+  };
 
   @action
   cancel() {

--- a/app/controllers/settings/emails.js
+++ b/app/controllers/settings/emails.js
@@ -11,10 +11,9 @@ import {
 
 export default class SettingsEmailController extends Controller {
   @service router;
-  @service toaster;
 
   validators;
-  
+
   constructor() {
     super(...arguments);
     this.initValidators();
@@ -32,10 +31,10 @@ export default class SettingsEmailController extends Controller {
       publicationRequestToEmail: new Validator(() => this.validateEmail(this.model.publicationRequestToEmail) && !isBlank(this.model.publicationRequestToEmail)),
       publicationRequestCcEmail: new Validator(() => this.validateEmail(this.model.publicationRequestCcEmail)),
       publicationRequestReplyToEmail: new Validator(() => this.validateEmail(this.model.publicationRequestReplyToEmail)),
-      cabinetSubmissionsSecretaryEmail: new Validator(() => this.validateEmail(this.model.cabinetSubmissionsSecretaryEmail)),
-      cabinetSubmissionsIkwEmail: new Validator(() => this.validateEmail(this.model.cabinetSubmissionsIkwEmail)),
-      cabinetSubmissionsIkwConfidentialEmail: new Validator(() => this.validateEmail(this.model.cabinetSubmissionsIkwConfidentialEmail)),
-      cabinetSubmissionsReplyToEmail: new Validator(() => this.validateEmail(this.model.cabinetSubmissionsReplyToEmail)),
+      cabinetSubmissionsSecretaryEmail: new Validator(() => this.validateEmail(this.model.cabinetSubmissionsSecretaryEmail) && !isBlank(this.model.cabinetSubmissionsSecretaryEmail)),
+      cabinetSubmissionsIkwEmail: new Validator(() => this.validateEmail(this.model.cabinetSubmissionsIkwEmail) && !isBlank(this.model.cabinetSubmissionsIkwEmail)),
+      cabinetSubmissionsIkwConfidentialEmail: new Validator(() => this.validateEmail(this.model.cabinetSubmissionsIkwConfidentialEmail) && !isBlank(this.model.cabinetSubmissionsIkwConfidentialEmail)),
+      cabinetSubmissionsReplyToEmail: new Validator(() => this.validateEmail(this.model.cabinetSubmissionsReplyToEmail) && !isBlank(this.model.cabinetSubmissionsReplyToEmail)),
     });
   };
 

--- a/app/templates/settings/emails.hbs
+++ b/app/templates/settings/emails.hbs
@@ -23,7 +23,7 @@
               <AuInput
                 value={{this.model.translationRequestToEmail}}
                 @error={{this.validators.translationRequestToEmail.showError}}
-                {{on "input" (queue (pick "target.value" (set this "translationRequestToEmail")) (fn this.onInputProperty "translationRequestToEmail"))}}
+                {{on "input" (pick "target.value" (fn this.onInputProperty "translationRequestToEmail"))}}
               />
             </AuFormRow>
             <AuFormRow @alignment="inline">
@@ -33,7 +33,7 @@
               <AuInput
                 value={{this.model.translationRequestCcEmail}}
                 @error={{this.validators.translationRequestCcEmail.showError}}
-                {{on "input" (pick "target.value" (set this "model.translationRequestCcEmail"))}}
+                {{on "input" (pick "target.value" (fn this.onInputProperty "translationRequestCcEmail"))}}
               />
             </AuFormRow>
             <AuFormRow @alignment="inline">
@@ -43,7 +43,7 @@
               <AuInput
                 value={{this.model.translationRequestReplyToEmail}}
                 @error={{this.validators.translationRequestReplyToEmail.showError}}
-                {{on "input" (pick "target.value" (set this "model.translationRequestReplyToEmail"))}}
+                {{on "input" (pick "target.value" (fn this.onInputProperty "translationRequestReplyToEmail"))}}
               />
             </AuFormRow>
           </div>
@@ -60,7 +60,7 @@
               <AuInput
                 value={{this.model.proofRequestToEmail}}
                 @error={{this.validators.proofRequestToEmail.showError}}
-                {{on "input" (pick "target.value" (set this "model.proofRequestToEmail"))}}
+                {{on "input" (pick "target.value" (fn this.onInputProperty "proofRequestToEmail"))}}
               />
             </AuFormRow>
             <AuFormRow @alignment="inline">
@@ -70,7 +70,7 @@
               <AuInput
                 value={{this.model.proofRequestCcEmail}}
                 @error={{this.validators.proofRequestCcEmail.showError}}
-                {{on "input" (pick "target.value" (set this "model.proofRequestCcEmail"))}}
+                {{on "input" (pick "target.value" (fn this.onInputProperty "proofRequestCcEmail"))}}
               />
             </AuFormRow>
             <AuFormRow @alignment="inline">
@@ -80,7 +80,7 @@
               <AuInput
                 value={{this.model.proofRequestReplyToEmail}}
                 @error={{this.validators.proofRequestReplyToEmail.showError}}
-                {{on "input" (pick "target.value" (set this "model.proofRequestReplyToEmail"))}}
+                {{on "input" (pick "target.value" (fn this.onInputProperty "proofRequestReplyToEmail"))}}
               />
             </AuFormRow>
           </div>
@@ -98,7 +98,7 @@
                 data-test-route-settings-emails-publication-request-to
                 value={{this.model.publicationRequestToEmail}}
                 @error={{this.validators.publicationRequestToEmail.showError}}
-                {{on "input" (pick "target.value" (set this "model.publicationRequestToEmail"))}}
+                {{on "input" (pick "target.value" (fn this.onInputProperty "publicationRequestToEmail"))}}
               />
             </AuFormRow>
             <AuFormRow @alignment="inline">
@@ -108,7 +108,7 @@
               <AuInput
                 value={{this.model.publicationRequestCcEmail}}
                 @error={{this.validators.publicationRequestCcEmail.showError}}
-                {{on "input" (pick "target.value" (set this "model.publicationRequestCcEmail"))}}
+                {{on "input" (pick "target.value" (fn this.onInputProperty "publicationRequestCcEmail"))}}
               />
             </AuFormRow>
             <AuFormRow @alignment="inline">
@@ -118,7 +118,7 @@
               <AuInput
                 value={{this.model.publicationRequestReplyToEmail}}
                 @error={{this.validators.publicationRequestReplyToEmail.showError}}
-                {{on "input" (pick "target.value" (set this "model.publicationRequestReplyToEmail"))}}
+                {{on "input" (pick "target.value" (fn this.onInputProperty "publicationRequestReplyToEmail"))}}
               />
             </AuFormRow>
           </div>
@@ -136,7 +136,7 @@
                 data-test-route-settings-emails-submission-to-secretary
                 value={{this.model.cabinetSubmissionsSecretaryEmail}}
                 @error={{this.validators.cabinetSubmissionsSecretaryEmail.showError}}
-                {{on "input" (pick "target.value" (set this "model.cabinetSubmissionsSecretaryEmail"))}}
+                {{on "input" (pick "target.value" (fn this.onInputProperty "cabinetSubmissionsSecretaryEmail"))}}
               />
             </AuFormRow>
             <AuFormRow @alignment="inline">
@@ -147,7 +147,7 @@
                 data-test-route-settings-emails-submission-to-ikw
                 value={{this.model.cabinetSubmissionsIkwEmail}}
                 @error={{this.validators.cabinetSubmissionsIkwEmail.showError}}
-                {{on "input" (pick "target.value" (set this "model.cabinetSubmissionsIkwEmail"))}}
+                {{on "input" (pick "target.value" (fn this.onInputProperty "cabinetSubmissionsIkwEmail"))}}
               />
             </AuFormRow>
             <AuFormRow @alignment="inline">
@@ -158,7 +158,7 @@
                 data-test-route-settings-emails-submission-to-kc-group
                 value={{this.model.cabinetSubmissionsIkwConfidentialEmail}}
                 @error={{this.validators.cabinetSubmissionsIkwConfidentialEmail.showError}}
-                {{on "input" (pick "target.value" (set this "model.cabinetSubmissionsIkwConfidentialEmail"))}}
+                {{on "input" (pick "target.value" (fn this.onInputProperty "cabinetSubmissionsIkwConfidentialEmail"))}}
               />
             </AuFormRow>
             <AuFormRow @alignment="inline">
@@ -169,7 +169,7 @@
                 data-test-route-settings-emails-submission-reply-to
                 value={{this.model.cabinetSubmissionsReplyToEmail}}
                 @error={{this.validators.cabinetSubmissionsReplyToEmail.showError}}
-                {{on "input" (pick "target.value" (set this "model.cabinetSubmissionsReplyToEmail"))}}
+                {{on "input" (pick "target.value" (fn this.onInputProperty "cabinetSubmissionsReplyToEmail"))}}
               />
             </AuFormRow>
           </div>

--- a/app/templates/settings/emails.hbs
+++ b/app/templates/settings/emails.hbs
@@ -129,7 +129,7 @@
           <h4>{{t "cabinet-submissions"}}</h4>
           <div class="au-c-form">
             <AuFormRow @alignment="inline">
-              <AuLabel class="au-u-2-6 au-u-max-width-tiny au-u-max-width-tiny">
+              <AuLabel @required={{true}} class="au-u-2-6 au-u-max-width-tiny au-u-max-width-tiny">
                 {{t "secretary-mail"}}
               </AuLabel>
               <AuInput
@@ -140,7 +140,7 @@
               />
             </AuFormRow>
             <AuFormRow @alignment="inline">
-              <AuLabel class="au-u-2-6 au-u-max-width-tiny au-u-max-width-tiny">
+              <AuLabel @required={{true}} class="au-u-2-6 au-u-max-width-tiny au-u-max-width-tiny">
                 {{t "ikw"}}
               </AuLabel>
               <AuInput
@@ -151,7 +151,7 @@
               />
             </AuFormRow>
             <AuFormRow @alignment="inline">
-              <AuLabel class="au-u-2-6 au-u-max-width-tiny au-u-max-width-tiny">
+              <AuLabel @required={{true}} class="au-u-2-6 au-u-max-width-tiny au-u-max-width-tiny">
                 {{t "kc-group"}}
               </AuLabel>
               <AuInput
@@ -162,7 +162,7 @@
               />
             </AuFormRow>
             <AuFormRow @alignment="inline">
-              <AuLabel class="au-u-2-6 au-u-max-width-tiny au-u-max-width-tiny">
+              <AuLabel @required={{true}} class="au-u-2-6 au-u-max-width-tiny au-u-max-width-tiny">
                 {{t "email-reply-to"}}
               </AuLabel>
               <AuInput

--- a/app/templates/settings/emails.hbs
+++ b/app/templates/settings/emails.hbs
@@ -181,7 +181,7 @@
             <Group.Item>
               <AuButton
                 @skin="naked"
-                @disabled={{or (not this.validators.areValid) this.save.isRunning}}
+                @disabled={{this.save.isRunning}}
                 {{on "click" this.cancel}}
               >
                 {{t "cancel"}}

--- a/app/templates/settings/emails.hbs
+++ b/app/templates/settings/emails.hbs
@@ -22,7 +22,8 @@
               </AuLabel>
               <AuInput
                 value={{this.model.translationRequestToEmail}}
-                {{on "input" (pick "target.value" (set this "model.translationRequestToEmail"))}}
+                @error={{this.validators.translationRequestToEmail.showError}}
+                {{on "input" (queue (pick "target.value" (set this "translationRequestToEmail")) (fn this.onInputProperty "translationRequestToEmail"))}}
               />
             </AuFormRow>
             <AuFormRow @alignment="inline">
@@ -31,6 +32,7 @@
               </AuLabel>
               <AuInput
                 value={{this.model.translationRequestCcEmail}}
+                @error={{this.validators.translationRequestCcEmail.showError}}
                 {{on "input" (pick "target.value" (set this "model.translationRequestCcEmail"))}}
               />
             </AuFormRow>
@@ -40,6 +42,7 @@
               </AuLabel>
               <AuInput
                 value={{this.model.translationRequestReplyToEmail}}
+                @error={{this.validators.translationRequestReplyToEmail.showError}}
                 {{on "input" (pick "target.value" (set this "model.translationRequestReplyToEmail"))}}
               />
             </AuFormRow>
@@ -56,6 +59,7 @@
               </AuLabel>
               <AuInput
                 value={{this.model.proofRequestToEmail}}
+                @error={{this.validators.proofRequestToEmail.showError}}
                 {{on "input" (pick "target.value" (set this "model.proofRequestToEmail"))}}
               />
             </AuFormRow>
@@ -65,6 +69,7 @@
               </AuLabel>
               <AuInput
                 value={{this.model.proofRequestCcEmail}}
+                @error={{this.validators.proofRequestCcEmail.showError}}
                 {{on "input" (pick "target.value" (set this "model.proofRequestCcEmail"))}}
               />
             </AuFormRow>
@@ -74,6 +79,7 @@
               </AuLabel>
               <AuInput
                 value={{this.model.proofRequestReplyToEmail}}
+                @error={{this.validators.proofRequestReplyToEmail.showError}}
                 {{on "input" (pick "target.value" (set this "model.proofRequestReplyToEmail"))}}
               />
             </AuFormRow>
@@ -91,6 +97,7 @@
               <AuInput
                 data-test-route-settings-emails-publication-request-to
                 value={{this.model.publicationRequestToEmail}}
+                @error={{this.validators.publicationRequestToEmail.showError}}
                 {{on "input" (pick "target.value" (set this "model.publicationRequestToEmail"))}}
               />
             </AuFormRow>
@@ -100,6 +107,7 @@
               </AuLabel>
               <AuInput
                 value={{this.model.publicationRequestCcEmail}}
+                @error={{this.validators.publicationRequestCcEmail.showError}}
                 {{on "input" (pick "target.value" (set this "model.publicationRequestCcEmail"))}}
               />
             </AuFormRow>
@@ -109,6 +117,7 @@
               </AuLabel>
               <AuInput
                 value={{this.model.publicationRequestReplyToEmail}}
+                @error={{this.validators.publicationRequestReplyToEmail.showError}}
                 {{on "input" (pick "target.value" (set this "model.publicationRequestReplyToEmail"))}}
               />
             </AuFormRow>
@@ -126,6 +135,7 @@
               <AuInput
                 data-test-route-settings-emails-submission-to-secretary
                 value={{this.model.cabinetSubmissionsSecretaryEmail}}
+                @error={{this.validators.cabinetSubmissionsSecretaryEmail.showError}}
                 {{on "input" (pick "target.value" (set this "model.cabinetSubmissionsSecretaryEmail"))}}
               />
             </AuFormRow>
@@ -136,6 +146,7 @@
               <AuInput
                 data-test-route-settings-emails-submission-to-ikw
                 value={{this.model.cabinetSubmissionsIkwEmail}}
+                @error={{this.validators.cabinetSubmissionsIkwEmail.showError}}
                 {{on "input" (pick "target.value" (set this "model.cabinetSubmissionsIkwEmail"))}}
               />
             </AuFormRow>
@@ -146,6 +157,7 @@
               <AuInput
                 data-test-route-settings-emails-submission-to-kc-group
                 value={{this.model.cabinetSubmissionsIkwConfidentialEmail}}
+                @error={{this.validators.cabinetSubmissionsIkwConfidentialEmail.showError}}
                 {{on "input" (pick "target.value" (set this "model.cabinetSubmissionsIkwConfidentialEmail"))}}
               />
             </AuFormRow>
@@ -156,6 +168,7 @@
               <AuInput
                 data-test-route-settings-emails-submission-reply-to
                 value={{this.model.cabinetSubmissionsReplyToEmail}}
+                @error={{this.validators.cabinetSubmissionsReplyToEmail.showError}}
                 {{on "input" (pick "target.value" (set this "model.cabinetSubmissionsReplyToEmail"))}}
               />
             </AuFormRow>
@@ -168,7 +181,7 @@
             <Group.Item>
               <AuButton
                 @skin="naked"
-                @disabled={{this.save.isRunning}}
+                @disabled={{or (not this.validators.areValid) this.save.isRunning}}
                 {{on "click" this.cancel}}
               >
                 {{t "cancel"}}


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4925

Moved regex to config
Used regex also in komma separated list.
Used our validator component to validate the fields.
Tested if it still works.

no spaces allowed, only komma is allowed to separate the mails (and only in settings)
I think that is right? semicolon gives errors in mail service right?