### PR TITLE
KAS-5019 implement limit on uploaded types by permission and allowed list

### DIFF
--- a/app/components/auk/file-uploader.hbs
+++ b/app/components/auk/file-uploader.hbs
@@ -50,6 +50,11 @@
       {{/if}}
     </div>
     {{#if (and (not this.uploadIsRunning) (not this.uploadIsCompleted))}}
+      {{#if @dropzoneMessage}}
+        <p>
+          {{t @dropzoneMessage}}
+        </p>
+      {{/if}}
       <p class="auk-u-text-muted">
         {{#if dropzone.active}}
           {{t "drop-text"}}

--- a/app/components/cases/submissions/document-upload-panel.hbs
+++ b/app/components/cases/submissions/document-upload-panel.hbs
@@ -11,6 +11,8 @@
       @reusable={{true}}
       @onUpload={{this.uploadPiece}}
       @onQueueUpdate={{@onFileQueueUpdate}}
+      @validateFile={{this.validateFile}}
+      @dropzoneMessage={{if (not (user-may "upload-any-submission-document-extension")) "submission-document-accepted-types"}}
     />
     <div class="upload-container">
       {{#each @pieces as |piece|}}

--- a/app/components/cases/submissions/document-upload-panel.js
+++ b/app/components/cases/submissions/document-upload-panel.js
@@ -11,6 +11,11 @@ export default class CasesSubmissionsDocumentUploadPanelComponent extends Compon
   @service conceptStore;
   @service toaster;
   @service intl;
+  @service draftSubmissionService;
+
+  validateFile = (file) => {
+    return this.draftSubmissionService.validateUploadedFile(file);
+  }
 
   @action
   async uploadPiece(file) {

--- a/app/components/documents/add-draft-document-card.hbs
+++ b/app/components/documents/add-draft-document-card.hbs
@@ -215,7 +215,13 @@
         @onAccessLevelChanged={{set this.newPiece.accessLevel "accessLevel"}}
       />
     {{else}}
-      <Auk::FileUploader @isSubmission={{true}} @multiple={{false}} @onUpload={{perform this.uploadPiece}} />
+      <Auk::FileUploader
+        @isSubmission={{true}}
+        @multiple={{false}}
+        @onUpload={{perform this.uploadPiece}}
+        @validateFile={{this.validateFile}}
+        @dropzoneMessage={{if (not (user-may "upload-any-submission-document-extension")) "submission-document-accepted-types"}}
+      />
     {{/if}}
   </:body>
 </ConfirmationModal>

--- a/app/components/documents/add-draft-document-card.js
+++ b/app/components/documents/add-draft-document-card.js
@@ -28,6 +28,7 @@ export default class DocumentsAddDraftDocumentCardComponent extends Component {
   @service toaster;
   @service intl;
   @service pieceAccessLevelService;
+  @service draftSubmissionService;
 
   @tracked piece;
   @tracked documentContainer;
@@ -177,6 +178,10 @@ export default class DocumentsAddDraftDocumentCardComponent extends Component {
       this.isOpenUploadModal = false;
       throw error;
     }
+  }
+
+  validateFile = (file) => {
+    return this.draftSubmissionService.validateUploadedFile(file);
   }
 
   @task

--- a/app/components/documents/draft-document-card.hbs
+++ b/app/components/documents/draft-document-card.hbs
@@ -226,7 +226,13 @@
         @onAccessLevelChanged={{set this.newPiece.accessLevel "accessLevel"}}
       />
     {{else}}
-      <Auk::FileUploader @isSubmission={{true}} @multiple={{false}} @onUpload={{perform this.uploadPiece}} />
+      <Auk::FileUploader
+        @isSubmission={{true}}
+        @multiple={{false}}
+        @onUpload={{perform this.uploadPiece}}
+        @validateFile={{this.validateFile}}
+        @dropzoneMessage={{if (not (user-may "upload-any-submission-document-extension")) "submission-document-accepted-types"}}
+      />
     {{/if}}
   </:body>
 </ConfirmationModal>

--- a/app/components/documents/draft-document-card.js
+++ b/app/components/documents/draft-document-card.js
@@ -32,6 +32,7 @@ export default class DocumentsDraftDocumentCardComponent extends Component {
   @service toaster;
   @service intl;
   @service pieceAccessLevelService;
+  @service draftSubmissionService;
 
   @tracked isOpenUploadModal = false;
   @tracked isOpenVerifyDeleteModal = false;
@@ -185,6 +186,10 @@ export default class DocumentsDraftDocumentCardComponent extends Component {
       this.isOpenUploadModal = false;
       throw error;
     }
+  }
+
+  validateFile = (file) => {
+    return this.draftSubmissionService.validateUploadedFile(file);
   }
 
   @task

--- a/app/components/documents/draft-document-card/edit-modal.hbs
+++ b/app/components/documents/draft-document-card/edit-modal.hbs
@@ -48,6 +48,8 @@
             @multiple={{false}}
             @onUpload={{set this "replacementSourceFile"}}
             @onQueueUpdate={{this.handleReplacementSourceFileUploadQueue}}
+            @validateFile={{this.validateFile}}
+            @dropzoneMessage={{if (not (user-may "upload-any-submission-document-extension")) "submission-document-accepted-types"}}
           />
         </c.content>
       {{/if}}
@@ -100,6 +102,8 @@
               @multiple={{false}}
               @onUpload={{set this "replacementDerivedFile"}}
               @onQueueUpdate={{this.handleReplacementDerivedFileUploadQueue}}
+              @validateFile={{this.validateFile}}
+              @dropzoneMessage={{if (not (user-may "upload-any-submission-document-extension")) "submission-document-accepted-types"}}
             />
           </c.content>
         {{/if}}
@@ -125,6 +129,8 @@
               @multiple={{false}}
               @onUpload={{set this "uploadedSourceFile"}}
               @onQueueUpdate={{this.handleSourceFileUploadQueue}}
+              @validateFile={{this.validateFile}}
+              @dropzoneMessage={{if (not (user-may "upload-any-submission-document-extension")) "submission-document-accepted-types"}}
             />
           </c.content>
         </AuCard>
@@ -154,6 +160,8 @@
               @multiple={{false}}
               @onUpload={{set this "uploadedDerivedFile"}}
               @onQueueUpdate={{this.handleDerivedFileUploadQueue}}
+              @validateFile={{this.validateFile}}
+              @dropzoneMessage={{if (not (user-may "upload-any-submission-document-extension")) "submission-document-accepted-types"}}
             />
           </c.content>
         </AuCard>

--- a/app/components/documents/draft-document-card/edit-modal.js
+++ b/app/components/documents/draft-document-card/edit-modal.js
@@ -15,6 +15,7 @@ export default class DocumentsDraftDocumentCardEditModalComponent extends Compon
   @service intl;
   @service toaster;
   @service fileConversionService;
+  @service draftSubmissionService;
 
   @tracked isUploadingSourceFile = false;
   @tracked isReplacingSourceFile = false;
@@ -52,6 +53,10 @@ export default class DocumentsDraftDocumentCardEditModalComponent extends Compon
         || this.isUploadingReplacementDerivedFile
         || this.isUploadingReplacementSourceFile
     );
+  }
+
+  validateFile = (file) => {
+    return this.draftSubmissionService.validateUploadedFile(file);
   }
 
   @action

--- a/app/config/config.js
+++ b/app/config/config.js
@@ -46,6 +46,13 @@ export const DOCUMENT_CONVERSION_SUPPORTED_MIME_TYPES = [
   'application/zip', // DOCX (Google Docs), XLSX (Google Docs, LibreOffice)
   'application/octet-stream' // DOCX (LibreOffice - Word 2010 - 365 format),
 ];
+
+export const SUBMISSION_ALLOWED_MIME_TYPES = [
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document', // DOCX (Word)
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', // XLSX (Excel)
+  'application/zip', // DOCX (Google Docs), XLSX (Google Docs, LibreOffice)
+  'application/pdf' // PDF
+];
 export const EMAIL_ATTACHMENT_WARN_SIZE = 10 * 1000000; // 10 MB
 export const EMAIL_ATTACHMENT_MAX_SIZE = 30 * 1000000; // 30 MB
 

--- a/app/config/permissions.js
+++ b/app/config/permissions.js
@@ -77,6 +77,7 @@ const {
 // - edit-sent-back-submissions: Allow editing submission when they have the Sent back status
 // - create-subcases-from-submissions: Allow creating a real subcase (and pieces, files, ...) from a submission
 // - delete-submissions
+// - upload-any-submission-document-extension: no enforced restrictions on mime-type/extension of document uploaded (submission mostly)
 // - remove-piece-from-parliament
 // - manage-agendaitems-with-parliament-flow
 
@@ -138,6 +139,7 @@ const groups = [
         'edit-in-treatment-submissions',
         'create-subcases-from-submissions',
         'delete-submissions',
+        'upload-any-submission-document-extension',
         'remove-piece-from-parliament',
         'manage-agendaitems-with-parliament-flow',
       ]
@@ -187,6 +189,7 @@ const groups = [
         'treat-and-accept-submissions',
         'edit-in-treatment-submissions',
         'create-subcases-from-submissions',
+        'upload-any-submission-document-extension',
       ]
     }
   },
@@ -231,6 +234,7 @@ const groups = [
         'treat-and-accept-submissions',
         'edit-in-treatment-submissions',
         'create-subcases-from-submissions',
+        'upload-any-submission-document-extension',
       ]
     }
   },

--- a/app/controllers/cases/case/subcases/subcase/new-submission.js
+++ b/app/controllers/cases/case/subcases/subcase/new-submission.js
@@ -103,6 +103,10 @@ export default class CasesCaseSubcasesSubcaseNewSubmissionController extends Con
     }
   };
 
+  validateFile = (file) => {
+    return this.draftSubmissionService.validateUploadedFile(file);
+  }
+
   uploadPiece = async (file) => {
     const name = file.filenameWithoutExtension;
     const parsed = new VRCabinetDocumentName(name).parsed;

--- a/app/controllers/cases/submissions/submission.js
+++ b/app/controllers/cases/submissions/submission.js
@@ -217,6 +217,10 @@ export default class CasesSubmissionsSubmissionController extends Controller {
     await this.checkIfHasConfidentialPiecesChanged.perform();
   };
 
+  validateFile = (file) => {
+    return this.draftSubmissionService.validateUploadedFile(file);
+  }
+
   @action
   async uploadPiece(file) {
     const name = file.filenameWithoutExtension;

--- a/app/services/draft-submission-service.js
+++ b/app/services/draft-submission-service.js
@@ -1,11 +1,14 @@
 import Service, { inject as service } from '@ember/service';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 import { isEnabledCabinetSubmissions } from 'frontend-kaleidos/utils/feature-flag';
+import { SUBMISSION_ALLOWED_MIME_TYPES } from 'frontend-kaleidos/config/config';
 
 export default class DraftSubmissionService extends Service {
   @service store;
   @service currentSession;
   @service subcaseService;
+  @service toaster;
+  @service intl;
 
   updateSubmissionStatus = async(submission, statusUri, comment='') => {
     const newStatus = await this.store.findRecordByUri('concept', statusUri);
@@ -192,5 +195,21 @@ export default class DraftSubmissionService extends Service {
   getLatestSubmissionForDecisionmakingFLow = async(decisionmakingFlow) => {
     const allSubmissions = await this.getAllSubmissionsForDecisionmakingFlow(decisionmakingFlow);
     return allSubmissions?.slice().at(0);
+  };
+
+  // for submissions we want to limit the amount of types certain profiles are allowed to upload
+  validateUploadedFile = (file) => {
+    const allowed = SUBMISSION_ALLOWED_MIME_TYPES.includes(file.type);
+    if (
+      !this.currentSession.may('upload-any-submission-document-extension') &&
+      !allowed
+    ) {
+      this.toaster.error(
+        this.intl.t('submission-document-incorrect-type', { name: file.name }),
+        this.intl.t('submission-document-accepted-types'),
+      );
+      return false;
+    }
+    return true;
   };
 }

--- a/app/templates/cases/case/subcases/subcase/new-submission.hbs
+++ b/app/templates/cases/case/subcases/subcase/new-submission.hbs
@@ -168,6 +168,8 @@
         @multiple={{true}}
         @reusable={{true}}
         @onUpload={{this.uploadPiece}}
+        @validateFile={{this.validateFile}}
+        @dropzoneMessage={{if (not (user-may "upload-any-submission-document-extension")) "submission-document-accepted-types"}}
       />
       <div class="upload-container">
         {{#each this.newPieces as |piece|}}

--- a/app/templates/cases/submissions/submission.hbs
+++ b/app/templates/cases/submissions/submission.hbs
@@ -190,6 +190,8 @@
         @multiple={{true}}
         @reusable={{true}}
         @onUpload={{this.uploadPiece}}
+        @validateFile={{this.validateFile}}
+        @dropzoneMessage={{if (not (user-may "upload-any-submission-document-extension")) "submission-document-accepted-types"}}
       />
       <div class="upload-container">
         {{#each this.newPieces as |piece|}}

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1503,5 +1503,7 @@
   "submission-already-in-treatment-title": "Aanpassingen aanvragen is niet meer mogelijk.",
   "submission-has-send-back-requested-after-reload": "Er is een aanpassing aangevraagd sinds het openen van deze pagina en het in behandeling nemen. Controleer de aanvraag vooraleer de indiening te aanvaarden.",
   "submission-edited-concurrently": "Deze indiening is recent door iemand anders bewerkt. Noteer je wijzigingen en hernieuw deze pagina om de laatste aanpassingen te zien.",
-  "uploaded-pieces-access-level-changed": "De rechten van de reeds opgeladen documenten werden aangepast"
+  "uploaded-pieces-access-level-changed": "De rechten van de reeds opgeladen documenten werden aangepast",
+  "submission-document-accepted-types": "Geaccepteerde bestandsformaten: pdf, docx, xlsx, zip",
+  "submission-document-incorrect-type": "Het document \"{name}\" heeft een onaanvaardbaar formaat en is geweigerd."
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5019

- new permission to allow certain profiles to upload any file type for submissions
- new list of allowed mime-types for submission files
- on all upload modals where draft pieces can be uploaded enforce a validation before the POST call happens
- toaster when a file was uploaded with an incorrect mime-type
- extra message in the relevant file uploader locations to inform the user of the limits.

# notes

- made the validation a service call instead of copying the full logic everywhere to reduce some duplication
- Since 5 templates (+ controllers or components) use the fileUploaders, some duplication seems unavoidable
- Was wondering if I should not duplicate the passing in of the `dropzoneMessage` param and put it in AukUploader instead but that would pollute a generic component with submission specific logic. With the current way you could change the message on each different instance if needed or have different permissions based on location (f.e. more strict on initial upload, less strict on edits)
- the dropzoneMessage has 0 styling but it stands out a bit because the existing text is muted, maybe we want to make it more clear or add icons depending on feedback (to avoid "Ik had het niet gezien" comments....)
- error toast message itself is prone to change based on user feedback since that was not decided yet (made up by me)
- 1 wrong file = 1 toast (60s), so: many wrong files = many toasts. I don't see an easy way to make a list and have 1 toast show them all. Also if everyone uploads the correct files there would be no need to reduce toasts so opted out of doing it. Toasts for everyone!


![image](https://github.com/user-attachments/assets/526691cb-b7c6-4149-9028-264d243d8ccc)
![image](https://github.com/user-attachments/assets/41cbed70-420f-41e4-8c0e-27f2edcf7fd4)
