### PR TITLE
KAS-4897 add concurrency checks on submissions

### DIFF
--- a/app/components/submission/header.hbs
+++ b/app/components/submission/header.hbs
@@ -5,81 +5,83 @@
         <OnThisPageLinks @items={{this.items}} />
       </Auk::Toolbar::Item>
     </Auk::Toolbar::Group>
-    {{#if this.hasActions}}
-      <Auk::Toolbar::Group @position="right">
-        <AuDropdown
-          data-test-submission-header-actions
-          @skin="secondary"
-          @title={{t "actions"}}
-          @alignment="right"
-        >
-          {{#if this.canCreateSubcase}}
-            <AuButton
-              data-test-submission-header-action-create-subcase
-              @skin="naked"
-              {{on "click" (toggle "isOpenCreateSubcaseModal" this)}}
-            >
-              {{#if this.isUpdate}}
-                {{t "accept-update-and-put-on-agenda"}}
-              {{else}}
-                {{t "create-subcase-and-put-on-agenda"}}
-              {{/if}}
-            </AuButton>
-          {{/if}}
-          {{#if this.canTakeInTreatment}}
-            <AuButton
-              data-test-submission-header-action-take-in-treatment
-              @skin="naked"
-              @alert={{if this.isSendBackRequested true}}
-              {{on "click" this.takeInTreatment}}
-            >
-              {{t "take-in-treatment"}}
-            </AuButton>
-          {{/if}}
-          <AuHr/>
-          {{#if this.canSendBackToSubmitter}}
-            <AuButton
-              data-test-submission-header-action-send-back
-              @skin="naked"
-              @alert={{not this.isSendBackRequested}}
-              {{on "click" (toggle "isOpenSendBackModal" this)}}
-            >
-              {{t "send-back-to-submitter"}}
-            </AuButton>
-          {{/if}}
-          {{#if this.canDeleteSubmission}}
-            <AuButton
-              data-test-submission-header-action-delete
-              @skin="naked"
-              @alert={{true}}
-              {{on "click" (toggle "isOpenDeleteModal" this)}}
-            >
-              {{t "delete-submission"}}
-            </AuButton>
-          {{/if}}
-        </AuDropdown>
-      </Auk::Toolbar::Group>
+    {{#if (not this.areTasksRunning)}}
+      {{#if this.hasActions}}
+        <Auk::Toolbar::Group @position="right">
+          <AuDropdown
+            data-test-submission-header-actions
+            @skin="secondary"
+            @title={{t "actions"}}
+            @alignment="right"
+          >
+            {{#if this.canCreateSubcase}}
+              <AuButton
+                data-test-submission-header-action-create-subcase
+                @skin="naked"
+                {{on "click" (toggle "isOpenCreateSubcaseModal" this)}}
+              >
+                {{#if this.isUpdate}}
+                  {{t "accept-update-and-put-on-agenda"}}
+                {{else}}
+                  {{t "create-subcase-and-put-on-agenda"}}
+                {{/if}}
+              </AuButton>
+            {{/if}}
+            {{#if this.canTakeInTreatment}}
+              <AuButton
+                data-test-submission-header-action-take-in-treatment
+                @skin="naked"
+                @alert={{if this.isSendBackRequested true}}
+                {{on "click" this.takeInTreatment.perform}}
+              >
+                {{t "take-in-treatment"}}
+              </AuButton>
+            {{/if}}
+            <AuHr/>
+            {{#if this.canSendBackToSubmitter}}
+              <AuButton
+                data-test-submission-header-action-send-back
+                @skin="naked"
+                @alert={{not this.isSendBackRequested}}
+                {{on "click" (toggle "isOpenSendBackModal" this)}}
+              >
+                {{t "send-back-to-submitter"}}
+              </AuButton>
+            {{/if}}
+            {{#if this.canDeleteSubmission}}
+              <AuButton
+                data-test-submission-header-action-delete
+                @skin="naked"
+                @alert={{true}}
+                {{on "click" (toggle "isOpenDeleteModal" this)}}
+              >
+                {{t "delete-submission"}}
+              </AuButton>
+            {{/if}}
+          </AuDropdown>
+        </Auk::Toolbar::Group>
+      {{/if}}
+      <AuButtonGroup>
+        {{#if this.canResubmitSubmission}}
+          <AuButton
+            data-test-submission-header-action-resubmit
+            @skin="primary"
+            {{on "click" (toggle "isOpenResubmitModal" this)}}
+          >
+            {{t "resubmit-submission"}}
+          </AuButton>
+        {{/if}}
+        {{#if this.canRequestSendBack}}
+          <AuButton
+            data-test-submission-header-action-request-send-back
+            @skin="primary"
+            {{on "click" this.openRequestSendBackModal}}
+          >
+            {{t "request-send-back-submission"}}
+          </AuButton>
+        {{/if}}
+      </AuButtonGroup>
     {{/if}}
-    <AuButtonGroup>
-      {{#if this.canResubmitSubmission}}
-        <AuButton
-          data-test-submission-header-action-resubmit
-          @skin="primary"
-          {{on "click" (toggle "isOpenResubmitModal" this)}}
-        >
-          {{t "resubmit-submission"}}
-        </AuButton>
-      {{/if}}
-      {{#if this.canRequestSendBack}}
-        <AuButton
-          data-test-submission-header-action-request-send-back
-          @skin="primary"
-          {{on "click" (toggle "isOpenRequestSendBackModal" this)}}
-        >
-          {{t "request-send-back-submission"}}
-        </AuButton>
-      {{/if}}
-    </AuButtonGroup>
   </Auk::Toolbar>
 </Auk::Navbar>
 
@@ -177,7 +179,17 @@
   @loading={{this.deleteSubmission.isRunning}}
   @disabled={{this.createSubcase.isRunning}}
   @message={{t "delete-submission-confirmation"}}
-/>
+  @confirmMessage={{t "delete-submission"}}
+>
+  <:body>
+    <AuAlert
+      @skin="error"
+      @icon="alert-triangle"
+    >
+      <p>{{t "delete-submission-confirmation"}}</p>
+    </AuAlert>
+  </:body>
+</ConfirmationModal>
 
 {{#if this.createSubcase.isRunning}}
   <Auk::Modal @size="medium">

--- a/app/components/submission/header.js
+++ b/app/components/submission/header.js
@@ -466,7 +466,7 @@ export default class SubmissionHeaderComponent extends Component {
         this.intl.t('submission-has-send-back-requested-after-reload'),
         this.intl.t('warning-title'),
         {
-          timeOut: 10000,
+          timeOut: 60000,
         }
       );
     }

--- a/app/components/submission/header.js
+++ b/app/components/submission/header.js
@@ -163,6 +163,17 @@ export default class SubmissionHeaderComponent extends Component {
     );
   }
 
+  get areTasksRunning() {
+    return (
+      this.takeInTreatment.isRunning ||
+      this.resubmitSubmission.isRunning ||
+      this.createSubcase.isRunning ||
+      this.sendBackToSubmitter.isRunning ||
+      this.deleteSubmission.isRunning ||
+      this.requestSendBackToSubmitter.isRunning
+    );
+  }
+
   get isSendBackRequested() {
     return this.args.submission?.isSendBackRequested;
   }
@@ -204,6 +215,13 @@ export default class SubmissionHeaderComponent extends Component {
   // In case of an update, the modal passes no parameters through,
   // so we just have to use the members of the component.
   resubmitSubmission = task(async (meeting, remarks) => {
+    await this.args.submission.belongsTo('status').reload();
+    if (!this.canResubmitSubmission) {
+      return this.toaster.error(
+        this.intl.t('submission-edited-concurrently'),
+        this.intl.t('warning-title')
+      );
+    }
     this.toggleResubmitModal();
     const selectedMeeting = meeting?.id ? meeting : this.selectedMeeting;
     const comment = meeting?.id ? remarks : this.comment;
@@ -287,6 +305,21 @@ export default class SubmissionHeaderComponent extends Component {
       formallyStatusUri,
       privateComment = null
     ) => {
+      // concurrency check with submission acceptors:
+      // concurrency shouldn't happen here since only 1 person should be able to edit a submission in this stage
+      // in reality any admin can accept a submission regardless of that and 1 non admin user could use 2 browser tabs
+      // so it remains possible to have concurrency here.
+      // we could check the modified date on submission here like we do for agendaitems and subcases
+      // internalReview already has a concurrency check on edit but happens after we saved some case data so not ideal.
+      // since status is that last thing to update, we hit internalReview concurrency before that in some cases
+      // this check will only work when the action was fully completed for the other user
+      await this.args.submission.belongsTo('status').reload();
+      if (!this.canCreateSubcase) {
+        return this.toaster.error(
+          this.intl.t('submission-edited-concurrently'),
+          this.intl.t('warning-title')
+        );
+      }
       this.toggleCreateSubcaseModal();
       const now = new Date();
       const trimmedShortTitle = trimText(this.args.submission.shortTitle);
@@ -422,7 +455,28 @@ export default class SubmissionHeaderComponent extends Component {
     }
   );
 
-  takeInTreatment = async () => {
+  takeInTreatment = task(async () => {
+    // concurrency with submission creators
+    const statusBeforeReload = this.args.submission?.isSendBackRequested;
+    await this.args.submission.belongsTo('status').reload();
+    const statusAfterReload = this.args.submission?.isSendBackRequested;
+    if (statusBeforeReload !== statusAfterReload && statusAfterReload) {
+      // ok to proceed with treatment but notify a request was made
+      this.toaster.warning(
+        this.intl.t('submission-has-send-back-requested-after-reload'),
+        this.intl.t('warning-title'),
+        {
+          timeOut: 10000,
+        }
+      );
+    }
+    // concurrency with submission acceptors, full stop here
+    if (!this.canTakeInTreatment) {
+      return this.toaster.error(
+        this.intl.t('submission-edited-concurrently'),
+        this.intl.t('warning-title')
+      );
+    }
     const subcase = await this.args.submission.subcase;
     if (subcase?.id) {
       const subcaseType = await subcase.type;
@@ -437,7 +491,7 @@ export default class SubmissionHeaderComponent extends Component {
     if (isPresent(this.args.onStatusUpdated)) {
       this.args.onStatusUpdated();
     }
-  };
+  });
 
   createOrUpdateInternalReview = async () => {
     // Do we have a subcase already?
@@ -476,6 +530,13 @@ export default class SubmissionHeaderComponent extends Component {
   };
 
   sendBackToSubmitter = task(async () => {
+    await this.args.submission.belongsTo('status').reload();
+    if (!this.canSendBackToSubmitter) {
+      return this.toaster.error(
+        this.intl.t('submission-edited-concurrently'),
+        this.intl.t('warning-title')
+      );
+    }
     await this._updateSubmission(
       CONSTANTS.SUBMISSION_STATUSES.TERUGGESTUURD,
       this.comment
@@ -491,6 +552,17 @@ export default class SubmissionHeaderComponent extends Component {
   });
 
   deleteSubmission = task(async () => {
+    const statusBefore = await this.args.submission.status;
+    const statusAfter = await this.args.submission.belongsTo('status').reload();
+    // since this based is based on a permission without status check
+    // this.canDeleteSubmission will always be true if you have the permission
+    // to slow down deletion, we can check if someone has recently changed the status and stop if true.
+    if (statusBefore.id !== statusAfter.id) {
+      return this.toaster.error(
+        this.intl.t('submission-edited-concurrently'),
+        this.intl.t('warning-title')
+      );
+    }
     const pieces = await this.args.submission.pieces;
     await Promise.all(pieces.map(async (piece) => deletePiece(piece)));
 
@@ -504,7 +576,28 @@ export default class SubmissionHeaderComponent extends Component {
     await this.router.transitionTo('submissions');
   });
 
+  openRequestSendBackModal = async() => {
+    if (await this.verifyCanRequestSendBack()) {
+      this.toggleRequestSendBackModal();
+    }
+  };
+
+  verifyCanRequestSendBack = async() => {
+    // concurrency check
+    await this.args.submission.belongsTo('status').reload();
+    if (!this.canRequestSendBack) {
+      this.toaster.error(
+        this.intl.t('submission-already-in-treatment'),
+        this.intl.t('submission-already-in-treatment-title')
+      );
+    }
+    return this.canRequestSendBack;
+  };
+
   requestSendBackToSubmitter = task(async () => {
+    if (!(await this.verifyCanRequestSendBack())) {
+      return;
+    }
     await this._updateSubmission(
       CONSTANTS.SUBMISSION_STATUSES.AANPASSING_AANGEVRAAGD,
       this.comment

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1499,8 +1499,8 @@
   "empty-internal-review": "Interne opmerkingen leegmaken",
   "empty-internal-review-message": "Bent u zeker dat u alle interne opmerkingen voor de goedgekeurde agendapunten op deze agenda wil leegmaken?\nDeze actie kan niet ongedaan worden gemaakt.\nDe interne opmerkingen van nieuwe agendapunten blijven ongewijzigd.",
   "annex-meeting-was-saved": "De annex vergadering {title} is aangepast. Verifieer of de ID van de vergadering, de beslissingen en notulen nog up-to-date zijn, en pas deze zo nodig aan.",
-  "submission-already-in-treatment": "Deze indiening is reeds in behandeling genomen, aanpassingen aanvragen is niet meer mogelijk.",
+  "submission-already-in-treatment": "Deze indiening is reeds in behandeling genomen, aanpassingen aanvragen is niet meer mogelijk via Kaleidos.",
   "submission-already-in-treatment-title": "Aanpassingen aanvragen is niet meer mogelijk.",
-  "submission-has-send-back-requested-after-reload": "Er is ondertussen een aanpassing aangevraagd. Controleer deze vooraleer de indiening te aanvaarden.",
+  "submission-has-send-back-requested-after-reload": "Er is een aanpassing aangevraagd sinds het openen van deze pagina en het in behandeling nemen. Controleer de aanvraag vooraleer de indiening te aanvaarden.",
   "submission-edited-concurrently": "Deze indiening is recent door iemand anders bewerkt. Noteer je wijzigingen en hernieuw deze pagina om de laatste aanpassingen te zien."
 }

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1451,7 +1451,7 @@
   "submit-new-case": "Nieuw agendapunt indienen",
   "submit-new-agendaitem": "Nieuw agendapunt indienen",
   "open-current-submission": "Open huidige indiening",
-  "delete-submission-confirmation": "Bent u zeker dat u de indiening wilt verwijderen?",
+  "delete-submission-confirmation": "Bent u zeker dat u de indiening wilt verwijderen? Deze actie kan niet ongedaan gemaakt worden.",
   "document-naming--toast-generating--message": "De VR nummers worden toegepast.",
   "error-while-fetching-document-naming-mapping": "Er ging iets fout tijdens het berekenen van de VR nummers.",
   "no-document-naming-needed": "Er zijn geen nieuwe documenten om te nummeren voor deze agenda.",
@@ -1498,5 +1498,9 @@
   "show-definitive-cases-only": "Toon enkel dossiers zonder definitieve goedkeuring",
   "empty-internal-review": "Interne opmerkingen leegmaken",
   "empty-internal-review-message": "Bent u zeker dat u alle interne opmerkingen voor de goedgekeurde agendapunten op deze agenda wil leegmaken?\nDeze actie kan niet ongedaan worden gemaakt.\nDe interne opmerkingen van nieuwe agendapunten blijven ongewijzigd.",
-  "annex-meeting-was-saved": "De annex vergadering {title} is aangepast. Verifieer of de ID van de vergadering, de beslissingen en notulen nog up-to-date zijn, en pas deze zo nodig aan."
+  "annex-meeting-was-saved": "De annex vergadering {title} is aangepast. Verifieer of de ID van de vergadering, de beslissingen en notulen nog up-to-date zijn, en pas deze zo nodig aan.",
+  "submission-already-in-treatment": "Deze indiening is reeds in behandeling genomen, aanpassingen aanvragen is niet meer mogelijk.",
+  "submission-already-in-treatment-title": "Aanpassingen aanvragen is niet meer mogelijk.",
+  "submission-has-send-back-requested-after-reload": "Er is ondertussen een aanpassing aangevraagd. Controleer deze vooraleer de indiening te aanvaarden.",
+  "submission-edited-concurrently": "Deze indiening is recent door iemand anders bewerkt. Noteer je wijzigingen en hernieuw deze pagina om de laatste aanpassingen te zien."
 }


### PR DESCRIPTION
## :warning:  started from ACCEPTANCE 

https://kanselarij.atlassian.net/browse/KAS-4987

ticket stated concurrency check on request send back :white_check_mark:   
Also implemented concurrency checks on the other actions.
In short, when submission status is updated > other tabs that try to do an action will pick this up and stop with a warning (1 exception)
Right now I don't have any follow up. 
The refresh of only status does mean you already get to see the status, but we don't enforce users to refresh the page so you don't see all the changes yet.
It's possible to enforce something like that but felt even more out of scope.
