### PR TITLE
clear the selected signflows list when navigating

### DIFF
--- a/app/routes/signatures/decisions.js
+++ b/app/routes/signatures/decisions.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 import Snapshot from 'frontend-kaleidos/utils/snapshot';
+import { TrackedArray } from 'tracked-built-ins';
 
 export default class SignaturesDecisionsRoute extends Route {
   @service store;
@@ -94,6 +95,7 @@ export default class SignaturesDecisionsRoute extends Route {
       controller.agendaitem = null;
       controller.agenda = null;
       controller.meeting = null;
+      controller.selectedSignFlows = new TrackedArray([]);
     }
   }
 }

--- a/app/routes/signatures/index.js
+++ b/app/routes/signatures/index.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 import Snapshot from 'frontend-kaleidos/utils/snapshot';
+import { TrackedArray } from 'tracked-built-ins';
 
 export default class SignaturesIndexRoute extends Route {
   @service store;
@@ -137,6 +138,7 @@ export default class SignaturesIndexRoute extends Route {
       controller.agendaitem = null;
       controller.agenda = null;
       controller.meeting = null;
+      controller.selectedSignFlows = new TrackedArray([]);
     }
   }
 }

--- a/app/routes/signatures/ratifications.js
+++ b/app/routes/signatures/ratifications.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 import Snapshot from 'frontend-kaleidos/utils/snapshot';
+import { TrackedArray } from 'tracked-built-ins';
 
 export default class SignaturesRatificationsRoute extends Route {
   @service store;
@@ -117,6 +118,7 @@ export default class SignaturesRatificationsRoute extends Route {
       controller.agendaitem = null;
       controller.agenda = null;
       controller.meeting = null;
+      controller.selectedSignFlows = new TrackedArray([]);
     }
   }
 }


### PR DESCRIPTION
Opgemerkt tijdens demo op sprintplanning:

de lijst geselecteerde sign-flows worden niet opgekuist bij wegnavigeren, wat raar is als de sign-flows die geselecteerd waren zijn verwijderd maar toch nog geselecteerd.

vb:
Maak voor 1 agenda enkele beslissingen en markeer die voor onderteken.
Ga naar de handtekeningen pagina voor beslissingen, selecteer alle beslissingen van die agenda
Ga terug naar de agenda, gebruik de feature om alle ondertekenflows te verwijderen van de agenda
Ga terug naar de handtekeningen pagina:
We zeggen nog steeds "X geselecteerd" rechtsboven, maar er is niks in de lijst te zien
verdergaan naar die "X" opstarten gaat dan sowieso errors geven.

Deze quick PR zou dat moeten fixen