### PR TITLE
KAS-5031: Correct the sorting of ongoing signatures and filter out ratifications

### DIFF
--- a/app/controllers/signatures/ongoing-ratifications.js
+++ b/app/controllers/signatures/ongoing-ratifications.js
@@ -43,7 +43,7 @@ export default class SignaturesOngoingRatificationsController extends Controller
   @tracked page = 0;
   @tracked size = PAGINATION_SIZES[3];
   @tracked sort = [
-    '-meeting.planned-start',
+    '-decision-activity.treatment.agendaitems.agenda.created-for.planned-start',
     'sign-subcase.sign-marking-activity.piece.name',
   ].join(',');
   @tracked isLoadingModel;

--- a/app/routes/signatures/ongoing.js
+++ b/app/routes/signatures/ongoing.js
@@ -58,7 +58,16 @@ export default class SignaturesOngoingRoute extends Route {
       params.page = 0;
     }
 
-    const filter = { ':has-no:meeting': true };
+    const filter = {
+      ':has-no:meeting': true,
+      'sign-subcase': {
+        'sign-marking-activity': {
+          piece: {
+            ':has-no:ratification-subcase': true,
+          }
+        },
+      },
+    };
     if (this.currentSession.may('view-all-ongoing-signatures')) {
       filter[':has:creator'] = 't';
     } else {


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5031

The sorting on sign flows shouldn't use meeting.planned-start, this relation seems to be empty in a lot of cases and thus won't sort correctly.

As opposed to when fetching all the sign flows for ratifications, when filtering the ratifications we cannot base ourserlves on the document type: resources does not provide an "inverse filter". Instead, we choose to use the absence of the ratification-subcase relation as a way to find those sign flows that are not for ratifications.