### PR TITLE
KAS-4986 add update to uploaded draft-pieces on toggl confidential

### DIFF
--- a/app/components/cases/submissions/document-upload-panel.hbs
+++ b/app/components/cases/submissions/document-upload-panel.hbs
@@ -2,7 +2,9 @@
   <Auk::Panel::Header class="au-u-background-gray-100">
     <h4 class="auk-panel__title">{{t "documents"}}</h4>
   </Auk::Panel::Header>
-  <Auk::Panel::Body>
+  <Auk::Panel::Body
+    {{did-update (perform this.onDidUpdate) @confidential}}
+  >
     <Auk::FileUploader
       @isSubmission={{true}}
       @multiple={{true}}

--- a/app/components/cases/submissions/document-upload-panel.js
+++ b/app/components/cases/submissions/document-upload-panel.js
@@ -9,6 +9,8 @@ import CONSTANTS from 'frontend-kaleidos/config/constants';
 export default class CasesSubmissionsDocumentUploadPanelComponent extends Component {
   @service store;
   @service conceptStore;
+  @service toaster;
+  @service intl;
 
   @action
   async uploadPiece(file) {
@@ -43,4 +45,30 @@ export default class CasesSubmissionsDocumentUploadPanelComponent extends Compon
   *deletePiece(piece) {
     yield this.args.onDeletePiece(piece);
   }
+
+  onDidUpdate = task(async () => {
+    if (this.args.confidential && this.args.pieces.length) {
+      // Strengthen the accessLevel of the draft-pieces to vertrouwelijk
+      const confidentialAccessLevel = await this.store.findRecordByUri(
+        'concept',
+        CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK,
+      );
+
+      let changedAccessLevelOfPieces = false;
+      const promises = this.args.pieces.map(async (piece) => {
+        const accessLevel = await piece.accessLevel;
+        if (accessLevel.uri != confidentialAccessLevel.uri) {
+          // pieces are not persisted yet in the store at this point
+          piece.accessLevel = confidentialAccessLevel;
+          changedAccessLevelOfPieces = true;
+        }
+      });
+      await Promise.all(promises);
+      if (changedAccessLevelOfPieces) {
+        this.toaster.success(
+          this.intl.t('uploaded-pieces-access-level-changed'),
+        );
+      }
+    }
+  });
 }

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1502,5 +1502,6 @@
   "submission-already-in-treatment": "De kanselarij heeft je indiening in behandeling genomen. Je kunt via Kaleidos geen aanpassing meer aanvragen. Neem contact op met de kanselarij via e-mail: ministerraad@vlaanderen.be.",
   "submission-already-in-treatment-title": "Aanpassingen aanvragen is niet meer mogelijk.",
   "submission-has-send-back-requested-after-reload": "Er is een aanpassing aangevraagd sinds het openen van deze pagina en het in behandeling nemen. Controleer de aanvraag vooraleer de indiening te aanvaarden.",
-  "submission-edited-concurrently": "Deze indiening is recent door iemand anders bewerkt. Noteer je wijzigingen en hernieuw deze pagina om de laatste aanpassingen te zien."
+  "submission-edited-concurrently": "Deze indiening is recent door iemand anders bewerkt. Noteer je wijzigingen en hernieuw deze pagina om de laatste aanpassingen te zien.",
+  "uploaded-pieces-access-level-changed": "De rechten van de reeds opgeladen documenten werden aangepast"
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4986

- added code to change accessLevel on draft piece when toggling confidential (only in new submissions form)
(we have a new subcase form where we have a similar process, not implement there)
- Made it so the toast doesn't "spam" when toggling on/off/on/off. only show toast when we did something
- This action happens on unpersisted pieces, so `piece.save()` is not needed. This also means this action is nearly instant (tested it with 100 docs, blink and you miss it happening)
- the success toaster has a default timeout (3,2 seconds). wanted to make it longer (and closable) but the default seems ok so left it alone.