### PR TITLE
KAS-4897: the great controllers reset

### DIFF
--- a/app/controllers/agenda/agendaitems/agendaitem/index.js
+++ b/app/controllers/agenda/agendaitems/agendaitem/index.js
@@ -17,7 +17,6 @@ export default class IndexAgendaitemAgendaitemsAgendaController extends Controll
   @service parliamentService;
 
   @controller('agenda.agendaitems') agendaitemsController;
-  @controller('agenda') agendaController;
   @tracked meeting;
   @tracked agenda;
   @tracked agendaActivity;
@@ -28,8 +27,6 @@ export default class IndexAgendaitemAgendaitemsAgendaController extends Controll
   @tracked mandatees;
   @tracked decisionActivity;
   @tracked parliamentFlow;
-
-  @tracked isEditingAgendaItemTitles = false;
 
   get isClosedMeeting() {
     return isPresent(this.meeting.agenda.get('id'));
@@ -94,11 +91,6 @@ export default class IndexAgendaitemAgendaitemsAgendaController extends Controll
     // reload the agenda route, detail tab should no longer show if we deleted the last and only agendaitem
     // Also, if we deleted the first agendaitem, we should also reload the main route to reload <Agenda::agendaTabs>
     return this.router.refresh('agenda');
-  }
-
-  @action
-  async toggleIsEditingAgendaItemTitles() {
-    this.isEditingAgendaItemTitles = !this.isEditingAgendaItemTitles;
   }
 
   @action

--- a/app/controllers/agendas.js
+++ b/app/controllers/agendas.js
@@ -17,12 +17,14 @@ export default class AgendasController extends Controller {
   @service store;
   @service router;
   @service mandatees;
+
   defaultPublicationActivityStatus;
   @tracked newMeeting;
   @tracked publicationActivities = [];
 
   @tracked isLoadingModel = false;
   @tracked isCreatingNewSession = false;
+
   @tracked filterAgendas = null;
   @tracked pageAgendas = 0;
   @tracked sizeAgendas = 10;
@@ -97,7 +99,9 @@ export default class AgendasController extends Controller {
   closeNewSessionModal() {
     this.isCreatingNewSession = false;
     this.newMeeting.deleteRecord();
+    this.newMeeting = null;
     this.publicationActivities.forEach((activity) => activity.deleteRecord());
+    this.publicationActivities = [];
   }
 
   @action

--- a/app/controllers/cases.js
+++ b/app/controllers/cases.js
@@ -1,5 +1,0 @@
-import Controller from '@ember/controller';
-
-export default class CasesController extends Controller {
-
-}

--- a/app/controllers/cases/case/subcases/new-submission.js
+++ b/app/controllers/cases/case/subcases/new-submission.js
@@ -7,6 +7,7 @@ export default class CasesCaseSubcasesNewSubmissionController extends Controller
 
   submitter;
   mandatees;
+  latestSubcase;
 
   onCancelSubmission = () => {
     this.preventUnload.disable();

--- a/app/controllers/cases/submissions/submission.js
+++ b/app/controllers/cases/submissions/submission.js
@@ -43,6 +43,8 @@ export default class CasesSubmissionsSubmissionController extends Controller {
   currentLinkedMandatee;
   previousMandateePersons;
 
+  subcase;
+
   get mayEdit() {
     const mayIfAdmin = this.currentSession.may('always-edit-submissions');
 

--- a/app/controllers/newsletters.js
+++ b/app/controllers/newsletters.js
@@ -1,4 +1,0 @@
-import Controller from '@ember/controller';
-
-export default class NewslettersController extends Controller {
-}

--- a/app/controllers/publications.js
+++ b/app/controllers/publications.js
@@ -1,5 +1,0 @@
-import Controller from '@ember/controller';
-
-export default class PublicationsController extends Controller {
-
-}

--- a/app/controllers/search.js
+++ b/app/controllers/search.js
@@ -28,7 +28,6 @@ export default class SearchController extends Controller {
   @tracked mandatees = [];
   @tracked dateFrom;
   @tracked dateTo;
-  @tracked hasToggleableFilters = false;
   @tracked filtersOpen = false;
 
   @tracked governmentAreas = [];

--- a/app/controllers/settings.js
+++ b/app/controllers/settings.js
@@ -1,5 +1,0 @@
-import Controller from '@ember/controller';
-
-export default class SettingsController extends Controller {
-
-}

--- a/app/routes/agenda/agendaitems/agendaitem/documents.js
+++ b/app/routes/agenda/agendaitems/agendaitem/documents.js
@@ -1,8 +1,10 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { TrackedArray } from 'tracked-built-ins';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 import { sortPieces } from 'frontend-kaleidos/utils/documents';
+import { deletePiece } from 'frontend-kaleidos/utils/document-delete-helpers';
 
 export default class DocumentsAgendaitemAgendaitemsAgendaRoute extends Route {
   @service store;
@@ -81,6 +83,8 @@ export default class DocumentsAgendaitemAgendaitemsAgendaRoute extends Route {
     controller.isOpenBatchDetailsModal = false;
     controller.isOpenPieceUploadModal = false;
     controller.isOpenPublicationModal = false;
+    controller.isOpenSignFlowModal = false;
+    controller.isOpenWarnDocEditOnApproved = false;
     controller.hasConfirmedDocEditOnApproved = false;
     controller.currentAgenda = this.currentAgenda;
     controller.previousAgenda = this.previousAgenda;
@@ -89,5 +93,13 @@ export default class DocumentsAgendaitemAgendaitemsAgendaRoute extends Route {
     controller.meeting = this.meeting;
     controller.decisionActivity = this.decisionActivity;
     controller.loadNewPieces.perform();
+  }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      Promise.all(
+        controller.newPieces.map(async (piece) => await deletePiece(piece))
+      ).then(() => (controller.newPieces = new TrackedArray([])));
+    }
   }
 }

--- a/app/routes/agenda/agendaitems/agendaitem/documents.js
+++ b/app/routes/agenda/agendaitems/agendaitem/documents.js
@@ -97,8 +97,14 @@ export default class DocumentsAgendaitemAgendaitemsAgendaRoute extends Route {
 
   resetController(controller, isExiting) {
     if (isExiting) {
+      // cleanup any unsaved pieces
       Promise.all(
-        controller.newPieces.map(async (piece) => await deletePiece(piece))
+        controller.newPieces.map(async (piece) => {
+          if (!piece?.id) {
+            // don't delete the draft-piece here.
+            await deletePiece(piece, false);
+          }
+        }),
       ).then(() => (controller.newPieces = new TrackedArray([])));
     }
   }

--- a/app/routes/agenda/documents.js
+++ b/app/routes/agenda/documents.js
@@ -31,13 +31,18 @@ export default class AgendaDocumentsRoute extends Route {
     controller.defaultAccessLevel = this.defaultAccessLevel;
   }
 
-  resetController(controller, isExiting) {
+  resetController(controller, isExiting) { 
     if (isExiting) {
       controller.isOpenBatchDetailsModal = false;
       controller.isOpenPieceUploadModal = false;
-      
+
+      // cleanup any unsaved pieces
       Promise.all(
-        controller.newPieces.map(async (piece) => await deletePiece(piece))
+        controller.newPieces.map(async (piece) => {
+          if (!piece?.id) {
+            await deletePiece(piece);
+          }
+        }),
       ).then(() => (controller.newPieces = new TrackedArray([])));
     }
   }

--- a/app/routes/agenda/documents.js
+++ b/app/routes/agenda/documents.js
@@ -1,7 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { TrackedArray } from 'tracked-built-ins';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 import { sortPieces } from 'frontend-kaleidos/utils/documents';
-import { inject as service } from '@ember/service';
+import { deletePiece } from 'frontend-kaleidos/utils/document-delete-helpers';
 
 export default class AgendaDocumentsRoute extends Route {
   @service store;
@@ -27,5 +29,16 @@ export default class AgendaDocumentsRoute extends Route {
     const agenda = this.modelFor('agenda').agenda;
     controller.agenda = agenda;
     controller.defaultAccessLevel = this.defaultAccessLevel;
+  }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.isOpenBatchDetailsModal = false;
+      controller.isOpenPieceUploadModal = false;
+      
+      Promise.all(
+        controller.newPieces.map(async (piece) => await deletePiece(piece))
+      ).then(() => (controller.newPieces = new TrackedArray([])));
+    }
   }
 }

--- a/app/routes/agendas.js
+++ b/app/routes/agendas.js
@@ -75,14 +75,18 @@ export default class AgendasRoute extends Route {
 
   resetController(controller, isExiting) {
     if (isExiting) {
-      if (controller.newMeeting) {
-        controller.newMeeting.deleteRecord();
+      // delete any non saved models
+      if (!controller.newMeeting?.id) {
+        controller.newMeeting?.deleteRecord();
+      }
+      if (controller.publicationActivities.length) {
+        controller.publicationActivities.forEach((activity) => {
+          if (!activity?.id) {
+            activity.deleteRecord();
+          }
+        });
       }
       controller.newMeeting = null;
-
-      if (controller.publicationActivities.length) {
-        controller.publicationActivities.forEach((activity) => activity.deleteRecord());
-      }
       controller.publicationActivities = [];
     }
   }

--- a/app/routes/agendas.js
+++ b/app/routes/agendas.js
@@ -70,6 +70,21 @@ export default class AgendasRoute extends Route {
   setupController(controller) {
     super.setupController(...arguments);
     controller.defaultPublicationActivityStatus = this.defaultPublicationActivityStatus;
+    controller.isCreatingNewSession = false;
+  }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      if (controller.newMeeting) {
+        controller.newMeeting.deleteRecord();
+      }
+      controller.newMeeting = null;
+
+      if (controller.publicationActivities.length) {
+        controller.publicationActivities.forEach((activity) => activity.deleteRecord());
+      }
+      controller.publicationActivities = [];
+    }
   }
 
   @action

--- a/app/routes/cases/case/subcases/subcase/index.js
+++ b/app/routes/cases/case/subcases/subcase/index.js
@@ -1,8 +1,10 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { TrackedArray } from 'tracked-built-ins';
 import { sortPieces } from 'frontend-kaleidos/utils/documents';
-import CONSTANTS from 'frontend-kaleidos/config/constants';
 import { addObjects } from 'frontend-kaleidos/utils/array-helpers';
+import { deletePiece } from 'frontend-kaleidos/utils/document-delete-helpers';
+import CONSTANTS from 'frontend-kaleidos/config/constants';
 
 export default class CasesCaseSubcasesSubcaseIndexRoute extends Route {
   @service store;
@@ -124,5 +126,16 @@ export default class CasesCaseSubcasesSubcaseIndexRoute extends Route {
     controller.documentsAreVisible = this.documentsAreVisible;
     controller.defaultAccessLevel = this.defaultAccessLevel;
     controller.piecesNotOnAgenda = this.piecesNotOnAgenda;
+  }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.isOpenPieceUploadModal = false;
+      controller.isOpenBatchDetailsModal = false;
+      
+      Promise.all(
+        controller.newPieces.map(async (piece) => await deletePiece(piece))
+      ).then(() => controller.newPieces = new TrackedArray([]));
+    }
   }
 }

--- a/app/routes/cases/case/subcases/subcase/index.js
+++ b/app/routes/cases/case/subcases/subcase/index.js
@@ -132,9 +132,15 @@ export default class CasesCaseSubcasesSubcaseIndexRoute extends Route {
     if (isExiting) {
       controller.isOpenPieceUploadModal = false;
       controller.isOpenBatchDetailsModal = false;
-      
+
+      // cleanup any unsaved pieces
       Promise.all(
-        controller.newPieces.map(async (piece) => await deletePiece(piece))
+        controller.newPieces.map(async (piece) => {
+          if (!piece?.id) {
+            // don't delete the draft-piece here.
+            await deletePiece(piece, false);
+          }
+        }),
       ).then(() => controller.newPieces = new TrackedArray([]));
     }
   }

--- a/app/routes/cases/case/subcases/subcase/new-submission.js
+++ b/app/routes/cases/case/subcases/subcase/new-submission.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 import { addObjects } from 'frontend-kaleidos/utils/array-helpers';
+import { deletePiece } from 'frontend-kaleidos/utils/document-delete-helpers';
 import { sortPieces } from 'frontend-kaleidos/utils/documents';
 import { TrackedArray } from 'tracked-built-ins';
 
@@ -160,8 +161,21 @@ export default class CasesCaseSubcasesSubcaseNewSubmissionRoute extends Route {
     controller.approvalComment = this.approvalComment;
     controller.notificationAddresses = this.notificationAddresses;
     controller.notificationComment = this.notificationComment;
-    // empty list of draft pieces in case user navigating away and back
-    // those pieces still exist but should no longer cause hidden BIS versions on real pieces.
-    controller.newDraftPieces = new TrackedArray([]);
+  }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.isOpenPieceUploadModal = false;
+      controller.isOpenCreateSubmissionModal = false;
+      controller.hasConfidentialPieces = false;
+      controller.comment = null;
+
+      Promise.all(
+        controller.newPieces.map(async (piece) => await deletePiece(piece))
+      ).then(() => controller.newPieces = new TrackedArray([]));
+      Promise.all(
+        controller.newDraftPieces.map(async (piece) => await deletePiece(piece))
+      ).then(() => controller.newDraftPieces = new TrackedArray([]));
+    }
   }
 }

--- a/app/routes/cases/case/subcases/subcase/new-submission.js
+++ b/app/routes/cases/case/subcases/subcase/new-submission.js
@@ -180,11 +180,20 @@ export default class CasesCaseSubcasesSubcaseNewSubmissionRoute extends Route {
       controller.hasConfidentialPieces = false;
       controller.comment = null;
 
+      // cleanup any unsaved pieces
       Promise.all(
-        controller.newPieces.map(async (piece) => await deletePiece(piece))
+        controller.newPieces.map(async (piece) => {
+          if (!piece?.id) {
+            await deletePiece(piece);
+          }
+        }),
       ).then(() => controller.newPieces = new TrackedArray([]));
       Promise.all(
-        controller.newDraftPieces.map(async (piece) => await deletePiece(piece))
+        controller.newDraftPieces.map(async (piece) => {
+          if (!piece?.id) {
+            await deletePiece(piece);
+          }
+        }),
       ).then(() => controller.newDraftPieces = new TrackedArray([]));
     }
   }

--- a/app/routes/cases/submissions/submission.js
+++ b/app/routes/cases/submissions/submission.js
@@ -135,23 +135,30 @@ export default class CasesSubmissionsSubmissionRoute extends Route {
     }
   }
 
-  setupController(controller, _model, _transition) {
+  setupController(controller, model, _transition) {
     super.setupController(...arguments);
+
+    controller.isOpenPieceUploadModal = false;
+    controller.isOpenBatchDetailsModal = false;
+
     controller.mandatees = this.mandatees;
     controller.pieces = this.pieces;
     controller.documentContainerIds = this.documentContainerIds;
     controller.newDraftPieces = this.newDraftPieces;
+    // controller.newPieces = this.newPieces;
     controller.statusChangeActivities = this.statusChangeActivities;
-    controller.currentLinkedMandatee = this.currentLinkedMandatee;
+    controller.approvalAddresses = model.approvalAddresses;
+    controller.notificationAddresses = model.notificationAddresses;
+    controller.approvalComment = model.approvalComment;
+    controller.notificationComment = model.notificationComment;
     controller.beingTreatedBy = this.beingTreatedBy;
     controller.isUpdate = this.isUpdate;
-    controller.subcase = this.subcase;
     controller.confidential = this.confidential;
+
     controller.hasConfidentialPieces = this.hasConfidentialPieces;
+    controller.currentLinkedMandatee = this.currentLinkedMandatee;
     controller.previousMandateePersons = this.previousMandateePersons;
-    controller.approvalAddresses = _model.approvalAddresses;
-    controller.notificationAddresses = _model.notificationAddresses;
-    controller.approvalComment = _model.approvalComment;
-    controller.notificationComment = _model.notificationComment;
+
+    controller.subcase = this.subcase;
   }
 }

--- a/app/routes/cases/submissions/submission.js
+++ b/app/routes/cases/submissions/submission.js
@@ -83,6 +83,7 @@ export default class CasesSubmissionsSubmissionRoute extends Route {
     }
 
     this.confidential = submission.confidential;
+    await submission.hasMany('pieces').reload();
     const newPieces = await submission.pieces;
     this.hasConfidentialPieces = await containsConfidentialPieces(newPieces.slice());
     let pieces = [];

--- a/app/routes/document.js
+++ b/app/routes/document.js
@@ -66,7 +66,6 @@ export default class DocumentRoute extends Route {
 
   resetController(controller, isExiting) {
     if (isExiting) {
-      controller.isSigning = false;
       controller.tab = 'details';
     }
   }

--- a/app/routes/publications/overview.js
+++ b/app/routes/publications/overview.js
@@ -1,0 +1,9 @@
+import Route from '@ember/routing/route';
+
+export default class PublicationsOverviewRoute extends Route {
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.isShowPublicationModal = false;
+    }
+  }
+}

--- a/app/routes/publications/publication/decisions/index.js
+++ b/app/routes/publications/publication/decisions/index.js
@@ -32,4 +32,10 @@ export default class PublicationsPublicationDecisionsIndexRoute extends Route {
     ctrl.publicationFlow = this.publicationFlow;
     ctrl.isViaCouncilOfMinisters = this.isViaCouncilOfMinisters;
   }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.isOpenReferenceDocumentUploadModal = false;
+    }
+  }
 }

--- a/app/routes/publications/publication/proofs/index.js
+++ b/app/routes/publications/publication/proofs/index.js
@@ -112,4 +112,11 @@ export default class PublicationsPublicationProofsRoute extends Route {
     controller.publicationSubcase = this.publicationSubcase;
     controller.publicationActivitiesCount = this.publicationActivitiesCount;
   }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.showProofUploadModal = false;
+      controller.showProofRequestModal = false;
+    }
+  }
 }

--- a/app/routes/publications/publication/publication-activities/index.js
+++ b/app/routes/publications/publication/publication-activities/index.js
@@ -93,6 +93,13 @@ export default class PublicationsPublicationPublicationActivitiesIndexRoute exte
     controller.publicationSubcase = this.publicationSubcase;
   }
 
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      this.isOpenRequestModal = false;
+      this.isOpenRegistrationModal = false;
+    }
+  }
+
   @action
   refresh() {
     // We want to refresh our own route + parent route which has the info panel

--- a/app/routes/publications/publication/publication-activities/index.js
+++ b/app/routes/publications/publication/publication-activities/index.js
@@ -95,8 +95,8 @@ export default class PublicationsPublicationPublicationActivitiesIndexRoute exte
 
   resetController(controller, isExiting) {
     if (isExiting) {
-      this.isOpenRequestModal = false;
-      this.isOpenRegistrationModal = false;
+      controller.isOpenRequestModal = false;
+      controller.isOpenRegistrationModal = false;
     }
   }
 

--- a/app/routes/publications/publication/translations/index.js
+++ b/app/routes/publications/publication/translations/index.js
@@ -104,4 +104,11 @@ export default class PublicationsPublicationTranslationsIndexRoute extends Route
     controller.publicationFlow = this.publicationFlow;
     controller.translationSubcase = this.translationSubcase;
   }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.showTranslationUploadModal = false;
+      controller.showTranslationRequestModal = false;
+    }
+  }
 }

--- a/app/routes/settings/organizations/index.js
+++ b/app/routes/settings/organizations/index.js
@@ -85,6 +85,15 @@ export default class SettingsOrganizationsIndexRoute extends Route {
     controller.loadSelectedOrganizations.perform();
   }
 
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.organizationBeingBlocked = null;
+
+      controller.showBlockOrganizationConfirmationModal = false;
+      controller.showUnblockOrganizationConfirmationModal = false;
+    }
+  }
+
   @action
   loading(transition) {
     // eslint-disable-next-line ember/no-controller-access-in-routes

--- a/app/routes/settings/organizations/index.js
+++ b/app/routes/settings/organizations/index.js
@@ -88,7 +88,6 @@ export default class SettingsOrganizationsIndexRoute extends Route {
   resetController(controller, isExiting) {
     if (isExiting) {
       controller.organizationBeingBlocked = null;
-
       controller.showBlockOrganizationConfirmationModal = false;
       controller.showUnblockOrganizationConfirmationModal = false;
     }

--- a/app/routes/settings/organizations/organization.js
+++ b/app/routes/settings/organizations/organization.js
@@ -18,4 +18,14 @@ export default class SettingsOrganizationsOrganizationRoute extends Route {
     super.setupController(...arguments);
     controller.linkedMandatees = this.linkedMandatees;
   }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.mandateeBeingUnlinked = null;
+      controller.showBlockOrganization = false;
+      controller.showUnblockOrganization = false;
+      controller.showUnlinkMandatee = false;
+      controller.showSelectMandateeModal = false;
+    }
+  }
 }

--- a/app/routes/settings/system-alerts/index.js
+++ b/app/routes/settings/system-alerts/index.js
@@ -7,4 +7,10 @@ export default class SystemAlertsRoute extends Route {
   model() {
     return this.store.findAll('alert');
   }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.selectedAlert = null;
+    }
+  }
 }

--- a/app/routes/settings/users/index.js
+++ b/app/routes/settings/users/index.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 import { isPresent } from '@ember/utils';
 import { inject as service } from '@ember/service';
+import { TrackedArray } from 'tracked-built-ins';
 import Snapshot from 'frontend-kaleidos/utils/snapshot';
 import parseDate from 'frontend-kaleidos/utils/parse-date-search-param';
 import startOfDay from 'date-fns/startOfDay';
@@ -125,6 +126,18 @@ export default class SettingsUsersIndexRoute extends Route {
     controller.dateToBuffer = parseDate(this.lastParams.committed.dateTo);
     controller.loadSelectedOrganizations.perform();
     controller.loadSelectedRoles.perform();
+  }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.userBeingBlocked = null;
+      controller.membershipsBeingBlocked = new TrackedArray([]);
+
+      controller.showBlockMembershipsConfirmationModal = false;
+      controller.showBlockUserConfirmationModal = false;
+      controller.showUnblockMembershipsConfirmationModal = false;
+      controller.showUnblockUserConfirmationModal = false;
+    }
   }
 
   @action

--- a/app/routes/settings/users/user.js
+++ b/app/routes/settings/users/user.js
@@ -18,4 +18,14 @@ export default class SettingsUsersUserRoute extends Route {
     super.setupController(controller, model);
     controller.selectedPerson = model.person;
   }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.membershipBeingBlocked = null;
+      controller.showBlockUser = false;
+      controller.showUnblockUser = false;
+      controller.showBlockMembership = false;
+      controller.showUnblockMembership = false;
+    }
+  }
 }

--- a/app/routes/signatures/decisions.js
+++ b/app/routes/signatures/decisions.js
@@ -88,12 +88,6 @@ export default class SignaturesDecisionsRoute extends Route {
 
   resetController(controller, isExiting) {
     if (isExiting) {
-      controller.closeSidebar();
-    }
-  }
-
-  resetController(controller, isExiting) {
-    if (isExiting) {
       controller.showSidebar = false;
       controller.piece = null;
       controller.decisionActivity = null;

--- a/app/routes/signatures/decisions.js
+++ b/app/routes/signatures/decisions.js
@@ -88,6 +88,12 @@ export default class SignaturesDecisionsRoute extends Route {
 
   resetController(controller, isExiting) {
     if (isExiting) {
+      controller.closeSidebar();
+    }
+  }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
       controller.showSidebar = false;
       controller.piece = null;
       controller.decisionActivity = null;

--- a/cypress/e2e/unit/session-kind.cy.js
+++ b/cypress/e2e/unit/session-kind.cy.js
@@ -87,7 +87,10 @@ context('Different session kinds should show different titles', () => {
     cy.intercept('GET', '/concepts?filter**').as('loadConcepts');
 
     cy.createAgenda(null, agendaDate, null, agendaNumber);
-    // set kind to PVV
+    // wait for refresh/setup/reset of controller
+    cy.get(route.agendasOverview.dataTable).contains('Aan het laden');
+    cy.get(route.agendasOverview.dataTable).should('not.contain', 'Aan het laden');
+    // make PVV agenda
     cy.get(route.agendas.action.newMeeting).click();
     cy.get(utils.kindSelector.kind).click();
     cy.selectFromDropdown(vvKind);


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4897

In deze ticket ben ik door alle controllers in de app gegaan en waar mogelijk kleine issues met het resetten van de controllers rechtgezet. Het ging voornamelijk over kleine dingen zoals modals die open bleven staan en `thing = store.createRecord()` die niet verwijderd worden.

Dit laatste doen we ook in componenten en daar zouden we dat ook moeten opkuisen, maar dat is misschien voor een andere ticket.

De eigenlijke issue die in de ticket beschreven werd is in f1209186273159b35c4a79362bd29065b5f7cfee gefixt geweest met (zoals Sven al aangaf in de comments van de ticket) een `reload()`. Eigenlijk is dat ook het enige dat écht gemerged "moet" worden.