### PR TITLE
KAS-5026 fix where a piece.save can happen before refresh with signature remove service concurrency

### DIFF
--- a/app/components/documents/batch-details/batch-documents-details-modal.js
+++ b/app/components/documents/batch-details/batch-documents-details-modal.js
@@ -178,7 +178,7 @@ export default class BatchDocumentsDetailsModal extends Component {
           await this.signatureService.removeSignFlow(signFlow);
         }
         if (hasChanged) {
-          // await piece.belongsTo('file').reload(); // concurrent edits of file are possible like when signatures are stripped
+          await piece.belongsTo('file').reload(); // concurrent edits of file are possible like when signatures are stripped
           await piece.save();
           await documentContainer.save();
           if (accessLevelHasChanged) {

--- a/app/components/documents/batch-details/batch-documents-details-modal.js
+++ b/app/components/documents/batch-details/batch-documents-details-modal.js
@@ -178,6 +178,7 @@ export default class BatchDocumentsDetailsModal extends Component {
           await this.signatureService.removeSignFlow(signFlow);
         }
         if (hasChanged) {
+          // await piece.belongsTo('file').reload(); // concurrent edits of file are possible like when signatures are stripped
           await piece.save();
           await documentContainer.save();
           if (accessLevelHasChanged) {

--- a/app/components/documents/document-card.js
+++ b/app/components/documents/document-card.js
@@ -446,6 +446,7 @@ export default class DocumentsDocumentCardComponent extends Component {
 
   @action
   async saveAccessLevel() {
+    await this.piece.belongsTo('file').reload(); // concurrent edits of file are possible like when signatures are stripped
     await this.piece.save();
     await this.pieceAccessLevelService.updatePreviousAccessLevels(this.piece);
     if (this.hasConfidentialityChanged && this.args.onChangeConfidentiality) {

--- a/app/components/documents/document-card/edit-modal.js
+++ b/app/components/documents/document-card/edit-modal.js
@@ -141,6 +141,7 @@ export default class DocumentsDocumentCardEditModalComponent extends Component {
         await piecePart.destroyRecord();
       }
     }
+    await this.args.piece.belongsTo('file').reload(); // concurrent edits of file are possible like when signatures are stripped
     if (this.uploadedSourceFile) {
       // use-case: we have a pdf and we want to add docx but keep our pdf
       // derived file does not exist yet in this case

--- a/app/components/documents/document-details-panel.js
+++ b/app/components/documents/document-details-panel.js
@@ -175,10 +175,11 @@ export default class DocumentsDocumentDetailsPanel extends Component {
         }
       }
     }
+    yield this.args.piece.belongsTo('file').reload(); // concurrent edits of file are possible like when signatures are stripped
     if (this.uploadedSourceFile) {
       // use-case: we have a pdf and we want to add docx but keep our pdf
       // derived file does not exist yet in this case
-      const oldFile = yield this.args.piece.file;
+      const oldFile = yield this.args.piece;
       this.uploadedSourceFile.derived = oldFile;
       this.args.piece.file = this.uploadedSourceFile;
       yield Promise.all([oldFile.save(), this.uploadedSourceFile.save()]);

--- a/app/components/documents/document-details-panel.js
+++ b/app/components/documents/document-details-panel.js
@@ -179,7 +179,7 @@ export default class DocumentsDocumentDetailsPanel extends Component {
     if (this.uploadedSourceFile) {
       // use-case: we have a pdf and we want to add docx but keep our pdf
       // derived file does not exist yet in this case
-      const oldFile = yield this.args.piece;
+      const oldFile = yield this.args.piece.file;
       this.uploadedSourceFile.derived = oldFile;
       this.args.piece.file = this.uploadedSourceFile;
       yield Promise.all([oldFile.save(), this.uploadedSourceFile.save()]);


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5026

One of the issues from the ticket is that it appears that "intern-regering" files are visible on the "intern-overheid" graph.
But this is not a propagation issue.
The issue is that some files are linked to 2 pieces (which is incorrect, the relation should be one-to-one)
This means that if 1 piece is "intern-overheid" the file gets propagated, even if the other piece is "intern-regering"

Reason for this that I can find:
Concurrency between frontend and `pdf-signature-remover` service.
- open a subcase
- add a pdf with signature (it will be stripped and flattened in the backend based on a POST delta)
- before refresh, change/save the accesslevel of the new document
- depending on the time between upload and saving the delta is most likely processed.
- the save has overridden what the backend has done, and saved the stale relation to the file (with signatures) while the document should have had a file with no signatures (from stripping)

Also possible in other views and when accepting a submission (we only strip/flatten real pieces, not draft pieces)
You can also change the accesslevel by using the "bulk edit" and have the same issue
Also when uploading > opening document view right after > change anything and save.
also when uploading > "edit" in document card > change anything (besides the mail file) and save

any `piece.save()` will also save file relation. if it's stale, the issue occurs
