### PR TITLE
KAS-5023: Session polling

### DIFF
--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -2,6 +2,7 @@ import Service, { inject as service } from '@ember/service';
 import { get } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { isPresent } from '@ember/utils';
+import { later } from '@ember/runloop';
 import { findGroupByRole } from 'frontend-kaleidos/config/permissions';
 
 export default class CurrentSessionService extends Service {
@@ -9,11 +10,19 @@ export default class CurrentSessionService extends Service {
   @service store;
   @service impersonation;
   @service userAgent;
+  @service toaster;
+  @service intl;
 
   @tracked user;
   @tracked organization;
   @tracked membership;
   @tracked role;
+
+  constructor() {
+    super(...arguments);
+
+    this.lifecycle();
+  }
 
   /* eslint-disable ember/no-get */
   async load() {
@@ -76,5 +85,37 @@ export default class CurrentSessionService extends Service {
 
   get isAuthenticated() {
     return this.session.isAuthenticated;
+  }
+
+  /*****
+   * Polling for logged in status logic is below!
+   */
+  updateInterval = 60 * 1000;
+
+  async lifecycle() {
+    // For as long as the user is logged in, we continue periodically polling
+    if (await this._checkLoggedInStatus()) {
+      later(this, this.lifecycle, this.updateInterval);
+    }
+  }
+
+  async _checkLoggedInStatus() {
+    let isLoggedIn = true;
+
+    const currentSessionUrl = this.session.data?.authenticated?.links?.self;
+    if (currentSessionUrl) {
+      const response = await fetch(currentSessionUrl);
+      if (!response.ok) {
+        this.toaster.warning(
+          'Uw sessie is verlopen, en u wordt zo meteen automatisch uitgelogd. Onvoltooid werk zal niet opgeslagen kunnen worden in Kaleidos. Gelieve dit indien nodig op uw eigen apparaat op te slaan alvorens deze pagina te verlaten.',
+          null,
+          { timeOut: null }
+        );
+        this.session.invalidate();
+        isLoggedIn = false;
+      }
+    }
+
+    return isLoggedIn;
   }
 }

--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -107,7 +107,7 @@ export default class CurrentSessionService extends Service {
       const response = await fetch(currentSessionUrl);
       if (!response.ok) {
         this.toaster.warning(
-          'Uw sessie is verlopen, en u wordt zo meteen automatisch uitgelogd. Onvoltooid werk zal niet opgeslagen kunnen worden in Kaleidos. Gelieve dit indien nodig op uw eigen apparaat op te slaan alvorens deze pagina te verlaten.',
+          this.intl.t('your-session-is-invalid'),
           null,
           { timeOut: null }
         );

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1509,5 +1509,6 @@
   "submission-document-incorrect-type": "Het document \"{name}\" heeft een onaanvaardbaar formaat en is geweigerd.",
   "delete-all-decisions-sign-flow-data":"Ondertekenflows voor alle beslissingen verwijderen",
   "delete-all-decisions-sign-flow-data-counter":"{count} van {total} ondertekenflows verwijderd.",
-  "verify-delete-all-decisions-sign-flow-data": "Bent u zeker dat u de ondertekenflows van alle beslissingen van deze agenda in Kaleidos wilt verwijderen? Deze actie kan niet ongedaan gemaakt worden. Vergeet niet om de flows ook in het platform Digitaal Ondertekenen stop te zetten. Dit gebeurt niet automatisch."
+  "verify-delete-all-decisions-sign-flow-data": "Bent u zeker dat u de ondertekenflows van alle beslissingen van deze agenda in Kaleidos wilt verwijderen? Deze actie kan niet ongedaan gemaakt worden. Vergeet niet om de flows ook in het platform Digitaal Ondertekenen stop te zetten. Dit gebeurt niet automatisch.",
+  "your-session-is-invalid": "Uw sessie is verlopen, en u wordt zo meteen automatisch uitgelogd. Onvoltooid werk zal niet opgeslagen kunnen worden in Kaleidos. Gelieve dit indien nodig op uw eigen apparaat op te slaan alvorens deze pagina te verlaten."
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5023

Poll for the current session every minute. If the session is invalid (the backend services should return a 401 in that case), we invalidate the frontend session and show a warning toast. If the user then clicks away to a page, we will only show data that is visible to an unauthenticated user (i.e. pretty much nothing), but we don't necessarily automatically redirect them to the login page (this depends on what route the user visits).

Related PRs:
- [x] https://github.com/kanselarij-vlaanderen/mock-login-service/pull/6