### PR TITLE
KAS-5008: Better error handling in document stamping

### DIFF
--- a/app/services/document-service.js
+++ b/app/services/document-service.js
@@ -54,6 +54,16 @@ export default class DocumentService extends Service {
           });
         }
       }
+    } else {
+      this.toaster.show(CopyErrorToClipboardToast, {
+        title: this.intl.t('warning-title'),
+        message: this.intl.t('error-while-stamping-document'),
+        errorContent: JSON.stringify(data),
+        showDatetime: true,
+        options: {
+          timeOut: 60 * 10 * 1000,
+        },
+      });
     }
   }
 
@@ -79,6 +89,16 @@ export default class DocumentService extends Service {
           });
         }
       }
+    } else {
+      this.toaster.show(CopyErrorToClipboardToast, {
+        title: this.intl.t('warning-title'),
+        message: this.intl.t('error-while-stamping-document'),
+        errorContent: JSON.stringify(data),
+        showDatetime: true,
+        options: {
+          timeOut: 60 * 10 * 1000,
+        },
+      });
     }
   }
 


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5008

When the document stamping service returns an error, we show it in a toast.

Related PRs:

- [x] https://github.com/kanselarij-vlaanderen/document-stamping-service/pull/8