### PR TITLE
KAS-4983: Disable clearing document type in selector

### DIFF
--- a/app/components/utils/document-type-selector.hbs
+++ b/app/components/utils/document-type-selector.hbs
@@ -9,7 +9,6 @@
     @selected={{@selectedDocumentType}}
     @onChange={{@onChange}}
     @disabled={{@disabled}}
-    @allowClear={{true}}
     @renderInPlace={{@renderInPlace}}
     @searchField="altLabel"
     @searchEnabled={{true}}


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4983

All documents in Kaleidos should have a type anyway, so by disabling this we prevent users from accidentally removing a document's type.