### PR TITLE
KAS-5017 fix code causing errors

### DIFF
--- a/app/controllers/cases/submissions/submission.js
+++ b/app/controllers/cases/submissions/submission.js
@@ -4,7 +4,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { TrackedArray } from 'tracked-built-ins';
 import { task, timeout } from 'ember-concurrency';
-import { addObject, removeObject } from 'frontend-kaleidos/utils/array-helpers';
+import { removeObject } from 'frontend-kaleidos/utils/array-helpers';
 import VRCabinetDocumentName from 'frontend-kaleidos/utils/vr-cabinet-document-name';
 import { findDocType } from 'frontend-kaleidos/utils/document-type';
 import { containsConfidentialPieces, sortPieces } from 'frontend-kaleidos/utils/documents';
@@ -253,7 +253,6 @@ export default class CasesSubmissionsSubmissionController extends Controller {
       submission: this.model,
     });
     this.newPieces.push(piece);
-    this.newDraftPieces.push(piece);
   }
 
   savePieces = task(async () => {
@@ -264,7 +263,7 @@ export default class CasesSubmissionsSubmissionController extends Controller {
       try {
         await this.savePiece.perform(piece, index);
       } catch (error) {
-        await this.deletePiece.perform(piece);
+        await this.deletePiece(piece);
         throw error;
       }
     });
@@ -303,7 +302,7 @@ export default class CasesSubmissionsSubmissionController extends Controller {
     this.isOpenPieceUploadModal = false;
   });
 
-  async deletePiece(piece) {
+  deletePiece = async(piece) => {
     const file = await piece.file;
     await file.destroyRecord();
     removeObject(this.newPieces, piece);
@@ -329,7 +328,8 @@ export default class CasesSubmissionsSubmissionController extends Controller {
     const index = this.pieces.indexOf(piece);
     this.pieces[index] = newVersion;
     this.pieces = [...this.pieces];
-    addObject(this.newDraftPieces, newVersion);
+    // No need to add this version to this.newDraftPieces (we did before)
+    // since this.savePieces will now trigger this.updateDraftPiecePositions 
     await this.savePieces.perform();
     await this.checkIfHasConfidentialPiecesChanged.perform();
   };


### PR DESCRIPTION
## HOTFIX started from ACCEPTANCE (equal to PRODUCTION on the day of creation)

https://kanselarij.atlassian.net/browse/KAS-5017

- error when deleting in upload modal:
Came from a method that still had old syntax and was used as an `action` without being declared as such with `@action`
Fix: either add `@action` or refactor to arrow notation which has access to "this" context. chose the latter.

- extra issue: on error, the delete was calling this async method like a task (`.perform`), which would have failed if it ever occured:
fix: remove the `.perform` and call like a normal method.

- extra issue: when adding new documents to a submission but cancelling before saving in the modal > the bulk edit window was broken because this not saved/ deleted piece was still in a list ("newDraftPieces").
fix: not adding it to the list during opload fixed it.
After uploading all, we do `updateDraftPiecePositions` which recalculates "newDraftPieces". Bulk edit no longer fails after deleting/cancelling new draft pieces.
