### PR TITLE
KAS-4984: Update decision code after changing agenda item type

### DIFF
--- a/app/components/subcase/bekrachtiging-description-panel/edit.hbs
+++ b/app/components/subcase/bekrachtiging-description-panel/edit.hbs
@@ -19,7 +19,7 @@
             <AuRadioGroup
               @alignment="inline"
               @selected={{this.agendaItemType}}
-              @onChange={{this.onChangeAgendaItemType}}
+              @disabled={{true}}
               as |Group|
             >
               {{#each this.agendaItemTypes as |type|}}

--- a/app/components/subcase/bekrachtiging-description-panel/edit.js
+++ b/app/components/subcase/bekrachtiging-description-panel/edit.js
@@ -48,8 +48,12 @@ export default class SubcaseBekrachtigingDescriptionPanelEdit extends Component 
 
   @task
   *loadAgendaItemTypes() {
-    this.agendaItemTypes = yield this.conceptStore.queryAllByConceptScheme(
+    const allAgendaItemTypes = yield this.conceptStore.queryAllByConceptScheme(
       CONSTANTS.CONCEPT_SCHEMES.AGENDA_ITEM_TYPES
+    );
+    // ratification can only be NOTA, subcase type should be changed first (will open different edit modal)
+    this.agendaItemTypes = allAgendaItemTypes.filter(
+      (type) => type.uri !== CONSTANTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT
     );
   }
 
@@ -94,7 +98,6 @@ export default class SubcaseBekrachtigingDescriptionPanelEdit extends Component 
     const propertiesToSetOnAgendaitem = {
       title: trimmedTitle,
       shortTitle: trimmedShortTitle,
-      type: this.agendaItemType,
     };
 
     const propertiesToSetOnSubCase = {
@@ -102,9 +105,7 @@ export default class SubcaseBekrachtigingDescriptionPanelEdit extends Component 
       shortTitle: trimmedShortTitle,
       subcaseName: this.subcaseName,
       type: this.subcaseType,
-      agendaItemType: this.agendaItemType,
     };
-    const oldAgendaItemType = await this.args.subcase.agendaItemType;
     await this.agendaitemAndSubcasePropertiesSync.saveChanges(
       this.args.subcase,
       propertiesToSetOnAgendaitem,
@@ -112,72 +113,16 @@ export default class SubcaseBekrachtigingDescriptionPanelEdit extends Component 
       resetFormallyOk
     );
 
+    // TODO ratifications shouldn't realistically be confidential, maybe disable the selector
     if (this.confidentialChanged && this.args.subcase.confidential) {
       await this.pieceAccessLevelService.updateDecisionsAccessLevelOfSubcase(this.args.subcase);
       await this.pieceAccessLevelService.updateSubmissionAccessLevelOfSubcase(this.args.subcase);
       await this.updateNewsItem.perform();
-    }
-
-    if (this.agendaItemType.uri !== oldAgendaItemType.uri) {
-      await this.updateNewsletterAfterRemarkChange();
-      await this.updateDecisionReports();
+      // TODO if this change is possible > regenerate report
     }
 
     this.args.onSave();
 
     this.isSaving = false;
-  }
-
-  async updateDecisionReports() {
-    const reports = await this.store.queryAll('report', {
-      'filter[decision-activity][subcase][:id:]': this.args.subcase.id,
-      'filter[:has-no:next-piece]': true,
-      sort: '-created',
-    });
-    for (const report of reports.slice()) {
-      const pieceParts = await report?.pieceParts;
-      if (pieceParts?.length) {
-        this.updateReportName(report, this.agendaItemType.uri);
-        await report.belongsTo('file').reload();
-        await report.save();
-        await this.decisionReportGeneration.generateReplacementReport.perform(
-          report
-        );
-      }
-    }
-  }
-
-  updateReportName(report, agendaitemTypeUri) {
-    if (agendaitemTypeUri === CONSTANTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT) {
-      report.name = report.name.replace('punt', 'mededeling');
-    } else {
-      report.name = report.name.replace('mededeling', 'punt');
-    }
-  }
-
-  async updateNewsletterAfterRemarkChange() {
-    const latestAgendaitem = await this.store.queryOne('agendaitem', {
-      'filter[agenda-activity][subcase][:id:]': this.args.subcase.id,
-      'filter[:has-no:next-version]': 't',
-      sort: '-created',
-    });
-    if (latestAgendaitem) {
-      const newsItem = await this.store.queryOne('news-item', {
-        'filter[agenda-item-treatment][agendaitems][:id:]': latestAgendaitem.id,
-      });
-      if (newsItem?.id) {
-        await newsItem.destroyRecord();
-      }
-      if (
-        this.agendaItemType.uri === CONSTANTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT
-      ) {
-        const newNewsItem =
-          await this.newsletterService.createNewsItemForAgendaitem(
-            latestAgendaitem,
-            true
-          );
-        await newNewsItem.save();
-      }
-    }
   }
 }

--- a/app/components/subcase/bekrachtiging-description-panel/edit.js
+++ b/app/components/subcase/bekrachtiging-description-panel/edit.js
@@ -113,12 +113,12 @@ export default class SubcaseBekrachtigingDescriptionPanelEdit extends Component 
       resetFormallyOk
     );
 
-    // TODO ratifications shouldn't realistically be confidential, maybe disable the selector
+    // ratifications shouldn't realistically be confidential
     if (this.confidentialChanged && this.args.subcase.confidential) {
       await this.pieceAccessLevelService.updateDecisionsAccessLevelOfSubcase(this.args.subcase);
       await this.pieceAccessLevelService.updateSubmissionAccessLevelOfSubcase(this.args.subcase);
       await this.updateNewsItem.perform();
-      // TODO if this change is possible > regenerate report
+      // we do not regenerate report in this case, shouldn't really happen
     }
 
     this.args.onSave();

--- a/app/components/subcase/bekrachtiging-description-panel/edit.js
+++ b/app/components/subcase/bekrachtiging-description-panel/edit.js
@@ -14,7 +14,6 @@ export default class SubcaseBekrachtigingDescriptionPanelEdit extends Component 
    */
   @service store;
   @service conceptStore;
-  @service decisionReportGeneration;
   @service newsletterService;
   @service agendaitemAndSubcasePropertiesSync;
   @service pieceAccessLevelService;

--- a/app/components/subcase/description-panel/edit.js
+++ b/app/components/subcase/description-panel/edit.js
@@ -153,7 +153,6 @@ export default class SubcaseDescriptionEdit extends Component {
       propertiesToSetOnAgendaitem,
       propertiesToSetOnSubCase,
       resetFormallyOk,
-      agendaitemTypeChanged,
     );
 
     if (this.confidentialChanged && this.args.subcase.confidential) {

--- a/app/components/subcase/description-panel/edit.js
+++ b/app/components/subcase/description-panel/edit.js
@@ -152,7 +152,8 @@ export default class SubcaseDescriptionEdit extends Component {
       this.args.subcase,
       propertiesToSetOnAgendaitem,
       propertiesToSetOnSubCase,
-      resetFormallyOk
+      resetFormallyOk,
+      agendaitemTypeChanged,
     );
 
     if (this.confidentialChanged && this.args.subcase.confidential) {

--- a/app/components/subcase/description-panel/edit.js
+++ b/app/components/subcase/description-panel/edit.js
@@ -312,8 +312,8 @@ export default class SubcaseDescriptionEdit extends Component {
       && (!oldDecisionResultCode
         || oldDecisionResultCode.uri === CONSTANTS.DECISION_RESULT_CODE_URIS.GOEDGEKEURD)
     ) {
-      const kennisname = await this.store.findRecordByUri('concept', CONSTANTS.DECISION_RESULT_CODE_URIS.KENNISNAME);
-      decisionActivity.decisionResultCode = kennisname;
+      const acknowledgedResult = await this.store.findRecordByUri('concept', CONSTANTS.DECISION_RESULT_CODE_URIS.KENNISNAME);
+      decisionActivity.decisionResultCode = acknowledgedResult;
     }
     await decisionActivity.save();
   }

--- a/app/components/subcase/description-panel/edit.js
+++ b/app/components/subcase/description-panel/edit.js
@@ -241,6 +241,7 @@ export default class SubcaseDescriptionEdit extends Component {
         'filter[decision-activity][treatment][agendaitems][:id:]': agendaitem.id,
       });
       const pieceParts = await report?.pieceParts;
+      await this._resetDecisionActivityResultCode(agendaitem, !!report);
       if (pieceParts?.length) {
         this.updateReportName(
           report,
@@ -289,5 +290,32 @@ export default class SubcaseDescriptionEdit extends Component {
         await newNewsItem.save();
       }
     }
+  }
+  /**
+   * Resets the decision result of an agendaitem after its type has changed.
+   * This function expects to be called AFTER the updates have been persisted,
+   * thus agendaitem.type contains the NEW type.
+   * @param {Agendaitem} agendaitem 
+   */
+  async _resetDecisionActivityResultCode(agendaitem, hasReport) {
+    const treatment = await agendaitem.treatment;
+    const decisionActivity = await treatment.decisionActivity;
+    const oldDecisionResultCode = await decisionActivity.decisionResultCode;
+
+    if (
+      this.agendaItemType.uri === CONSTANTS.AGENDA_ITEM_TYPES.NOTA
+      && oldDecisionResultCode?.uri === CONSTANTS.DECISION_RESULT_CODE_URIS.KENNISNAME
+    ) {
+      const approvedResult = await this.store.findRecordByUri('concept', CONSTANTS.DECISION_RESULT_CODE_URIS.GOEDGEKEURD);
+      decisionActivity.decisionResultCode = hasReport? approvedResult : null;
+    } else if (
+      this.agendaItemType.uri === CONSTANTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT
+      && (!oldDecisionResultCode
+        || oldDecisionResultCode.uri === CONSTANTS.DECISION_RESULT_CODE_URIS.GOEDGEKEURD)
+    ) {
+      const kennisname = await this.store.findRecordByUri('concept', CONSTANTS.DECISION_RESULT_CODE_URIS.KENNISNAME);
+      decisionActivity.decisionResultCode = kennisname;
+    }
+    await decisionActivity.save();
   }
 }

--- a/app/services/agendaitem-and-subcase-properties-sync.js
+++ b/app/services/agendaitem-and-subcase-properties-sync.js
@@ -47,15 +47,12 @@ const setModifiedOnAgendaOfAgendaitem = async(agendaitem) => {
 export default class AgendaitemAndSubcasePropertiesSyncService extends Service {
   @service store;
 
-  async saveChanges(agendaitemOrSubcase, propertiesToSetOnAgendaitem, propertiesToSetOnSubcase, resetFormallyOk, agendaitemTypeChanged=false) {
+  async saveChanges(agendaitemOrSubcase, propertiesToSetOnAgendaitem, propertiesToSetOnSubcase, resetFormallyOk) {
     const item = agendaitemOrSubcase;
     const isAgendaitem = item.modelName === 'agendaitem';
 
-    let agendaitem = null;
-
     await item.preEditOrSaveCheck();
     if (isAgendaitem) {
-      agendaitem = item;
       const agenda = await item.agenda;
       const agendaStatus = await agenda.status;
       const agendaActivity = await item.agendaActivity;
@@ -87,43 +84,9 @@ export default class AgendaitemAndSubcasePropertiesSyncService extends Service {
         sort: '-agenda-activity.start-date,-created',
       });
       if (agendaitemOnDesignAgenda?.id) {
-        agendaitem = agendaitemOnDesignAgenda;
         await setNewPropertiesToModel(agendaitemOnDesignAgenda, propertiesToSetOnAgendaitem, resetFormallyOk);
         await setModifiedOnAgendaOfAgendaitem(agendaitemOnDesignAgenda);
       }
     }
-
-    if (agendaitem?.id && agendaitemTypeChanged) {
-      await this._resetDecisionActivityResultCode(agendaitem);
-    }
-  }
-
-
-  /**
-   * Resets the decision result of an agendaitem after its type has changed.
-   * This function expects to be called AFTER the updates have been persisted,
-   * thus agendaitem.type contains the NEW type.
-   * @param {Agendaitem} agendaitem 
-   */
-  async _resetDecisionActivityResultCode(agendaitem) {
-    const newType = await agendaitem.type;
-    const treatment = await agendaitem.treatment;
-    const decisionActivity = await treatment.decisionActivity;
-    const oldDecisionResultCode = await decisionActivity.decisionResultCode;
-
-    if (
-      newType.uri === CONSTANTS.AGENDA_ITEM_TYPES.NOTA
-      && oldDecisionResultCode?.uri === CONSTANTS.DECISION_RESULT_CODE_URIS.KENNISNAME
-    ) {
-      decisionActivity.decisionResultCode = null;
-    } else if (
-      newType.uri === CONSTANTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT
-      && (!oldDecisionResultCode
-        || oldDecisionResultCode.uri === CONSTANTS.DECISION_RESULT_CODE_URIS.GOEDGEKEURD)
-    ) {
-      const kennisname = await this.store.findRecordByUri('concept', CONSTANTS.DECISION_RESULT_CODE_URIS.KENNISNAME);
-      decisionActivity.decisionResultCode = kennisname;
-    }
-    await decisionActivity.save();
   }
 }

--- a/app/services/agendaitem-and-subcase-properties-sync.js
+++ b/app/services/agendaitem-and-subcase-properties-sync.js
@@ -47,12 +47,15 @@ const setModifiedOnAgendaOfAgendaitem = async(agendaitem) => {
 export default class AgendaitemAndSubcasePropertiesSyncService extends Service {
   @service store;
 
-  async saveChanges(agendaitemOrSubcase, propertiesToSetOnAgendaitem, propertiesToSetOnSubcase, resetFormallyOk) {
+  async saveChanges(agendaitemOrSubcase, propertiesToSetOnAgendaitem, propertiesToSetOnSubcase, resetFormallyOk, agendaitemTypeChanged=false) {
     const item = agendaitemOrSubcase;
     const isAgendaitem = item.modelName === 'agendaitem';
 
+    let agendaitem = null;
+
     await item.preEditOrSaveCheck();
     if (isAgendaitem) {
+      agendaitem = item;
       const agenda = await item.agenda;
       const agendaStatus = await agenda.status;
       const agendaActivity = await item.agendaActivity;
@@ -84,9 +87,43 @@ export default class AgendaitemAndSubcasePropertiesSyncService extends Service {
         sort: '-agenda-activity.start-date,-created',
       });
       if (agendaitemOnDesignAgenda?.id) {
+        agendaitem = agendaitemOnDesignAgenda;
         await setNewPropertiesToModel(agendaitemOnDesignAgenda, propertiesToSetOnAgendaitem, resetFormallyOk);
         await setModifiedOnAgendaOfAgendaitem(agendaitemOnDesignAgenda);
       }
     }
+
+    if (agendaitem?.id && agendaitemTypeChanged) {
+      await this._resetDecisionActivityResultCode(agendaitem);
+    }
+  }
+
+
+  /**
+   * Resets the decision result of an agendaitem after its type has changed.
+   * This function expects to be called AFTER the updates have been persisted,
+   * thus agendaitem.type contains the NEW type.
+   * @param {Agendaitem} agendaitem 
+   */
+  async _resetDecisionActivityResultCode(agendaitem) {
+    const newType = await agendaitem.type;
+    const treatment = await agendaitem.treatment;
+    const decisionActivity = await treatment.decisionActivity;
+    const oldDecisionResultCode = await decisionActivity.decisionResultCode;
+
+    if (
+      newType.uri === CONSTANTS.AGENDA_ITEM_TYPES.NOTA
+      && oldDecisionResultCode?.uri === CONSTANTS.DECISION_RESULT_CODE_URIS.KENNISNAME
+    ) {
+      decisionActivity.decisionResultCode = null;
+    } else if (
+      newType.uri === CONSTANTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT
+      && (!oldDecisionResultCode
+        || oldDecisionResultCode.uri === CONSTANTS.DECISION_RESULT_CODE_URIS.GOEDGEKEURD)
+    ) {
+      const kennisname = await this.store.findRecordByUri('concept', CONSTANTS.DECISION_RESULT_CODE_URIS.KENNISNAME);
+      decisionActivity.decisionResultCode = kennisname;
+    }
+    await decisionActivity.save();
   }
 }

--- a/cypress/support/commands/case-commands.js
+++ b/cypress/support/commands/case-commands.js
@@ -154,14 +154,14 @@ function addSubcaseViaModal(subcase) {
   });
 
   // Set the type
-  if (subcase.agendaitemType) {
+  if (subcase.agendaitemType && !subcase.ratification) {
     cy.get(appuniversum.radio).contains(subcase.agendaitemType)
       .scrollIntoView()
       .click();
   }
 
   // toggle confidential
-  if (subcase.confidential) {
+  if (subcase.confidential && !subcase.ratification) {
     cy.get(cases.newSubcaseForm.toggleConfidential).parent()
       .scrollIntoView()
       .click();


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4984

When changing the type of a subcase (and its agendaitem, but changing the type only happens from the subcase page), also reset the decision result code when applicable (i.e. when unset or when it's on "goedgekeurd"/"akte genomen").

Agendaitems which have been "ingetrokken" or "uitgesteld" will not get their decision result codes changed.