### PR TITLE
KAS-4959: Deprecation warning oplossen rond 'outputPaths' en Embroider

### DIFF
--- a/app/templates/styleguide.hbs
+++ b/app/templates/styleguide.hbs
@@ -4,7 +4,7 @@
 <link
   integrity=""
   rel="stylesheet"
-  href="/assets/styleguide.css"
+  href="/assets/styleguide/styleguide.css"
 >
 
 <div class="br-styleguide-columns">

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,6 +3,7 @@
 /* eslint-disable */
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 const webpack = require('webpack');
+const compileSass = require('broccoli-sass-source-maps')(require('sass'));
 
 module.exports = async function (defaults) {
   const { setConfig } = await import('@warp-drive/build-config');
@@ -24,13 +25,6 @@ module.exports = async function (defaults) {
     flatpickr: {
       locales: ['nl'],
     },
-    outputPaths: {
-      app: {
-        css: {
-          'styleguide': '/assets/styleguide.css'
-        }
-      }
-    },
     'ember-simple-auth': {
       useSessionSetupMethod: true,
     },
@@ -43,7 +37,7 @@ module.exports = async function (defaults) {
     'ember-test-selectors': {
       strip: false
     },
-    //polyfill for insecure context (like cypress on jenkins) https://github.com/emberjs/data/tree/v5.0.0?tab=readme-ov-file#randomuuid-polyfill
+    // polyfill for insecure context (like cypress on jenkins) https://github.com/emberjs/data/tree/v5.0.0?tab=readme-ov-file#randomuuid-polyfill
     '@embroider/macros': {
       setConfig: {
         '@ember-data/store': {
@@ -79,5 +73,17 @@ module.exports = async function (defaults) {
     ],
   });
 
-  return app.toTree();
+  // instead of using `outputPaths` for building the styleguide CSS (which is deprecated now), we use a fork of `broccoli-sass` to do this
+  const styleguideCss = compileSass(
+    ['app/styles'],
+    'styleguide.scss',
+    'assets/styleguide/styleguide.css',
+    {
+      outputStyle: process.env.DEPLOY_ENV !== 'production' ? 'expanded' : 'compressed',
+      sourceMap: process.env.DEPLOY_ENV !== 'production',
+      sourceMapEmbed: process.env.DEPLOY_ENV !== 'production'
+    }
+  );
+
+  return app.toTree([styleguideCss]);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "alphabet": "^1.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "broccoli-funnel": "^3.0.8",
+        "broccoli-sass-source-maps": "^4.3.0",
         "cypress": "^12.17.4",
         "date-fns": "^2.29.3",
         "dayjs": "^1.11.13",
@@ -13317,7 +13318,9 @@
       }
     },
     "node_modules/broccoli-sass-source-maps": {
-      "version": "4.2.4",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/broccoli-sass-source-maps/-/broccoli-sass-source-maps-4.3.0.tgz",
+      "integrity": "sha512-t/YEueiFAOboCERQsH6J9RmifEDkqkoFjIB6owIeilpSbhJbNXj0FfzWcXnG/ahKYByHE4g3H7agHr2mtlJdDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "alphabet": "^1.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-funnel": "^3.0.8",
+    "broccoli-sass-source-maps": "^4.3.0",
     "cypress": "^12.17.4",
     "date-fns": "^2.29.3",
     "dayjs": "^1.11.13",


### PR DESCRIPTION
**Tickets binnen Jira:** 
- https://kanselarij.atlassian.net/browse/KAS-4959

⚠️ Moet op zich niet echt gereviewed worden, maar alle tests moeten wel volledig ok zijn om te weten dat er geen functionele impact is.