### PR TITLE
Feature/kas 5007 remove all decision signflows

### DIFF
--- a/app/components/agenda/agenda-header/agenda-actions.hbs
+++ b/app/components/agenda/agenda-header/agenda-actions.hbs
@@ -94,16 +94,19 @@
       {{t "edit-meeting"}}
     </AuButton>
   {{/if}}
-  {{#if (and (not @meeting.isPreDigitalDecisions) (user-may "manage-decisions"))}}
-    <AuHr />
-    <AuButton
-      data-test-agenda-actions-mark-decisions-for-signing
-      @skin="link"
-      {{on "click" this.markDecisionsForSigning}}
-      role="menuitem"
-    >
-      {{t "sign-decisions"}}
-    </AuButton>
+  {{#if (not @meeting.isPreDigitalDecisions)}}
+    {{#if (user-may "manage-decisions")}}
+      <AuHr />
+      <AuButton
+        data-test-agenda-actions-mark-decisions-for-signing
+        @skin="link"
+        {{on "click" this.markDecisionsForSigning}}
+        role="menuitem"
+      >
+        {{t "sign-decisions"}}
+      </AuButton>
+    {{/if}}
+    {{#if (user-may "remove-all-decisions")}}
       <AuButton
         @skin="link"
         @alert={{true}}
@@ -112,7 +115,8 @@
       >
         {{t "delete-all-decisions-sign-flow-data"}}
       </AuButton>
-    <AuHr />
+      <AuHr />
+    {{/if}}
   {{/if}}
   {{#if this.canEditDesignAgenda}}
     <AuButton

--- a/app/components/agenda/agenda-header/agenda-actions.hbs
+++ b/app/components/agenda/agenda-header/agenda-actions.hbs
@@ -97,13 +97,22 @@
   {{#if (and (not @meeting.isPreDigitalDecisions) (user-may "manage-decisions"))}}
     <AuHr />
     <AuButton
-      data-test-agenda-actions-mark-decisions-sor-signing
+      data-test-agenda-actions-mark-decisions-for-signing
       @skin="link"
       {{on "click" this.markDecisionsForSigning}}
       role="menuitem"
     >
       {{t "sign-decisions"}}
     </AuButton>
+      <AuButton
+        @skin="link"
+        @alert={{true}}
+        {{on "click" (toggle "showVerifyDeleteDecisionsSignFlows" this)}}
+        role="menuitem"
+      >
+        {{t "delete-all-decisions-sign-flow-data"}}
+      </AuButton>
+    <AuHr />
   {{/if}}
   {{#if this.canEditDesignAgenda}}
     <AuButton
@@ -378,3 +387,13 @@
     </Auk::Modal::Footer>
   </Auk::Modal>
 {{/if}}
+
+<ConfirmationModal
+  @modalOpen={{this.showVerifyDeleteDecisionsSignFlows}}
+  @title={{t "delete-all-decisions-sign-flow-data"}}
+  @message={{t "verify-delete-all-decisions-sign-flow-data"}}
+  @onConfirm={{this.removeSignFlowDataForAllDecisions.perform}}
+  @onCancel={{toggle "showVerifyDeleteDecisionsSignFlows" this}}
+  @confirmMessage={{t "delete"}}
+  @alert={{true}}
+/>

--- a/app/components/agenda/agenda-header/agenda-actions.js
+++ b/app/components/agenda/agenda-header/agenda-actions.js
@@ -56,6 +56,8 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
   @tracked showDownloadDecisions = false;
   @tracked showConfirmEmptyInternalReviews = false;
   @tracked showVerifyDeleteDecisionsSignFlows = false;
+  @tracked signFlowsToRemoveDoneCounter;
+  @tracked signFlowsToRemoveTotalCounter;
 
   @tracked decisionPublicationActivity;
   @tracked documentPublicationActivity;
@@ -146,6 +148,13 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
     const isDesignAgendaA = this.args.currentAgenda.status.get('isDesignAgenda') && this.args.reverseSortedAgendas.length == 1;
     // need permission and be on the latest agenda to do the action
     return this.currentSession.may('manage-agendaitems') && this.currentAgendaIsLatest && !isDesignAgendaA;
+  }
+
+  get removeSignFlowDataLoadingMessage() {
+    return this.intl.t('delete-all-decisions-sign-flow-data-counter', {
+      count: this.signFlowsToRemoveDoneCounter,
+      total: this.signFlowsToRemoveTotalCounter,
+    });
   }
 
   @bind
@@ -372,19 +381,26 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
     this.router.refresh(this.router.currentRouteName);
   }
 
-
   removeSignFlowDataForAllDecisions = task(async () => {
     this.showVerifyDeleteDecisionsSignFlows = false;
-    this.args.onStartLoading(this.intl.t('delete-all-decisions-sign-flow-data'))
     const signFlows = await this.store.queryAll('sign-flow', {
       'filter[sign-subcase][sign-marking-activity][piece][document-container][type][:uri:]' : CONSTANTS.DOCUMENT_TYPES.DECISION,
       'filter[decision-activity][:has:treatment]': true,
       'filter[meeting][:id:]': this.args.meeting.id,
-    })
-    for (const signFlow of signFlows.slice()) {
-      await this.signatureService.removeSignFlow(signFlow);
-    }
+    });
+    this.signFlowsToRemoveDoneCounter = 0;
+    this.signFlowsToRemoveTotalCounter = signFlows.length;
+    this.args.onStartLoading(this.removeSignFlowDataLoadingMessage);
+
+    const savePromises = signFlows.map((signFlow) => this.removeSignFlowDataForAllDecisionsThrottled.perform(signFlow));
+    await all(savePromises);
     this.args.onStopLoading();
+  });
+
+  removeSignFlowDataForAllDecisionsThrottled = task({ maxConcurrency: 5, enqueue: true}, async (signFlow) => {
+    await this.signatureService.removeSignFlow(signFlow);
+    this.signFlowsToRemoveDoneCounter++;
+    this.args.onStartLoading(this.removeSignFlowDataLoadingMessage);
   });
 
   emptyInteralReviews = async() => {
@@ -402,7 +418,7 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
     this.args.didApproveAgendaitems(); // just calls a refresh route
   };
 
-  emptyInteralReviewsOfAgendaitemThrottled = task({ maxConcurrency: 5}, async (agendaitem) => {
+  emptyInteralReviewsOfAgendaitemThrottled = task({ maxConcurrency: 5, enqueue: true}, async (agendaitem) => {
     const internalReview = await this.store.queryOne('submission-internal-review', {
       'filter[subcase][agenda-activities][agendaitems][:id:]': agendaitem.id,
     })

--- a/app/components/agenda/agenda-header/agenda-actions.js
+++ b/app/components/agenda/agenda-header/agenda-actions.js
@@ -375,15 +375,14 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
 
   removeSignFlowDataForAllDecisions = task(async () => {
     this.showVerifyDeleteDecisionsSignFlows = false;
-    this.args.onStartLoading(this.intl.t('delete-all-decisions-sign-flow-data'));
-    const reports = await this.store.queryAll('report', {
-      'filter[:has-no:next-piece]': true,
-      'filter[:has:piece-parts]': true,
-      'filter[decision-activity][treatment][agendaitems][agenda][created-for][:id:]':
-        this.args.meeting.id,
-    });
-    for (const report of reports.slice()) {
-      await this.signatureService.removeSignFlowForPiece(report, true);
+    this.args.onStartLoading(this.intl.t('delete-all-decisions-sign-flow-data'))
+    const signFlows = await this.store.queryAll('sign-flow', {
+      'filter[sign-subcase][sign-marking-activity][piece][document-container][type][:uri:]' : CONSTANTS.DOCUMENT_TYPES.DECISION,
+      'filter[decision-activity][:has:treatment]': true,
+      'filter[meeting][:id:]': this.args.meeting.id,
+    })
+    for (const signFlow of signFlows.slice()) {
+      await this.signatureService.removeSignFlow(signFlow);
     }
     this.args.onStopLoading();
   });

--- a/app/components/agenda/agenda-header/agenda-actions.js
+++ b/app/components/agenda/agenda-header/agenda-actions.js
@@ -55,6 +55,7 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
   @tracked selectedMandatees = [];
   @tracked showDownloadDecisions = false;
   @tracked showConfirmEmptyInternalReviews = false;
+  @tracked showVerifyDeleteDecisionsSignFlows = false;
 
   @tracked decisionPublicationActivity;
   @tracked documentPublicationActivity;
@@ -370,6 +371,22 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
     await this.signatureService.markReportsForSignature(reports);
     this.router.refresh(this.router.currentRouteName);
   }
+
+
+  removeSignFlowDataForAllDecisions = task(async () => {
+    this.showVerifyDeleteDecisionsSignFlows = false;
+    this.args.onStartLoading(this.intl.t('delete-all-decisions-sign-flow-data'));
+    const reports = await this.store.queryAll('report', {
+      'filter[:has-no:next-piece]': true,
+      'filter[:has:piece-parts]': true,
+      'filter[decision-activity][treatment][agendaitems][agenda][created-for][:id:]':
+        this.args.meeting.id,
+    });
+    for (const report of reports.slice()) {
+      await this.signatureService.removeSignFlowForPiece(report, true);
+    }
+    this.args.onStopLoading();
+  });
 
   emptyInteralReviews = async() => {
     this.showConfirmEmptyInternalReviews = false;

--- a/app/config/permissions.js
+++ b/app/config/permissions.js
@@ -47,6 +47,7 @@ const {
 // - manage-retracted-agendaitems: Re-propose retracted agendaitems
 // - manage-press-agenda: Allow access to press agenda action
 // - manage-decisions: Change the decision result, upload a decision report
+// - remove-all-decisions: Shows a button to remove all decisions
 // - manage-cases: Create and update cases
 // - manage-users: Block and archive users
 // - manage-alerts: Manage systeem notifications to be shown in the application
@@ -116,6 +117,7 @@ const groups = [
         'manage-agendaitems',
         'manage-retracted-agendaitems',
         'manage-decisions',
+        'remove-all-decisions',
         'manage-ratification',
         'manage-cases',
         'manage-meetings',

--- a/cypress/selectors/agenda.selectors.js
+++ b/cypress/selectors/agenda.selectors.js
@@ -107,7 +107,7 @@ const selectors = {
     downloadDecisions: '[data-test-agenda-actions-download-decisions]',
     generateSignedDecisionsBundle: '[data-test-agenda-actions-generate-signed-decisions-bundle]',
     toggleEditingMeeting: '[data-test-agenda-actions-toggle-editing-meeting]',
-    markDecisionsForSigning: '[data-test-agenda-actions-mark-decisions-sor-signing]',
+    markDecisionsForSigning: '[data-test-agenda-actions-mark-decisions-for-signing]',
     releaseDecisions: '[data-test-agenda-actions-release-decisions]',
     planReleaseDocuments: '[data-test-agenda-actions-release-documents-planning]',
     approveAllAgendaitems: '[data-test-agenda-actions-approve-all-agendaitems]',

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1508,5 +1508,6 @@
   "submission-document-accepted-types": "Geaccepteerde bestandsformaten: pdf, docx, xlsx, zip",
   "submission-document-incorrect-type": "Het document \"{name}\" heeft een onaanvaardbaar formaat en is geweigerd.",
   "delete-all-decisions-sign-flow-data":"Ondertekenflows voor alle beslissingen verwijderen",
+  "delete-all-decisions-sign-flow-data-counter":"{count} van {total} ondertekenflows verwijderd.",
   "verify-delete-all-decisions-sign-flow-data": "Bent u zeker dat u de ondertekenflows van alle beslissingen van deze agenda in Kaleidos wilt verwijderen? Deze actie kan niet ongedaan gemaakt worden. Vergeet niet om de flows ook in het platform Digitaal Ondertekenen stop te zetten. Dit gebeurt niet automatisch."
 }

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1506,5 +1506,7 @@
   "submission-edited-concurrently": "Deze indiening is recent door iemand anders bewerkt. Noteer je wijzigingen en hernieuw deze pagina om de laatste aanpassingen te zien.",
   "uploaded-pieces-access-level-changed": "De rechten van de reeds opgeladen documenten werden aangepast",
   "submission-document-accepted-types": "Geaccepteerde bestandsformaten: pdf, docx, xlsx, zip",
-  "submission-document-incorrect-type": "Het document \"{name}\" heeft een onaanvaardbaar formaat en is geweigerd."
+  "submission-document-incorrect-type": "Het document \"{name}\" heeft een onaanvaardbaar formaat en is geweigerd.",
+  "delete-all-decisions-sign-flow-data":"Ondertekenflows voor alle beslissingen verwijderen",
+  "verify-delete-all-decisions-sign-flow-data": "Bent u zeker dat u de ondertekeningen van de beslissingen in Kaleidos wilt verwijderen? Deze actie kan niet ongedaan gemaakt worden. Vergeet niet om de flows ook in het platform Digitaal Ondertekenen stop te zetten. Dit gebeurt niet automatisch."
 }

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1508,5 +1508,5 @@
   "submission-document-accepted-types": "Geaccepteerde bestandsformaten: pdf, docx, xlsx, zip",
   "submission-document-incorrect-type": "Het document \"{name}\" heeft een onaanvaardbaar formaat en is geweigerd.",
   "delete-all-decisions-sign-flow-data":"Ondertekenflows voor alle beslissingen verwijderen",
-  "verify-delete-all-decisions-sign-flow-data": "Bent u zeker dat u de ondertekeningen van de beslissingen in Kaleidos wilt verwijderen? Deze actie kan niet ongedaan gemaakt worden. Vergeet niet om de flows ook in het platform Digitaal Ondertekenen stop te zetten. Dit gebeurt niet automatisch."
+  "verify-delete-all-decisions-sign-flow-data": "Bent u zeker dat u de ondertekenflows van alle beslissingen van deze agenda in Kaleidos wilt verwijderen? Deze actie kan niet ongedaan gemaakt worden. Vergeet niet om de flows ook in het platform Digitaal Ondertekenen stop te zetten. Dit gebeurt niet automatisch."
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5007

- the query for getting the list. I tried reports first, then `removeSignFlowForPiece` but that method loads a lot more data so went for a query to `sign-flows` directly. Tested it locally with a small dataset (I did some overrides in de signing service to get a preparation-activity without actually sending to SH for quicker testing)
- The process of doing sign-flows 1 by 1 is a bit slow, but was unsure if the service could handle multiple deletes. So made sure to show the loader during the process.


notes:
We could maybe list amounts if the process takes too long (X of Y removed).
Need to test on a server with a large amount
Should I have made a path on the signing-service instead? ticket didn't specify, also not sure that would be faster than what I am doing now because you have to update the ember store of the user.