### PR TITLE
KAS-5040 split original test file with setup and cleanup, add more tests

### DIFF
--- a/app/components/auk/checkbox-tree.hbs
+++ b/app/components/auk/checkbox-tree.hbs
@@ -1,5 +1,6 @@
 <AuCheckboxGroup class="auk-u-maximize-width"> {{!-- Just use the group component here as a styling method as also using the included functionality would unnecessarily overcomplicate things --}}
   <AuCheckbox
+    data-test-checkbox-tree-toggle-all
     @checked={{this.isSelectedAllItems}}
     @indeterminate={{and (not this.isSelectedAllItems) this.isSelectedSomeItems}}
     @disabled={{@disabled}}
@@ -15,6 +16,7 @@
   >
     {{#each @items as |item|}}
       <Group.Checkbox
+        data-test-checkbox-tree-toggle-single
         @value={{item}}
         @disabled={{or (@itemDisabled item) @disabled}}
       >

--- a/app/components/cases/submissions/decisionmaking-flow-selector.hbs
+++ b/app/components/cases/submissions/decisionmaking-flow-selector.hbs
@@ -3,6 +3,7 @@
   <div class="au-u-flex au-u-flex--spaced-small auk-u-maximize-width">
     {{#if @selectedDecisionmakingFlow}}
       <AuInput
+        data-test-submission-decisionmaking-flow-selector-existing-case-title
         id="newCaseTitleId"
         value={{@selectedDecisionmakingFlow.case.shortTitle}}
         @width="block"
@@ -11,6 +12,7 @@
       {{#unless @disableEdit}}
         <AuButtonGroup class="au-u-flex--no-wrap">
           <AuButton
+            data-test-submission-decisionmaking-flow-selector-use-new-case
             @skin="secondary"
             @icon="pencil"
             {{on "click" (queue this.onClearSelectedDecisionmakingFlow this.setFocus)}}
@@ -18,6 +20,7 @@
             {{t "new-case"}}
           </AuButton>
           <AuButton
+            data-test-submission-decisionmaking-flow-selector-use-different-case
             @skin="secondary"
             @icon="add"
             {{on "click" (toggle "isUsingExistingDecisionmakingFlow" this)}}
@@ -28,6 +31,7 @@
       {{/unless}}
     {{else}}
       <AuInput
+        data-test-submission-decisionmaking-flow-selector-new-case-title
         id="newCaseTitleId"
         value={{@selectedDecisionmakingFlowTitle}}
         @width="block"
@@ -37,6 +41,7 @@
       {{#unless @disableEdit}}
         <AuButtonGroup class="au-u-flex--no-wrap">
           <AuButton
+            data-test-submission-decisionmaking-flow-selector-use-existing-case
             @skin="secondary"
             @icon="add"
             {{on "click" (toggle "isUsingExistingDecisionmakingFlow" this)}}

--- a/app/components/documents/add-draft-document-card.hbs
+++ b/app/components/documents/add-draft-document-card.hbs
@@ -3,6 +3,7 @@
     {{if (not this.bordered) 'vlc-document-card--borderless'}}"
   {{did-update (perform this.loadPieceRelatedData) @piece}}
   {{did-update (perform this.loadPieceRelatedData) @documentContainer}}
+  data-test-add-draft-document-card
 >
   <div class="vlc-document-card__summary">
     <div class="vlc-document-card__content">
@@ -27,7 +28,7 @@
             <div
               class="auk-o-flex auk-o-flex--vertical-center auk-o-flex--spaced"
             >
-              <span class="auk-overline">
+              <span data-test-add-draft-document-card-type class="auk-overline">
                 {{#unless this.loadPieceRelatedData.isRunning}}
                   {{this.documentContainer.type.altLabel}}
                 {{/unless}}
@@ -39,6 +40,7 @@
               </span>
             {{/if}}
             <LinkTo
+              data-test-add-draft-document-card-name-value
               @route="document"
               @model={{this.piece.id}}
               target="_blank"
@@ -75,6 +77,7 @@
                   }}
                     {{t "as"}}
                     <AuLinkExternal
+                      data-test-add-draft-document-card-primary-source-link
                       href={{await this.piece.namedDownloadLinkPromise}}
                       download
                     >
@@ -125,6 +128,7 @@
             >
               {{!-- template-lint-disable require-context-role --}}
               <AuButton
+                data-test-add-draft-document-card-upload-new-draft-piece
                 @skin="link"
                 @icon="plus"
                 {{on "click" (toggle "isOpenUploadModal" this)}}
@@ -141,6 +145,7 @@
             >
               {{!-- template-lint-disable require-context-role --}}
               <AuButton
+                data-test-add-draft-document-card-delete-draft-piece
                 @skin="naked"
                 @alert={{true}}
                 @icon="trash"
@@ -163,6 +168,7 @@
             @title={{t "previous-versions"}}
             @disabled={{this.loadPieceRelatedData.isRunning}}
             @expandTask={{this.loadVersionHistory}}
+            data-test-add-draft-document-card-version-history
           >
             {{#if this.loadVersionHistory.isRunning}}
               <div class="auk-u-p-3">

--- a/app/components/documents/uploaded-document.hbs
+++ b/app/components/documents/uploaded-document.hbs
@@ -36,6 +36,7 @@
           <AuFormRow>
             <AuLabel>{{t (if @simplifiedOptions "confidential" "confidentiality-level")}}</AuLabel>
             <Utils::AccessLevelSelector
+              data-test-uploaded-document-access-level
               @selected={{@piece.accessLevel}}
               @allowClear={{false}}
               @simplifiedOptions={{@simplifiedOptions}}

--- a/app/components/subcases/subcase-header.hbs
+++ b/app/components/subcases/subcase-header.hbs
@@ -9,6 +9,7 @@
       {{#if this.maySubmitNewDocuments}}
         <Auk::Toolbar::Item>
           <AuLink
+            data-test-subcase-header-create-update-submission
             @skin="button-secondary"
             @icon="plus"
             @route="cases.case.subcases.subcase.new-submission"
@@ -24,6 +25,7 @@
       {{#if this.currentSubmission}}
         <Auk::Toolbar::Item>
           <AuLink
+            data-test-subcase-header-open-current-submission
             @skin="button-secondary"
             @route="cases.submissions.submission"
             @model={{this.currentSubmission.id}}

--- a/app/templates/agenda/submissions.hbs
+++ b/app/templates/agenda/submissions.hbs
@@ -4,6 +4,7 @@
       {{#if @model.length}}
         <div>
           <table
+            data-test-route-agenda-submissions-data-table
             class="auk-table auk-table--agenda auk-table--hoverable auk-table--sticky-header auk-table--sticky-action-column"
           >
             <thead>
@@ -55,20 +56,24 @@
                   {{on "click" (fn this.navigateToSubmission submission)}}
                 >
                   <td>
-                    <p>
+                    <p data-test-route-agenda-submissions-row-short-title>
                       {{#if submission.shortTitle}}
                         {{submission.shortTitle}}
                       {{else}}
                         -
                       {{/if}}
                       {{#if (not submission.decisionmakingFlow.id)}}
-                        <span class="auk-u-text-small au-u-muted auk-u-text-nowrap auk-u-mr-2">
+                        <span
+                          data-test-route-agenda-submissions-row-new-case
+                          class="auk-u-text-small au-u-muted auk-u-text-nowrap auk-u-mr-2"
+                        >
                           <Auk::ColorBadge @skin="success" />
                           {{t "new-case"}}
                         </span>
                       {{/if}}
                       {{#if submission.confidential}}
                         <AuPill
+                          data-test-route-agenda-submissions-row-limited-access
                           @size="small"
                           @skin="warning"
                           @icon="lock-closed"
@@ -78,10 +83,10 @@
                       {{/if}}
                     </p>
                   </td>
-                  <td>
+                  <td data-test-route-agenda-submissions-row-submitter>
                     {{or submission.requestedBy.person.fullName "-"}}
                   </td>
-                  <td>
+                  <td data-test-route-agenda-submissions-row-mandatees>
                     {{#let (await (this.getMandateeNames submission)) as |names|}}
                       {{#if names}}
                         {{join ", " names}}
@@ -90,7 +95,7 @@
                       {{/if}}
                     {{/let}}
                   </td>
-                  <td>
+                  <td data-test-route-agenda-submissions-row-subcase-type>
                     {{#if submission.type.label}}
                       <AuPill @size="small" @skin="ongoing">{{capitalize submission.type.label}}</AuPill>
                     {{else if submission.type.altLabel}}
@@ -99,10 +104,10 @@
                       -
                     {{/if}}
                   </td>
-                  <td>
+                  <td data-test-route-agenda-submissions-row-status>
                     <Cases::Submissions::StatusPill @status={{submission.status}}/>
                   </td>
-                  <td>
+                  <td data-test-route-agenda-submissions-row-treated-by>
                     {{#let (await (this.getTreatedBy submission)) as |beingTreatedBy|}}
                       {{#if beingTreatedBy}}
                         {{beingTreatedBy.fullName}}
@@ -113,6 +118,7 @@
                   </td>
                   <td class="auk-u-text-align--right">
                     <AuLink
+                      data-test-route-agenda-submissions-row-go-to-submission
                       @skin="button-naked"
                       @icon="chevron-right"
                       @hideText={{true}}

--- a/app/templates/cases/case/subcases/subcase/new-submission.hbs
+++ b/app/templates/cases/case/subcases/subcase/new-submission.hbs
@@ -119,6 +119,7 @@
         </Auk::Panel::Body>
         <Auk::Panel::Footer>
           <AuButton
+            data-test-route-cases--new-submission-add-documents
             @skin="naked"
             @icon="plus"
             class="au-u-padding-left-none"
@@ -133,6 +134,7 @@
   <AuToolbar @reverse={{true}} @size="large" @border="top" as |Group|>
     <Group>
       <AuButton
+        data-test-route-cases--new-submission-cancel
         @skin="secondary"
         @disabled={{or this.createSubmission.isRunning}}
         {{on "click" (perform this.cancelForm)}}
@@ -140,6 +142,7 @@
         {{t "cancel"}}
       </AuButton>
       <AuButton
+        data-test-route-cases--new-submission-save
         @skin="primary"
         @disabled={{eq this.newDraftPieces.length 0}}
         {{on "click" (toggle "isOpenCreateSubmissionModal" this)}}
@@ -205,6 +208,7 @@
       <:body>
         <AuLabel for="remarks">{{t "remarks-for-secretary-about-submission"}}</AuLabel>
         <AuTextarea
+          data-test-route-cases--new-submission-submit-comment
           id="remarks"
           rows="4"
           value=""

--- a/cypress/e2e/unit/submission_A_setup.cy.js
+++ b/cypress/e2e/unit/submission_A_setup.cy.js
@@ -1,0 +1,81 @@
+/* global context, it, cy, Cypress, before, afterEach */
+
+// / <reference types="Cypress" />
+import dependency from '../../selectors/dependency.selectors';
+import appuniversum from '../../selectors/appuniversum.selectors';
+import settings from '../../selectors/settings.selectors';
+import mandateeNames from '../../selectors/mandatee-names.selectors';
+import utils from '../../selectors/utils.selectors';
+
+const agendaDate = Cypress.dayjs().add(4, 'weeks')
+  .day(1); // anything but day 4
+// const agendaDate = Cypress.dayjs('2024-09-13');
+
+const linkedMandatee = {
+  // the second active mandatee will be our linked mandatee
+  mandatee: mandateeNames.current.second, // might not be needed, depends what we want to check
+  fullName: mandateeNames.current.second.fullName,
+  submitter: true,
+};
+
+before(() => {
+  cy.login('Admin');
+  cy.createAgenda(null, agendaDate, 'indieningen kabinet');
+  cy.logoutFlow();
+});
+
+context('setup emails and mandatees', () => {
+  afterEach(() => {
+    cy.logout();
+  });
+
+  it('add one mandatee to dossierbeheerder', () => {
+    cy.login('Admin');
+    // setup: add minister to dossierbeheerder
+    cy.visit('instellingen/organisaties/40df7139-fdfb-4ab7-92cd-e73ceba32721');
+    cy.get(settings.organization.technicalInfo.showSelectMandateeModal).click();
+    cy.get(appuniversum.loader).should('not.exist');
+    cy.get(utils.mandateeSelector.container).click();
+    cy.get(dependency.emberPowerSelect.optionLoadingMessage).should(
+      'not.exist'
+    );
+    cy.get(dependency.emberPowerSelect.optionTypeToSearchMessage).should(
+      'not.exist'
+    );
+    cy.get(dependency.emberPowerSelect.option)
+      .contains(linkedMandatee.fullName)
+      .scrollIntoView()
+      .click();
+    cy.intercept('PATCH', '/user-organizations/**').as(
+      'patchUserOrganizations'
+    );
+    cy.get(utils.mandateesSelector.add).should('not.be.disabled')
+      .click();
+    cy.wait('@patchUserOrganizations');
+  });
+
+  it.only('set email setting defaults', () => {
+    cy.login('Admin');
+    cy.get(utils.mHeader.settings).click();
+    cy.get(settings.overview.manageEmails).click();
+    cy.get(settings.email.publication.requestTo).click()
+      .clear()
+      .type('example@test.com');
+    cy.get(settings.email.submission.toSecretary).click()
+      .clear()
+      .type('example+sec@test.com');
+    cy.get(settings.email.submission.toIKW).click()
+      .clear()
+      .type('example+ikw@test.com');
+    cy.get(settings.email.submission.toKCGroup).click()
+      .clear()
+      .type('example+KC@test.com');
+    cy.get(settings.email.submission.replyTo).click()
+      .clear()
+      .type('example+replyTo@test.com');
+    cy.intercept('PATCH', '/email-notification-settings/**')
+      .as('patchEmailSettings');
+    cy.get(settings.email.save).click();
+    cy.wait('@patchEmailSettings');
+  });
+});

--- a/cypress/e2e/unit/submission_A_setup.cy.js
+++ b/cypress/e2e/unit/submission_A_setup.cy.js
@@ -54,7 +54,7 @@ context('setup emails and mandatees', () => {
     cy.wait('@patchUserOrganizations');
   });
 
-  it.only('set email setting defaults', () => {
+  it('set email setting defaults', () => {
     cy.login('Admin');
     cy.get(utils.mHeader.settings).click();
     cy.get(settings.overview.manageEmails).click();

--- a/cypress/e2e/unit/submission_B.cy.js
+++ b/cypress/e2e/unit/submission_B.cy.js
@@ -44,11 +44,17 @@ context('Submission happy flows', () => {
     cy.logout();
   });
 
+  const limitedAccess = 'Beperkte toegang';
+  const submittedStatus = 'Ingediend';
+  const treatedStatus = 'Behandeld';
+  const sentbackStatus = 'Teruggestuurd';
+  const reSubmittedStatus = 'Opnieuw ingediend';
+
   const accessCabinet = 'Intern Regering';
   const accessConfidential = 'Vertrouwelijk';
   const agendaDateFormatted = agendaDate.format('DD-MM-YYYY');
   const agendaTypeNota = 'Nota';
-  // const agendaTypeAnnouncement = 'Mededeling';
+  const agendaTypeAnnouncement = 'Mededeling';
   const mandatee1 = {
     fullName: mandateeNames.current.first.fullName,
     submitter: false,
@@ -92,6 +98,7 @@ context('Submission happy flows', () => {
 
   // first submission for new case
   const submissionNewCaseShortTitle = `Submission new case short title 1 - ${currentTimestamp()}`;
+  // const submissionNewCaseShortTitle = 'Submission new case short title 1 - 1745846633';
   const submissionNewCase = {
     newCase: true,
     agendaitemType: agendaTypeNota,
@@ -113,7 +120,7 @@ context('Submission happy flows', () => {
 
   // first submission for an existing case
   const submissionExistingCaseShortTitle = `Submission existing case short title 1 - ${currentTimestamp()}`;
-  // const submissionExistingCaseShortTitle = 'Submission existing case short title 1 - 1725621062'
+  // const submissionExistingCaseShortTitle = 'Submission existing case short title 1 - 1745846633';
   const previousSubcaseInfo = {
     agendaitemType: agendaTypeNota,
     shortTitle: 'Cypress test: profile rights - subcase 2 with decision - 1715070204',
@@ -457,6 +464,47 @@ context('Submission happy flows', () => {
     cy.get(submissions.statusChangeActivity.item).contains(submissionExistingCase.comment);
   });
 
+  it('check the submissions table after creating both', () => {
+    cy.login('Kabinetdossierbeheerder');
+    cy.visit('/indieningen?aantal=2');
+    // these 2 will only be in view if there is no submission on a later agenda
+    cy.get(route.submissionsOverview.row.shortTitle)
+      .contains(submissionNewCaseShortTitle)
+      .parents('tr')
+      .as('submissionNewCaseRow');
+    cy.get(route.submissionsOverview.row.shortTitle)
+      .contains(submissionExistingCaseShortTitle)
+      .parents('tr')
+      .as('submissionExistingCaseRow');
+
+    cy.get('@submissionNewCaseRow').find(route.submissionsOverview.row.newCase);
+    cy.get('@submissionNewCaseRow').find(route.submissionsOverview.row.limitedAccess)
+      .should('contain', limitedAccess);
+    cy.get('@submissionNewCaseRow').find(route.submissionsOverview.row.plannedStart)
+      .should('contain', agendaDateFormatted);
+    cy.get('@submissionNewCaseRow').find(route.submissionsOverview.row.subcaseType)
+      .contains(submissionNewCase.subcaseType, {
+        matchCase: false,
+      });
+    cy.get('@submissionNewCaseRow').find(route.submissionsOverview.row.status)
+      .should('contain', submittedStatus);
+    cy.get('@submissionNewCaseRow').find(route.submissionsOverview.row.goToSubmission);
+
+    cy.get('@submissionExistingCaseRow').find(route.submissionsOverview.row.newCase)
+      .should('not.exist');
+    cy.get('@submissionExistingCaseRow').find(route.submissionsOverview.row.limitedAccess)
+      .should('not.exist');
+    cy.get('@submissionExistingCaseRow').find(route.submissionsOverview.row.plannedStart)
+      .should('contain', agendaDateFormatted);
+    cy.get('@submissionExistingCaseRow').find(route.submissionsOverview.row.subcaseType)
+      .contains(submissionExistingCase.subcaseType, {
+        matchCase: false,
+      });
+    cy.get('@submissionExistingCaseRow').find(route.submissionsOverview.row.status)
+      .should('contain', submittedStatus);
+    cy.get('@submissionExistingCaseRow').find(route.submissionsOverview.row.goToSubmission);
+  });
+
   it('open the first submission as admin, check available options', () => {
     cy.login('Admin');
     // TODO-Setup move these to profile tests eventually per status per profile
@@ -636,6 +684,27 @@ context('Submission happy flows', () => {
     cy.acceptSubmissionCreateSubcase(submissionExistingCase);
   });
 
+  it('check the submissions table after accepting both', () => {
+    cy.login('Kabinetdossierbeheerder');
+    cy.visit('/indieningen?aantal=2');
+    // these 2 will only be in view if there is no submission on a later agenda
+    cy.get(route.submissionsOverview.row.shortTitle)
+      .contains(submissionNewCaseShortTitle)
+      .parents('tr')
+      .as('submissionNewCaseRow');
+    cy.get(route.submissionsOverview.row.shortTitle)
+      .contains(submissionExistingCaseShortTitle)
+      .parents('tr')
+      .as('submissionExistingCaseRow');
+
+    // only status changed
+    // a case was created but not visible yet to this profile
+    cy.get('@submissionNewCaseRow').find(route.submissionsOverview.row.status)
+      .should('contain', treatedStatus);
+    cy.get('@submissionExistingCaseRow').find(route.submissionsOverview.row.status)
+      .should('contain', treatedStatus);
+  });
+
   it('send back the submission from the agenda', () => {
     cy.login('Kanselarij');
     const fileSpy = cy.spy();
@@ -681,6 +750,176 @@ context('Submission happy flows', () => {
     cy.get(document.draftDocumentCard.card).should('have.length', 2);
     // check we didn't get routed to a subcase view
     cy.url().should('contain', '/dossiers/indieningen');
+  });
+
+  it('check the submissions table after sending back one', () => {
+    cy.login('Kabinetdossierbeheerder');
+    cy.visit('/indieningen?aantal=2');
+    // these 2 will only be in view if there is no submission on a later agenda
+    cy.get(route.submissionsOverview.row.shortTitle)
+      .contains(submissionNewCaseShortTitle)
+      .parents('tr')
+      .as('submissionNewCaseRow');
+    cy.get(route.submissionsOverview.row.shortTitle)
+      .contains(submissionExistingCaseShortTitle)
+      .parents('tr')
+      .as('submissionExistingCaseRow');
+
+    // only status changed (The case was removed but was not yet visible to this profile)
+    cy.get('@submissionNewCaseRow').find(route.submissionsOverview.row.status)
+      .should('contain', sentbackStatus);
+
+    cy.get('@submissionExistingCaseRow').find(route.submissionsOverview.row.status)
+      .should('contain', treatedStatus);
+  });
+
+  it('change and resubmit the first submission', () => {
+    const randomInt = Math.floor(Math.random() * Math.floor(10000));
+    cy.intercept('POST', '/submission-status-change-activities')
+      .as(`createNewSubmissionStatusChangeActivity${randomInt}`);
+    cy.intercept('PATCH', '/submissions/*').as(`patchSubmission${randomInt}`);
+
+    cy.login('Kabinetdossierbeheerder');
+    cy.openSubmission(submissionNewCase.shortTitle);
+    // can edit description
+    // can not change anything about the new case
+    cy.get(submissions.descriptionView.edit).click();
+    cy.get(submissions.decisionmakingFlowSelector.newCaseTitle)
+      .should('be.disabled')
+      .should('have.value', submissionNewCase.shortTitle);
+    cy.get(submissions.decisionmakingFlowSelector.useDifferentCase)
+      .should('not.exist');
+    cy.get(submissions.decisionmakingFlowSelector.useExistingCase)
+      .should('not.exist');
+    cy.get(submissions.decisionmakingFlowSelector.useNewCase)
+      .should('not.exist');
+    cy.get(submissions.decisionmakingFlowSelector.existingCaseTitle)
+      .should('not.exist');
+
+    // change to announcement
+    cy.get(submissions.descriptionEdit.agendaitemType).contains(agendaTypeAnnouncement)
+      .find('input')
+      .should('not.be.checked')
+      .parent()
+      .click();
+
+    // currently confidential
+    cy.get(submissions.descriptionEdit.confidential).should('be.checked');
+
+    cy.get(submissions.descriptionEdit.shortTitle).should('have.value', submissionNewCase.shortTitle);
+    cy.get(submissions.descriptionEdit.title).should('not.exist');
+    cy.get(submissions.descriptionEdit.subcaseType).should('contain', submissionNewCase.subcaseType, {
+      matchCase: false,
+    });
+    cy.get(submissions.descriptionEdit.shortcut).should('not.exist');
+    cy.get(submissions.descriptionEdit.shortcutEdit).should('not.exist');
+    cy.get(submissions.descriptionEdit.subcaseName).should('not.exist');
+    cy.get(submissions.descriptionEdit.subcaseNameCancel).should('not.exist');
+    cy.get(submissions.descriptionEdit.subcaseNameClear).should('not.exist');
+    cy.get(submissions.descriptionEdit.save).click();
+    cy.wait(`@patchSubmission${randomInt}`);
+
+    cy.get(mandatee.mandateePanelView.rows).should('have.length', 3);
+    cy.get(mandatee.mandateePanelView.actions.edit).click();
+    cy.get(mandatee.mandateePanelEdit.rows)
+      .eq(0)
+      .within(() => {
+        cy.get(mandatee.mandateePanelEdit.row.submitter)
+          .find('input')
+          .should('not.be.checked')
+          .should('be.disabled');
+        cy.get(mandatee.mandateePanelEdit.row.delete).should('not.be.disabled');
+      });
+    cy.get(mandatee.mandateePanelEdit.rows)
+      .eq(1)
+      .within(() => {
+        cy.get(mandatee.mandateePanelEdit.row.submitter)
+          .find('input')
+          .should('be.checked')
+          .should('be.disabled');
+        cy.get(mandatee.mandateePanelEdit.row.delete).should('be.disabled');
+      });
+    // remove third mandatee
+    cy.get(mandatee.mandateePanelEdit.rows)
+      .eq(2)
+      .within(() => {
+        cy.get(mandatee.mandateePanelEdit.row.submitter)
+          .find('input')
+          .should('not.be.checked')
+          .should('be.disabled');
+        cy.get(mandatee.mandateePanelEdit.row.delete).should('not.be.disabled')
+          .click();
+      });
+    cy.get(mandatee.mandateePanelEdit.actions.save).click();
+    cy.wait(`@patchSubmission${randomInt}`);
+    cy.get(mandatee.mandateePanelView.rows).should('have.length', 2);
+
+    // add a new mandatee
+    cy.addSubmissionMandatee(mandateeNames.current.fourth);
+    cy.get(mandatee.mandateePanelView.rows).should('have.length', 3);
+
+    // this util component is generic and has been tested in other specs
+    cy.get(utils.governmentAreasPanel.edit);
+    cy.get(utils.governmentAreasPanel.rows).as('listItemsAreas');
+    cy.get('@listItemsAreas').should('have.length', 2, {
+      timeout: 5000,
+    });
+    cy.get('@listItemsAreas')
+      .eq(0)
+      .find(utils.governmentAreasPanel.row.label)
+      .should('contain', domain1.name);
+    cy.get('@listItemsAreas')
+      .eq(0)
+      .find(utils.governmentAreasPanel.row.fields)
+      .should('contain', '-');
+    cy.get('@listItemsAreas')
+      .eq(1)
+      .find(utils.governmentAreasPanel.row.label)
+      .should('contain', domain2.name);
+    cy.get('@listItemsAreas')
+      .eq(1)
+      .find(utils.governmentAreasPanel.row.fields)
+      .should('contain', domain2.fields[(0, 1)]);
+
+    // notification edits are allowed
+    cy.get(submissions.notificationsPanel.edit);
+
+    // header
+    cy.get(submissions.submissionHeader.actions).should('not.exist');
+    cy.get(submissions.submissionHeader.requestSendBack).should('not.exist');
+    cy.get(submissions.submissionHeader.resubmit).click();
+    // TODO-command, also used in the createSubmission command
+    // select the agenda for the submission
+    cy.get(submissions.proposableAgendas.agendaRow)
+      .children()
+      .contains(submissionNewCase.agendaDate)
+      .scrollIntoView()
+      .click();
+    // save the form
+    cy.get(submissions.proposableAgendas.save).click();
+    cy.wait(`@createNewSubmissionStatusChangeActivity${randomInt}`);
+    cy.wait(`@patchSubmission${randomInt}`);
+  });
+
+  it('check the submissions table after resubmitting', () => {
+    cy.login('Kabinetdossierbeheerder');
+    cy.visit('/indieningen?aantal=2');
+    // these 2 will only be in view if there is no submission on a later agenda
+    cy.get(route.submissionsOverview.row.shortTitle)
+      .contains(submissionNewCaseShortTitle)
+      .parents('tr')
+      .as('submissionNewCaseRow');
+    cy.get(route.submissionsOverview.row.shortTitle)
+      .contains(submissionExistingCaseShortTitle)
+      .parents('tr')
+      .as('submissionExistingCaseRow');
+
+    // only status changed
+    cy.get('@submissionNewCaseRow').find(route.submissionsOverview.row.status)
+      .should('contain', reSubmittedStatus);
+
+    cy.get('@submissionExistingCaseRow').find(route.submissionsOverview.row.status)
+      .should('contain', treatedStatus);
   });
 
   // needs an existing subcase with at least 1 submission

--- a/cypress/e2e/unit/submission_B.cy.js
+++ b/cypress/e2e/unit/submission_B.cy.js
@@ -1,4 +1,4 @@
-/* global context, it, cy, Cypress, before, afterEach, expect */
+/* global context, it, cy, Cypress, afterEach, expect */
 
 // / <reference types="Cypress" />
 // import cases from '../../selectors/case.selectors';
@@ -36,68 +36,6 @@ const linkedMandatee = {
   fullName: mandateeNames.current.second.fullName,
   submitter: true,
 };
-
-before(() => {
-  cy.login('Admin');
-  cy.createAgenda(null, agendaDate, 'indieningen kabinet');
-  cy.logoutFlow();
-});
-
-context('setup emails and mandatees', () => {
-  afterEach(() => {
-    cy.logout();
-  });
-
-  it('add one mandatee to dossierbeheerder', () => {
-    cy.login('Admin');
-    // setup: add minister to dossierbeheerder
-    cy.visit('instellingen/organisaties/40df7139-fdfb-4ab7-92cd-e73ceba32721');
-    cy.get(settings.organization.technicalInfo.showSelectMandateeModal).click();
-    cy.get(appuniversum.loader).should('not.exist');
-    cy.get(utils.mandateeSelector.container).click();
-    cy.get(dependency.emberPowerSelect.optionLoadingMessage).should(
-      'not.exist'
-    );
-    cy.get(dependency.emberPowerSelect.optionTypeToSearchMessage).should(
-      'not.exist'
-    );
-    cy.get(dependency.emberPowerSelect.option)
-      .contains(linkedMandatee.fullName)
-      .scrollIntoView()
-      .click();
-    cy.intercept('PATCH', '/user-organizations/**').as(
-      'patchUserOrganizations'
-    );
-    cy.get(utils.mandateesSelector.add).should('not.be.disabled')
-      .click();
-    cy.wait('@patchUserOrganizations');
-  });
-
-  it('set email setting defaults', () => {
-    cy.login('Admin');
-    cy.get(utils.mHeader.settings).click();
-    cy.get(settings.overview.manageEmails).click();
-    cy.get(settings.email.publication.requestTo).click()
-      .clear()
-      .type('johan.delaure@redpencil.io');
-    cy.get(settings.email.submission.toSecretary).click()
-      .clear()
-      .type('johan.delaure+sec@redpencil.io');
-    cy.get(settings.email.submission.toIKW).click()
-      .clear()
-      .type('johan.delaure+ikw@redpencil.io');
-    cy.get(settings.email.submission.toKCGroup).click()
-      .clear()
-      .type('johan.delaure+KC@redpencil.io');
-    cy.get(settings.email.submission.replyTo).click()
-      .clear()
-      .type('johan.delaure+replyTo@redpencil.io');
-    cy.intercept('PATCH', '/email-notification-settings/**')
-      .as('patchEmailSettings');
-    cy.get(settings.email.save).click();
-    cy.wait('@patchEmailSettings');
-  });
-});
 
 // create Agenda for all? multiple agendas (1 of each type)? the list in the modal will be massive already
 
@@ -791,27 +729,5 @@ context.skip('change mandatees on organisation', () => {
     cy.get(utils.mandateesSelector.add).should('not.be.disabled')
       .click();
     cy.wait('@patchUserOrganizations');
-  });
-});
-
-context('cleanup mandatees from organisation', () => {
-  it('remove mandatees from organisation', () => {
-    cy.login('Admin');
-    cy.visit('instellingen/organisaties/40df7139-fdfb-4ab7-92cd-e73ceba32721');
-    // unlink first mandatee
-    cy.intercept('PATCH', '/user-organizations/**').as('patchorgs');
-    cy.get(settings.organization.technicalInfo.row.unlinkMandatee)
-      .eq(0)
-      .click();
-    cy.get(settings.organization.confirm.unlinkMandatee)
-      .click()
-      .wait('@patchorgs');
-    // unlink second mandatee
-    // cy.get(settings.organization.technicalInfo.row.unlinkMandatee).eq(0)
-    //   .click();
-    // cy.get(settings.organization.confirm.unlinkMandatee).click()
-    //   .wait('@patchorgs');
-    // cy.get(settings.organization.technicalInfo.row.mandatee).should('not.exist');
-    cy.logout();
   });
 });

--- a/cypress/e2e/unit/submission_C.cy.js
+++ b/cypress/e2e/unit/submission_C.cy.js
@@ -1,0 +1,454 @@
+/* global context, it, cy, beforeEach, afterEach, expect */
+
+// / <reference types="Cypress" />
+import cases from '../../selectors/case.selectors';
+// import dependency from '../../selectors/dependency.selectors';
+// import agenda from '../../selectors/agenda.selectors';
+// import publication from '../../selectors/publication.selectors';
+// import auk from '../../selectors/auk.selectors';
+import appuniversum from '../../selectors/appuniversum.selectors';
+import document from '../../selectors/document.selectors';
+// import settings from '../../selectors/settings.selectors';
+import mandatee from '../../selectors/mandatee.selectors';
+// import route from '../../selectors/route.selectors';
+// import signature from '../../selectors/signature.selectors';
+import mandateeNames from '../../selectors/mandatee-names.selectors';
+import submissions from '../../selectors/submission.selectors';
+import utils from '../../selectors/utils.selectors';
+
+// TODO-submission test sending back, request sending back, removing, sending back when on agenda
+// TODO-submission more profile testing, who can see what when.
+// TODO-submission all update submission testing
+// TODO-submission change mandatee to co-mandatee and check actions
+// TODO-submission change mandatee to not a co-mandatee and check actions
+
+// function currentTimestamp() {
+//   return Cypress.dayjs().unix();
+// }
+
+function uploadDraftFileWithWrongFormat(file) {
+  const spy = cy.spy();
+  const randomInt = Math.floor(Math.random() * Math.floor(10000));
+  cy.get(submissions.documentUploadPanel.panel).as('fileUploadDialog');
+  cy.intercept('POST', '/draft-files', spy).as(`createNewDraftFile${randomInt}`);
+
+  cy.get('@fileUploadDialog').within(() => {
+    const fileFullName = `${file.fileName}.${file.fileExtension}`;
+    const filePath = `${file.folder}/${fileFullName}`;
+
+    cy.fixture(filePath, {
+      encoding: null,
+    }).then((fileContent) => {
+      cy.get('[type=file]').selectFile(
+        {
+          contents: fileContent,
+          fileName: fileFullName,
+          mimeType: file.mimeType,
+        }
+      );
+    });
+    cy.wait(2000).then(() => expect(spy).not.to.have.been.called);
+  });
+}
+
+// const agendaDate = Cypress.dayjs().add(4, 'weeks')
+//   .day(1); // anything but day 4
+// const agendaDate = Cypress.dayjs('2024-09-13');
+
+const linkedMandatee = {
+  // the second active mandatee will be our linked mandatee
+  mandatee: mandateeNames.current.second, // might not be needed, depends what we want to check
+  fullName: mandateeNames.current.second.fullName,
+  submitter: true,
+};
+
+context('Cancel editing tests on new submission form for new case', () => {
+  beforeEach(() => {
+    cy.login('Kabinetdossierbeheerder');
+  });
+
+  afterEach(() => {
+    cy.logout();
+  });
+
+  const secEmail = 'example+sec@test.com';
+  const ikwEmail = 'example+ikw@test.com';
+  const kcEmail = 'example+KC@test.com';
+
+  const pdfFile = {
+    folder: 'files',
+    fileName: 'test onderwerp-1-nota',
+    fileExtension: 'pdf',
+    newFileName: 'submission 1 nota pdf',
+    fileTypeLong: 'Nota',
+    fileTypeParsed: true,
+  };
+
+  const docxFile = {
+    folder: 'files',
+    fileName: 'test',
+    fileExtension: 'docx',
+    mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    newFileName: 'submission 1 nota docx',
+  };
+
+  it('Cancel form with documents', () => {
+    cy.intercept('DELETE', '/draft-files/*').as('deleteNewDraftFile');
+
+    cy.visit('indieningen?aantal=2');
+    cy.get(cases.casesHeader.openSubmissionModal).click();
+    cy.get(cases.casesHeader.navigateToNewSubmission).click();
+    cy.addDocumentsInSubmissionFileUpload([pdfFile]);
+    cy.get(submissions.newSubmissionForm.cancel).click();
+    cy.wait('@deleteNewDraftFile');
+  });
+
+  it('Remove document from form', () => {
+    cy.intercept('DELETE', '/draft-files/*').as('deleteNewDraftFile');
+
+    cy.visit('indieningen?aantal=2');
+    cy.get(cases.casesHeader.openSubmissionModal).click();
+    cy.get(cases.casesHeader.navigateToNewSubmission).click();
+    cy.addDocumentsInSubmissionFileUpload([pdfFile]);
+    cy.get(document.vlUploadedDocument.deletePiece).should('exist')
+      .click()
+      .wait('@deleteNewDraftFile');
+    cy.get(document.vlUploadedDocument.filename).should('not.exist');
+
+    cy.get(submissions.newSubmissionForm.cancel).click();
+  });
+
+  it('Only allow certain type of files on submissions', () => {
+    const fileTxt = {
+      folder: 'files',
+      fileName: 'test',
+      fileExtension: 'txt',
+      mimeType: 'text/plain',
+    };
+
+    cy.intercept('DELETE', '/draft-files/*').as('deleteNewDraftFile');
+
+    cy.visit('indieningen?aantal=2');
+    cy.get(cases.casesHeader.openSubmissionModal).click();
+    cy.get(cases.casesHeader.navigateToNewSubmission).click();
+    // cy.addDocumentsInSubmissionFileUpload([fileTxt]);
+    uploadDraftFileWithWrongFormat(fileTxt);
+    cy.get(document.vlUploadedDocument.filename).should('not.exist');
+    cy.get(appuniversum.toaster).contains('Geldige bestandsformaten zijn');
+    cy.get(appuniversum.alert.close).click();
+
+    // pdf files tests above, no fixtures exist yet for .xlsx and .zip
+    // should pass:
+    // .pdf, .PDF (will get lowercased), .docx, .xlsx, .zip
+    // should fail:
+    // .doc, .xls, image formats, .odt and any not listed
+    // only restricted to profiles without the permissions "upload-any-submission-document-extension"
+    cy.addDocumentsInSubmissionFileUpload([docxFile]);
+    cy.get(document.vlUploadedDocument.filename).should('have.length', 1);
+    cy.get(appuniversum.alert.close).should('not.exist');
+
+    cy.get(submissions.newSubmissionForm.cancel).click();
+    cy.wait('@deleteNewDraftFile');
+  });
+
+  it('Confidentiality effect on docs and email', () => {
+    cy.intercept('DELETE', '/draft-files/*').as('deleteNewDraftFile');
+
+    cy.visit('indieningen?aantal=2');
+    cy.get(cases.casesHeader.openSubmissionModal).click();
+    cy.get(cases.casesHeader.navigateToNewSubmission).click();
+
+    cy.get(submissions.notificationsPanel.approvers.item).as(
+      'listItemsApprovers'
+    );
+    cy.get(submissions.notificationsPanel.notification.item).as(
+      'listItemsNotified'
+    );
+    // default emails from setting / normal submission
+    cy.get('@listItemsApprovers').should('have.length', 1);
+    cy.get(submissions.notificationsPanel.approvers.item).contains(secEmail);
+    cy.get('@listItemsNotified').should('have.length', 1);
+    cy.get(submissions.notificationsPanel.notification.item).contains(ikwEmail);
+
+    // toggle confidential on submission
+    cy.get(submissions.newSubmissionForm.toggleConfidential).should('not.be.checked')
+      .parent()
+      .click();
+    cy.get(submissions.newSubmissionForm.toggleConfidential).should('be.checked');
+
+    // confidential changes notified
+    cy.get('@listItemsApprovers').should('have.length', 1);
+    cy.get(submissions.notificationsPanel.approvers.item).contains(secEmail);
+    cy.get('@listItemsNotified').should('have.length', 1);
+    cy.get(submissions.notificationsPanel.notification.item).contains(kcEmail);
+
+    // docs uploaded with confidential become confidential
+    cy.addDocumentsInSubmissionFileUpload([pdfFile]);
+    cy.get(document.uploadedDocument.accessLevel).should('be.checked');
+
+    // confidential submission and confidential doc > no changes
+    cy.get('@listItemsApprovers').should('have.length', 1);
+    cy.get(submissions.notificationsPanel.approvers.item).contains(secEmail);
+    cy.get('@listItemsNotified').should('have.length', 1);
+    cy.get(submissions.notificationsPanel.notification.item).contains(kcEmail);
+
+    // toggle confidential on submission
+    cy.get(submissions.newSubmissionForm.toggleConfidential).should('be.checked')
+      .parent()
+      .click();
+    cy.get(submissions.newSubmissionForm.toggleConfidential).should('not.be.checked');
+
+    // normal submission and confidential doc > notified changes
+    cy.get('@listItemsApprovers').should('have.length', 1);
+    cy.get(submissions.notificationsPanel.approvers.item).contains(secEmail);
+    cy.get('@listItemsNotified').should('have.length', 2);
+    cy.get(submissions.notificationsPanel.notification.item).contains(kcEmail);
+    cy.get(submissions.notificationsPanel.notification.item).contains(ikwEmail);
+
+    // toggle confidential on doc
+    cy.get(document.uploadedDocument.accessLevel).should('be.checked')
+      .parent()
+      .click();
+    cy.get(document.uploadedDocument.accessLevel).should('not.be.checked');
+
+    // normal submission and normal doc > changes notified
+    cy.get('@listItemsApprovers').should('have.length', 1);
+    cy.get(submissions.notificationsPanel.approvers.item).contains(secEmail);
+    cy.get('@listItemsNotified').should('have.length', 1);
+    cy.get(submissions.notificationsPanel.notification.item).contains(ikwEmail);
+
+    // toggle confidential on submission
+    cy.get(submissions.newSubmissionForm.toggleConfidential).should('not.be.checked')
+      .parent()
+      .click();
+    cy.get(submissions.newSubmissionForm.toggleConfidential).should('be.checked');
+
+    // any existing docs become confidential, notified changes
+    cy.get(appuniversum.toaster).contains('De rechten van de reeds opgeladen documenten werden aangepast');
+
+    cy.get(document.uploadedDocument.accessLevel).should('be.checked');
+    cy.get('@listItemsApprovers').should('have.length', 1);
+    cy.get(submissions.notificationsPanel.approvers.item).contains(secEmail);
+    cy.get('@listItemsNotified').should('have.length', 1);
+    cy.get(submissions.notificationsPanel.notification.item).contains(kcEmail);
+
+    cy.get(submissions.newSubmissionForm.cancel).click();
+  });
+
+  it('Can not remove your own mandatee / other mandatees get added or removed when clicked', () => {
+    cy.visit('indieningen?aantal=2');
+    cy.get(cases.casesHeader.openSubmissionModal).click();
+    cy.get(cases.casesHeader.navigateToNewSubmission).click();
+
+    // checkbox tree, input for our mandatee is disabled and checked
+    cy.get(mandatee.mandateeSelectorPanel.container)
+      .find(appuniversum.checkbox)
+      .contains(linkedMandatee.fullName)
+      .parent()
+      .find('input')
+      .as('linkedMandateeCheckbox');
+    cy.get('@linkedMandateeCheckbox')
+      .should('be.checked')
+      .should('be.disabled');
+
+    // list with submitter toggle. Should be check and disabled
+    cy.get(mandatee.mandateeSelectorPanel.selectedMinister).as('listItems');
+    cy.get('@listItems').should('have.length', 1);
+    cy.get('@listItems')
+      .find(mandatee.mandateeSelectorPanel.selectedMinisterName)
+      .contains(linkedMandatee.fullName)
+      .parents(mandatee.mandateeSelectorPanel.selectedMinister)
+      .as('linkedMandateeRow');
+    cy.get('@linkedMandateeRow')
+      .find(mandatee.mandateeSelectorPanel.submitterRadio)
+      .should('be.disabled')
+      .should('be.checked');
+
+    // only 1 is checked
+    cy.get(mandatee.mandateeSelectorPanel.container)
+      .find(utils.checkboxTree.toggleSingle)
+      .parent()
+      .find(':checked')
+      .should('have.length', 1);
+
+    // add all mandatees
+    cy.get(mandatee.mandateeSelectorPanel.container)
+      .find(utils.checkboxTree.toggleAll)
+      .parent()
+      .click();
+
+    // our mandatee is unchanged
+    cy.get('@linkedMandateeCheckbox')
+      .should('be.checked')
+      .should('be.disabled');
+    cy.get('@linkedMandateeRow')
+      .find(mandatee.mandateeSelectorPanel.submitterRadio)
+      .should('be.disabled')
+      .should('be.checked');
+
+    // all mandatees are toggled
+    cy.get(mandatee.mandateeSelectorPanel.container)
+      .find(utils.checkboxTree.toggleSingle)
+      .parent()
+      .find(':checked')
+      .should('have.length', 9);
+
+    // all mandatees in list, 1 checked, all disabled
+    cy.get('@listItems').should('have.length', 9);
+    cy.get('@listItems').find(':checked')
+      .and('have.length', 1); // only 1 is checked
+    cy.get('@listItems').find(':disabled')
+      .and('have.length', 9); // all are disabled
+
+    // remove all mandatees
+    cy.get(utils.checkboxTree.toggleAll)
+      .parent()
+      .click();
+
+    // our mandatee is unchanged
+    cy.get('@linkedMandateeCheckbox')
+      .should('be.checked')
+      .should('be.disabled');
+    cy.get('@linkedMandateeRow')
+      .find(mandatee.mandateeSelectorPanel.submitterRadio)
+      .should('be.disabled')
+      .should('be.checked');
+
+    // only 1 in the list
+    cy.get('@listItems').should('have.length', 1);
+    cy.get('@listItems').find(':checked')
+      .and('have.length', 1);
+    cy.get('@listItems').find(':disabled')
+      .and('have.length', 1);
+
+    // add 1 mandatee
+    cy.get(mandatee.mandateeSelectorPanel.container)
+      .find(utils.checkboxTree.toggleSingle)
+      .parent()
+      .eq(5)
+      .click();
+
+    // our mandatee is unchanged
+    cy.get('@linkedMandateeCheckbox')
+      .should('be.checked')
+      .should('be.disabled');
+    cy.get('@linkedMandateeRow')
+      .find(mandatee.mandateeSelectorPanel.submitterRadio)
+      .should('be.disabled')
+      .should('be.checked');
+
+    // 2 mandatees are toggled
+    cy.get(mandatee.mandateeSelectorPanel.container)
+      .find(utils.checkboxTree.toggleSingle)
+      .parent()
+      .find(':checked')
+      .should('have.length', 2);
+
+    // 2 in the list
+    cy.get('@listItems').should('have.length', 2);
+    cy.get('@listItems').find(':checked')
+      .and('have.length', 1);
+    cy.get('@listItems').find(':disabled')
+      .and('have.length', 2);
+  });
+
+  it('Add and delete emails, default emails can not be deleted', () => {
+    const emailToAdd = 'test@email.com';
+    cy.visit('indieningen?aantal=2');
+    cy.get(cases.casesHeader.openSubmissionModal).click();
+    cy.get(cases.casesHeader.navigateToNewSubmission).click();
+
+    cy.get(submissions.notificationsPanel.approvers.item).should('have.length', 1);
+    cy.get(submissions.notificationsPanel.approvers.remove).should('not.exist');
+    cy.get(submissions.notificationsPanel.notification.item).should('have.length', 1);
+    cy.get(submissions.notificationsPanel.notification.remove).should('not.exist');
+
+    cy.get(submissions.notificationsPanel.approvers.add).click();
+    cy.get(utils.emailModal.input).click()
+      .type(emailToAdd);
+    cy.get(utils.emailModal.add).click();
+
+    cy.get(submissions.notificationsPanel.notification.add).click();
+    cy.get(utils.emailModal.input).click()
+      .type(emailToAdd);
+    cy.get(utils.emailModal.add).click();
+
+    // the added emails can be removed
+    cy.get(submissions.notificationsPanel.approvers.item).should('have.length', 2);
+    cy.get(submissions.notificationsPanel.approvers.remove).should('have.length', 1);
+    cy.get(submissions.notificationsPanel.notification.item).should('have.length', 2);
+    cy.get(submissions.notificationsPanel.notification.remove).should('have.length', 1);
+
+    cy.get(submissions.notificationsPanel.approvers.item)
+      .contains(secEmail)
+      .find(submissions.notificationsPanel.approvers.remove)
+      .should('not.exist');
+    cy.get(submissions.notificationsPanel.approvers.item)
+      .contains(emailToAdd)
+      .find(submissions.notificationsPanel.approvers.remove)
+      .click();
+
+    cy.get(submissions.notificationsPanel.notification.item)
+      .contains(ikwEmail)
+      .find(submissions.notificationsPanel.notification.remove)
+      .should('not.exist');
+    cy.get(submissions.notificationsPanel.notification.item)
+      .contains(emailToAdd)
+      .find(submissions.notificationsPanel.notification.remove)
+      .click();
+
+    // both removed, no remove button
+    cy.get(submissions.notificationsPanel.approvers.item).should('have.length', 1);
+    cy.get(submissions.notificationsPanel.approvers.remove).should('not.exist');
+    cy.get(submissions.notificationsPanel.notification.item).should('have.length', 1);
+    cy.get(submissions.notificationsPanel.notification.remove).should('not.exist');
+
+    // add another notification mail
+    cy.get(submissions.notificationsPanel.notification.add).click();
+    cy.get(utils.emailModal.input).click()
+      .type(emailToAdd);
+    cy.get(utils.emailModal.add).click();
+
+    // confidential changes default notification email but keeps the added email
+    // toggle confidential on submission
+    cy.get(submissions.newSubmissionForm.toggleConfidential).should('not.be.checked')
+      .parent()
+      .click();
+    cy.get(submissions.newSubmissionForm.toggleConfidential).should('be.checked');
+
+    cy.get(submissions.notificationsPanel.notification.item).should('have.length', 2);
+    cy.get(submissions.notificationsPanel.notification.remove).should('have.length', 1);
+
+    cy.get(submissions.notificationsPanel.notification.item)
+      .contains(kcEmail)
+      .find(submissions.notificationsPanel.notification.remove)
+      .should('not.exist');
+    cy.get(submissions.notificationsPanel.notification.item)
+      .contains(emailToAdd)
+      .find(submissions.notificationsPanel.notification.remove)
+      .click();
+    cy.get(submissions.notificationsPanel.notification.item).should('have.length', 1);
+    cy.get(submissions.notificationsPanel.notification.remove).should('not.exist');
+  });
+
+  it('Scenarios preventing the creation of a submission', () => {
+    cy.visit('indieningen?aantal=2');
+    cy.get(cases.casesHeader.openSubmissionModal).click();
+    cy.get(cases.casesHeader.navigateToNewSubmission).click();
+    // these are mandatory:
+    // - short title not empty (only whitespaces count for now but really shouldn't)
+    // - subcase type selected
+    // - at least 1 document
+    // - all documents must have a document type (button enabled but red toast is shown)
+
+    // nothing filled in, save is disabled
+    cy.get(submissions.newSubmissionForm.save).should('be.disabled');
+
+    // upload doc with a type > disabled
+    // add short title > disabled
+    // add subcase type > enabled
+    // remove short title > disabled
+    // add short title and remove doc > disabled
+    // add document without type > enabled but error is thrown
+  });
+});

--- a/cypress/e2e/unit/submission_C.cy.js
+++ b/cypress/e2e/unit/submission_C.cy.js
@@ -16,12 +16,6 @@ import mandateeNames from '../../selectors/mandatee-names.selectors';
 import submissions from '../../selectors/submission.selectors';
 import utils from '../../selectors/utils.selectors';
 
-// TODO-submission test sending back, request sending back, removing, sending back when on agenda
-// TODO-submission more profile testing, who can see what when.
-// TODO-submission all update submission testing
-// TODO-submission change mandatee to co-mandatee and check actions
-// TODO-submission change mandatee to not a co-mandatee and check actions
-
 // function currentTimestamp() {
 //   return Cypress.dayjs().unix();
 // }

--- a/cypress/e2e/unit/submission_D.cy.js
+++ b/cypress/e2e/unit/submission_D.cy.js
@@ -2,18 +2,17 @@
 
 // / <reference types="Cypress" />
 // import cases from '../../selectors/case.selectors';
-import dependency from '../../selectors/dependency.selectors';
 import agenda from '../../selectors/agenda.selectors';
-// import publication from '../../selectors/publication.selectors';
-// import auk from '../../selectors/auk.selectors';
 import appuniversum from '../../selectors/appuniversum.selectors';
-// import document from '../../selectors/document.selectors';
-import settings from '../../selectors/settings.selectors';
-// import mandatee from '../../selectors/mandatee.selectors';
-import route from '../../selectors/route.selectors';
-// import signature from '../../selectors/signature.selectors';
+import auk from '../../selectors/auk.selectors';
+import cases from '../../selectors/case.selectors';
+import dependency from '../../selectors/dependency.selectors';
+import document from '../../selectors/document.selectors';
+import mandatee from '../../selectors/mandatee.selectors';
 import mandateeNames from '../../selectors/mandatee-names.selectors';
-// import submissions from '../../selectors/submission.selectors';
+import route from '../../selectors/route.selectors';
+import settings from '../../selectors/settings.selectors';
+import submissions from '../../selectors/submission.selectors';
 import utils from '../../selectors/utils.selectors';
 
 // TODO-submission test sending back, request sending back, removing, sending back when on agenda
@@ -47,9 +46,11 @@ const newLinkedMandatee = {
 const limitedAccess = 'Beperkte toegang';
 const submittedStatus = 'Ingediend';
 const inTreatmentStatus = 'In behandeling';
-// const treatedStatus = 'Behandeld';
+const treatedStatus = 'Behandeld';
 // const sentbackStatus = 'Teruggestuurd';
-// const reSubmittedStatus = 'Opnieuw ingediend';
+const updateSubmitted = 'Update ingediend';
+const reSubmittedStatus = 'Opnieuw ingediend';
+const onAgendaStatus = 'Geagendeerd';
 
 // const accessCabinet = 'Intern Regering';
 // const accessConfidential = 'Vertrouwelijk';
@@ -60,6 +61,21 @@ const agendaTypeNota = 'Nota';
 const submissionOtherSpecNewCaseShortTitle = 'Submission new case short title 1';
 const submissionOtherSpecExistingCaseShortTitle = 'Submission existing case short title 1';
 
+const newDraftPiece = {
+  folder: 'files',
+  fileName: 'test onderwerp-1-nota',
+  fileExtension: 'pdf',
+  // newFileName: 'submission 1 nota pdf',
+};
+const newPdfFile = {
+  folder: 'files',
+  fileName: 'test onderwerp-3-IF',
+  fileExtension: 'pdf',
+  newFileName: 'submission 3 IF pdf',
+  fileTypeLong: 'Advies Inspectie Financiën',
+  fileTypeParsed: true,
+};
+const updateComment = 'New documents for update';
 
 context('change mandatees on organisation', () => {
   afterEach(() => {
@@ -354,6 +370,262 @@ context('Create 2 submissions as first mandatee', () => {
     // The new agendaitem has been put on the bottom below the approved ones
     cy.get(agenda.agendaOverviewItem.subitem).eq(3)
       .contains(submissionAnotherNewCaseShortTitle);
+  });
+
+  it('test the submissions overview sorting and filter', () => {
+    cy.login('Kanselarij');
+    cy.visit('/indieningen?aantal=5');
+    cy.get(route.submissionsOverview.row.shortTitle).should('have.length', 4);
+    cy.get(route.submissionsOverview.row.shortTitle).contains(submissionOtherSpecNewCaseShortTitle)
+      .parents('tr')
+      .find(route.submissionsOverview.row.status)
+      .should('contain', reSubmittedStatus);
+    cy.get(route.submissionsOverview.row.shortTitle).contains(submissionOtherSpecExistingCaseShortTitle)
+      .parents('tr')
+      .find(route.submissionsOverview.row.status)
+      .should('contain', onAgendaStatus);
+    cy.get(route.submissionsOverview.row.shortTitle).contains(submissionNewCaseShortTitle)
+      .parents('tr')
+      .find(route.submissionsOverview.row.status)
+      .should('contain', onAgendaStatus);
+    cy.get(route.submissionsOverview.row.shortTitle).contains(submissionAnotherNewCaseShortTitle)
+      .parents('tr')
+      .find(route.submissionsOverview.row.status)
+      .should('contain', treatedStatus);
+    // TODO add tests for filters, mandatees, sorting here. (date filter may need multiple agendas for better tests)
+
+    // treated = not propagated yet. Editors see the subcase view after clicking
+    cy.get(route.submissionsOverview.row.shortTitle).contains(submissionAnotherNewCaseShortTitle)
+      .parents('tr')
+      .find(route.submissionsOverview.row.goToSubmission)
+      .click();
+    cy.get(appuniversum.loader);
+    cy.get(appuniversum.loader).should('not.exist');
+    cy.url().should('contain', '/dossiers/');
+    cy.url().should('contain', '/deeldossiers/');
+  });
+
+  it('treated second submission is not propagated yet', () => {
+    cy.login('Kabinetdossierbeheerder');
+    cy.visit('/indieningen?aantal=5');
+    // creators see the submissions view after clicking
+    cy.get(route.submissionsOverview.row.shortTitle).contains(submissionAnotherNewCaseShortTitle)
+      .parents('tr')
+      .find(route.submissionsOverview.row.goToSubmission)
+      .click();
+    cy.get(appuniversum.loader);
+    cy.get(appuniversum.loader).should('not.exist');
+    cy.url().should('contain', '/dossiers/');
+    cy.url().should('contain', '/indieningen/');
+  });
+
+  // TODO CRUD on a BIS update maybe later or before the next it?
+
+  it('create BIS update for first submission', () => {
+    const randomInt = Math.floor(Math.random() * Math.floor(10000));
+
+    cy.login('Kabinetdossierbeheerder');
+    cy.visit('/indieningen?aantal=5');
+    // on agenda = propagated on open meeting. creators see the subcase view and can submit updates
+    cy.get(route.submissionsOverview.row.shortTitle).contains(submissionNewCaseShortTitle)
+      .parents('tr')
+      .find(route.submissionsOverview.row.goToSubmission)
+      .click();
+    cy.get(appuniversum.loader);
+    cy.get(appuniversum.loader).should('not.exist');
+    cy.url().should('contain', '/dossiers/');
+    cy.url().should('contain', '/deeldossiers/');
+    cy.url().should('not.contain', '/nieuwe-indiening');
+
+    // previous submissions history
+    cy.get(submissions.historyPanel.panel);
+    cy.get(submissions.statusChangeActivity.item).should('have.length', 3);
+
+    cy.get(cases.subcaseHeader.createUpdateSubmission).click();
+    cy.get(appuniversum.loader).should('not.exist');
+    cy.url().should('contain', '/dossiers/');
+    cy.url().should('contain', '/deeldossiers/');
+    cy.url().should('contain', '/nieuwe-indiening');
+
+    // limited edit on update submissions
+    cy.get(submissions.descriptionView.panel);
+    cy.get(submissions.descriptionView.edit).should('not.exist');
+    cy.get(mandatee.mandateePanelView.actions.edit);
+    cy.get(utils.governmentAreasPanel.emptyState); // we didn't add any
+    cy.get(utils.governmentAreasPanel.edit).should('not.exist');
+    cy.get(submissions.notificationsPanel.edit).should('not.exist');
+    cy.get(submissions.notificationsPanel.approvers.add);
+    cy.get(submissions.notificationsPanel.approvers.commentEdit);
+    cy.get(submissions.notificationsPanel.notification.add);
+    cy.get(submissions.notificationsPanel.notification.commentEdit);
+    // doc 1 is a real piece, only new version is allowed
+    cy.get(document.addDraftDocumentCard.card).should('have.length', 2);
+    cy.get(document.addDraftDocumentCard.card).eq(0)
+      .as('doc1');
+    cy.get('@doc1').find(document.addDraftDocumentCard.name.value)
+      .contains('VR 20'); // this document has gotten a VR number
+    cy.get('@doc1').find(document.addDraftDocumentCard.name.value)
+      .contains(submissionNewCase.documents[0].newFileName);
+    cy.get('@doc1').find(document.addDraftDocumentCard.name.value)
+      .should('not.contain', 'BIS');
+    cy.get('@doc1').find(document.addDraftDocumentCard.versionHistory)
+      .should('not.exist');
+    cy.get('@doc1').find(document.addDraftDocumentCard.type)
+      .contains(submissionNewCase.agendaitemType);
+    cy.get('@doc1').find(document.addDraftDocumentCard.uploadDraftPiece);
+    cy.get('@doc1').find(document.addDraftDocumentCard.deleteDraftPiece)
+      .should('not.exist');
+    cy.get('@doc1').find(document.accessLevelPill.edit)
+      .should('not.exist');
+
+    cy.get(route.draftUpdateSubmission.addDraftDocuments);
+    cy.get(route.draftUpdateSubmission.cancel);
+    cy.get(route.draftUpdateSubmission.save).should('be.disabled')
+      .contains('Nieuwe indiening'); // we need at least 1 document to allow saving
+
+    cy.addNewDraftPiece(submissionNewCase.documents[0].newFileName, newDraftPiece);
+    cy.addDocumentsInUpdateSubmissionFileUpload([newPdfFile]);
+
+    // there are now 3 documents
+    cy.get(document.addDraftDocumentCard.card).should('have.length', 3);
+    cy.get('@doc1').find(document.addDraftDocumentCard.name.value)
+      .contains('VR 20');
+    cy.get('@doc1').find(document.addDraftDocumentCard.name.value)
+      .contains(submissionNewCase.documents[0].newFileName);
+    // this changed
+    cy.get('@doc1').find(document.addDraftDocumentCard.versionHistory);
+    cy.get('@doc1').find(document.addDraftDocumentCard.name.value)
+      .should('contain', 'BIS');
+    // we can now only delete the uploaded draft file
+    cy.get('@doc1').find(document.addDraftDocumentCard.uploadDraftPiece)
+      .should('not.exist');
+    cy.get('@doc1').find(document.addDraftDocumentCard.deleteDraftPiece);
+
+    cy.get(document.addDraftDocumentCard.card).eq(2)
+      .as('doc3');
+    cy.get('@doc3').find(document.addDraftDocumentCard.name.value)
+      .should('not.contain', 'VR 20'); // this document does not have a VR number yet
+    cy.get('@doc3').find(document.addDraftDocumentCard.name.value)
+      .contains(newPdfFile.newFileName);
+    cy.get('@doc3').find(document.addDraftDocumentCard.type)
+      .contains(newPdfFile.fileTypeLong);
+    // new draft piece can only be deleted
+    cy.get('@doc1').find(document.addDraftDocumentCard.uploadDraftPiece)
+      .should('not.exist');
+    cy.get('@doc1').find(document.addDraftDocumentCard.deleteDraftPiece);
+    // TODO should we show the accesslevel? no way to see if this doc is confidential at this stage (which might be important)
+    cy.get('@doc3').find(document.accessLevelPill.edit)
+      .should('not.exist');
+
+    cy.get(route.draftUpdateSubmission.save).should('not.be.disabled')
+      .click();
+
+    // when proposing if not postponed
+    // there is no choice of agendas here, this is a different modal
+    cy.get(submissions.proposableAgendas.comment).should('not.exist');
+    cy.get(route.draftUpdateSubmission.submitComment).type(updateComment);
+
+    // save the submission
+    // TODO-command to avoid repetitive intercepts/waits for update submissions
+    cy.intercept('POST', '/submissions').as(`createNewSubmission${randomInt}`);
+    cy.intercept('PATCH', '/draft-pieces/**').as('patchDraftPieces');
+    cy.intercept('POST', '/submission-status-change-activities')
+      .as('createNewSubmissionStatusChangeActivity');
+    // should be 3, 1-3 may fail depending on email adresses set on profile and settings
+    cy.intercept('POST', '/emails').as('createMails');
+    cy.intercept('POST', '/meetings/*/submit-submission').as('submitSubmission');
+
+    cy.get(auk.confirmationModal.footer.confirm).contains('Nieuwe indiening')
+      .click();
+
+    // patch to draft piece = linking the submission
+    cy.wait('@patchDraftPieces', {
+      timeout: 24000,
+    });
+    cy.wait('@createNewSubmissionStatusChangeActivity');
+    cy.wait(`@createNewSubmission${randomInt}`);
+    cy.wait('@createMails');
+    cy.wait('@submitSubmission');
+
+    cy.get(appuniversum.loader, {
+      timeout: 60000,
+    }).should('not.exist');
+
+    // check if we have transitioned to the detail page of the submission
+    cy.get(submissions.descriptionView.panel);
+
+    // TODO alert from mail creation pops up because the profile dossierbeheerder has no email set
+    cy.get(appuniversum.alert.close).click();
+
+    // user is able to request a sendback
+    cy.get(submissions.submissionHeader.requestSendBack);
+    cy.get(submissions.overviewHeader.caseLink).click();
+    cy.get(appuniversum.loader).should('not.exist');
+    cy.get(cases.subcaseHeader.createUpdateSubmission).should('not.exist');
+    cy.get(cases.subcaseHeader.openCurrentSubmission);
+
+    // submission history panel
+    cy.get(submissions.statusChangeActivity.item).should('have.length', 4);
+    // this profile can't see the comment
+    cy.get(submissions.statusChangeActivity.item).eq(0)
+      .should('not.contain', updateComment)
+      .should('contain', updateSubmitted);
+  });
+
+  it('check views as kanselarij after creating update', () => {
+    cy.login('Kanselarij');
+    cy.visit('/indieningen?aantal=5');
+    // since we sort on modified, the new update should always be at the top
+    cy.get(route.submissionsOverview.row.shortTitle).should('have.length', 5);
+    cy.get(route.submissionsOverview.row.shortTitle).contains(submissionOtherSpecNewCaseShortTitle)
+      .parents('tr')
+      .find(route.submissionsOverview.row.status)
+      .should('contain', reSubmittedStatus);
+    cy.get(route.submissionsOverview.row.shortTitle).contains(submissionOtherSpecExistingCaseShortTitle)
+      .parents('tr')
+      .find(route.submissionsOverview.row.status)
+      .should('contain', onAgendaStatus);
+    cy.get(route.submissionsOverview.row.shortTitle).contains(submissionAnotherNewCaseShortTitle)
+      .parents('tr')
+      .find(route.submissionsOverview.row.status)
+      .should('contain', treatedStatus);
+
+    // there are now 2 rows with the same name
+    // previous submission is still on agenda
+    cy.get(route.submissionsOverview.row.status)
+      .should('contain', onAgendaStatus)
+      .parents('tr')
+      .find(route.submissionsOverview.row.shortTitle)
+      .contains(submissionNewCaseShortTitle);
+    // new submission is an update, open it
+    cy.get(route.submissionsOverview.row.shortTitle).eq(0)
+      .contains(submissionNewCaseShortTitle)
+      .parents('tr')
+      .as('updateSubmissionRow');
+    cy.get('@updateSubmissionRow').find(route.submissionsOverview.row.status)
+      .should('contain', updateSubmitted);
+    cy.get('@updateSubmissionRow').find(route.submissionsOverview.row.goToSubmission)
+      .click();
+
+    // submission view
+    // submission history panel of this submission
+    cy.get(submissions.historyPanel.panel);
+    cy.get(submissions.statusChangeActivity.item).should('have.length', 1);
+    cy.get(submissions.statusChangeActivity.item).eq(0)
+      .should('contain', updateComment)
+      .should('contain', updateSubmitted);
+
+    cy.get(submissions.overviewHeader.caseLink).click();
+    cy.get(appuniversum.loader).should('not.exist');
+    cy.get(cases.subcaseHeader.createUpdateSubmission).should('not.exist');
+    cy.get(cases.subcaseHeader.openCurrentSubmission);
+
+    // submission history panel on subcase view
+    cy.get(submissions.statusChangeActivity.item).should('have.length', 4);
+    // this profile can see the comment
+    cy.get(submissions.statusChangeActivity.item).eq(0)
+      .should('contain', updateComment)
+      .should('contain', updateSubmitted);
   });
 });
 

--- a/cypress/e2e/unit/submission_D.cy.js
+++ b/cypress/e2e/unit/submission_D.cy.js
@@ -1,0 +1,401 @@
+/* global context, it, cy, Cypress, afterEach */
+
+// / <reference types="Cypress" />
+// import cases from '../../selectors/case.selectors';
+import dependency from '../../selectors/dependency.selectors';
+import agenda from '../../selectors/agenda.selectors';
+// import publication from '../../selectors/publication.selectors';
+// import auk from '../../selectors/auk.selectors';
+import appuniversum from '../../selectors/appuniversum.selectors';
+// import document from '../../selectors/document.selectors';
+import settings from '../../selectors/settings.selectors';
+// import mandatee from '../../selectors/mandatee.selectors';
+import route from '../../selectors/route.selectors';
+// import signature from '../../selectors/signature.selectors';
+import mandateeNames from '../../selectors/mandatee-names.selectors';
+// import submissions from '../../selectors/submission.selectors';
+import utils from '../../selectors/utils.selectors';
+
+// TODO-submission test sending back, request sending back, removing, sending back when on agenda
+// TODO-submission more profile testing, who can see what when.
+// TODO-submission all update submission testing
+// TODO-submission change mandatee to co-mandatee and check actions
+// TODO-submission change mandatee to not a co-mandatee and check actions
+
+function currentTimestamp() {
+  return Cypress.dayjs().unix();
+}
+
+const agendaDate = Cypress.dayjs().add(4, 'weeks')
+  .day(1); // anything but day 4
+// const agendaDate = Cypress.dayjs('2024-09-13');
+
+// the second active mandatee will be our current linked mandatee
+const oldLinkedMandatee = {
+  mandatee: mandateeNames.current.second,
+  fullName: mandateeNames.current.second.fullName,
+  submitter: true,
+};
+// link the first mandatee instead
+const newLinkedMandatee = {
+  mandatee: mandateeNames.current.first,
+  fullName: mandateeNames.current.first.fullName,
+  submitter: true,
+};
+
+
+const limitedAccess = 'Beperkte toegang';
+const submittedStatus = 'Ingediend';
+const inTreatmentStatus = 'In behandeling';
+// const treatedStatus = 'Behandeld';
+// const sentbackStatus = 'Teruggestuurd';
+// const reSubmittedStatus = 'Opnieuw ingediend';
+
+// const accessCabinet = 'Intern Regering';
+// const accessConfidential = 'Vertrouwelijk';
+const agendaDateFormatted = agendaDate.format('DD-MM-YYYY');
+const agendaTypeNota = 'Nota';
+// const agendaTypeAnnouncement = 'Mededeling';
+
+const submissionOtherSpecNewCaseShortTitle = 'Submission new case short title 1';
+const submissionOtherSpecExistingCaseShortTitle = 'Submission existing case short title 1';
+
+
+context('change mandatees on organisation', () => {
+  afterEach(() => {
+    cy.logout();
+  });
+
+  it('check the submissions table before changing mandatee', () => {
+    cy.login('Kabinetdossierbeheerder');
+    cy.visit('/indieningen?aantal=2');
+    cy.get(appuniversum.loader).should('not.exist');
+    // at this point, there should be only 2 (may be altered by earlier tests)
+    cy.get(route.submissionsOverview.row.shortTitle).should('have.length', 2);
+  });
+
+  // PM has 2 mandatee roles, we should link both
+  it('change mandatees on to first mandatee', () => {
+    cy.login('Admin');
+    cy.visit('instellingen/organisaties/40df7139-fdfb-4ab7-92cd-e73ceba32721');
+    // unlink first mandatee
+    cy.intercept('PATCH', '/user-organizations/**').as('patchorgs');
+    cy.get(settings.organization.technicalInfo.row.unlinkMandatee)
+      .eq(0)
+      .click();
+    cy.get(settings.organization.confirm.unlinkMandatee)
+      .click()
+      .wait('@patchorgs');
+
+    // link new mandatee
+    cy.intercept('PATCH', '/user-organizations/**').as(
+      'patchUserOrganizations'
+    );
+    cy.get(settings.organization.technicalInfo.showSelectMandateeModal).click();
+    cy.get(appuniversum.loader).should('not.exist');
+    cy.get(utils.mandateeSelector.container).click();
+    cy.get(dependency.emberPowerSelect.optionLoadingMessage).should(
+      'not.exist'
+    );
+    cy.get(dependency.emberPowerSelect.optionTypeToSearchMessage).should(
+      'not.exist'
+    );
+    cy.get(dependency.emberPowerSelect.option)
+      .contains(newLinkedMandatee.fullName)
+      .scrollIntoView()
+      .click();
+    cy.get(utils.mandateesSelector.add).should('not.be.disabled')
+      .click();
+    cy.wait('@patchUserOrganizations');
+    // link new mandatee
+    cy.get(settings.organization.technicalInfo.showSelectMandateeModal).click();
+    cy.get(appuniversum.loader).should('not.exist');
+    cy.get(utils.mandateeSelector.container).click();
+    cy.get(dependency.emberPowerSelect.optionLoadingMessage).should(
+      'not.exist'
+    );
+    cy.get(dependency.emberPowerSelect.optionTypeToSearchMessage).should(
+      'not.exist'
+    );
+    cy.get(dependency.emberPowerSelect.option)
+      .contains(newLinkedMandatee.fullName)
+      .scrollIntoView()
+      .click();
+    cy.get(utils.mandateesSelector.add).should('not.be.disabled')
+      .click();
+    cy.wait('@patchUserOrganizations');
+  });
+
+  it('check the submissions table after changing mandatee', () => {
+    cy.login('Kabinetdossierbeheerder');
+    cy.visit('/indieningen?aantal=2');
+    cy.get(appuniversum.loader).should('not.exist');
+    // We can see the submission where our mandatee was not the submitter
+    cy.get(route.submissionsOverview.row.shortTitle).should('have.length', 1)
+      .eq(0)
+      .parents('tr')
+      .as('submissionNewCaseRow');
+    cy.get('@submissionNewCaseRow').contains(submissionOtherSpecNewCaseShortTitle);
+    cy.get('@submissionNewCaseRow').find(route.submissionsOverview.row.newCase);
+    cy.get('@submissionNewCaseRow').find(route.submissionsOverview.row.limitedAccess)
+      .should('contain', limitedAccess);
+    cy.get('@submissionNewCaseRow').find(route.submissionsOverview.row.plannedStart)
+      .should('contain', agendaDateFormatted);
+  });
+
+  // could open up the submission and check stuff? don't see a point yet.
+  // need specific profile test when more setup is done. Maybe send one back and then change the mandatee?
+  // it would show only the right mandatee connected to org is allowed to edit
+});
+
+context('Create 2 submissions as first mandatee', () => {
+  afterEach(() => {
+    cy.logout();
+  });
+
+  const files1 = [
+    {
+      folder: 'files',
+      fileName: 'test onderwerp-1-nota',
+      fileExtension: 'pdf',
+      newFileName: 'submission first mandatee nota doc',
+      fileTypeLong: 'Nota',
+      fileTypeParsed: true,
+    },
+    {
+      folder: 'files',
+      fileName: 'test onderwerp-2-BVR',
+      fileExtension: 'pdf',
+      newFileName: 'submission first mandatee BVR doc',
+      fileTypeLong: 'Besluit Vlaamse Regering',
+      fileTypeParsed: true,
+    }
+  ];
+  // 1 submission to approve > will be added as agendaitem number 2 (mandatee priority)
+  const submissionNewCaseShortTitle = `Submission new case short title 2 - ${currentTimestamp()}`;
+  // const submissionNewCaseShortTitle = 'Submission new case short title 2 - ';
+  const submissionNewCase = {
+    newCase: true,
+    agendaitemType: agendaTypeNota,
+    shortTitle: submissionNewCaseShortTitle,
+    subcaseType: 'principiële goedkeuring',
+    documents: files1,
+    agendaDate: agendaDateFormatted,
+    formallyOk: 'Formeel OK',
+  };
+
+  // 1 submission for some profile tests maybe
+  // approve after agenda was > will be added as agendaitem number 2 (mandatee priority)
+  // maybe accept to different agenda, postponed, retracted, anything really
+  const submissionAnotherNewCaseShortTitle = `Submission another new case short title 2 - ${currentTimestamp()}`;
+  // const submissionAnotherNewCaseShortTitle = 'Submission another new case short title 2 - ';
+  const submissionAnotherNewCase = {
+    newCase: true,
+    confidential: true,
+    agendaitemType: agendaTypeNota,
+    shortTitle: submissionAnotherNewCaseShortTitle,
+    subcaseType: 'principiële goedkeuring',
+    documents: files1,
+    agendaDate: agendaDateFormatted,
+  };
+
+  it('create 2 submissions for first mandatee', () => {
+    cy.login('Kabinetdossierbeheerder');
+    cy.visit('/indieningen?aantal=2');
+    cy.get(appuniversum.loader).should('not.exist');
+    cy.createSubmission(submissionNewCase);
+    cy.createSubmission(submissionAnotherNewCase);
+  });
+
+  it('check the submissions table after creating', () => {
+    cy.login('Kabinetdossierbeheerder');
+    cy.visit('/indieningen?aantal=5');
+
+    // 1 from _B.cy
+    // 2 from this spec so far
+    cy.get(route.submissionsOverview.row.shortTitle).should('have.length', 3);
+    cy.get(route.submissionsOverview.row.shortTitle)
+      .contains(submissionNewCaseShortTitle)
+      .parents('tr')
+      .as('submissionNewCaseRow');
+    cy.get(route.submissionsOverview.row.shortTitle)
+      .contains(submissionAnotherNewCaseShortTitle)
+      .parents('tr')
+      .as('submissionAnotherNewCaseRow');
+
+    cy.get('@submissionNewCaseRow').find(route.submissionsOverview.row.newCase);
+    cy.get('@submissionNewCaseRow').find(route.submissionsOverview.row.limitedAccess)
+      .should('not.exist');
+    cy.get('@submissionNewCaseRow').find(route.submissionsOverview.row.plannedStart)
+      .should('contain', agendaDateFormatted);
+    cy.get('@submissionNewCaseRow').find(route.submissionsOverview.row.subcaseType)
+      .contains(submissionNewCase.subcaseType, {
+        matchCase: false,
+      });
+    cy.get('@submissionNewCaseRow').find(route.submissionsOverview.row.status)
+      .should('contain', submittedStatus);
+
+    // small check on the second one just to make sure it is listed
+    cy.get('@submissionAnotherNewCaseRow').find(route.submissionsOverview.row.status)
+      .should('contain', submittedStatus);
+  });
+
+  it('Treating and accepting the first submission will reorder agendaitems', () => {
+    cy.login('Secretarie');
+    cy.openAgendaForDate(agendaDate);
+    cy.get(agenda.agendaOverviewItem.subitem).should('have.length', 2);
+    cy.get(agenda.agendaOverviewItem.subitem).eq(0)
+      .contains('Goedkeuring van het verslag');
+    cy.get(agenda.agendaOverviewItem.subitem).eq(1)
+      .contains(submissionOtherSpecExistingCaseShortTitle);
+    cy.openSubmission(submissionNewCase.shortTitle);
+    cy.takeInTreatment();
+    cy.acceptSubmissionCreateSubcase(submissionNewCase);
+
+    // the accepted submission has higher mandatee priority and has been put between the first 2 agendaitems
+    // TODO we also need to check if decisions were changed etc, but this can be tested separate from submission
+    // that is a "submit a subcase to meeting" thing, not a submission specific thing
+    cy.openAgendaForDate(agendaDate);
+    cy.get(agenda.agendaOverviewItem.subitem).should('have.length', 3);
+    cy.get(agenda.agendaOverviewItem.subitem).eq(0)
+      .contains('Goedkeuring van het verslag');
+    cy.get(agenda.agendaOverviewItem.subitem).eq(1)
+      .contains(submissionNewCase.shortTitle);
+    cy.get(agenda.agendaOverviewItem.subitem).eq(2)
+      .contains(submissionOtherSpecExistingCaseShortTitle);
+  });
+
+  it('approving the agenda in its current state', () => {
+    // there should be 3
+    // 1 from _B.cy
+    // 2 from this spec so far
+    cy.login('Secretarie');
+    cy.openAgendaForDate(agendaDate);
+    cy.setAllItemsFormallyOk(2); // 3 items, but we can set formally ok on accepting submission
+    // TODO how long will yggdrasil take? We need to check what other profiles see 'geagendeerd' and for BIS updates
+    cy.approveDesignAgenda();
+  });
+
+  // process the sent back one? we don't have all that info here
+  // we could edit it in _B, but accept it in _D?
+
+  it('Check second submission via agenda view, take in treatment', () => {
+    cy.login('Kanselarij');
+    cy.openAgendaForDate(agendaDate);
+    // submissions via agenda for a change
+    cy.get(agenda.agendaTabs.tabs).contains('Indieningen')
+      .click();
+    // 1 from _B, 1 from this spec, treated submissions are not listed
+    cy.get(route.agendaSubmissions.row.shortTitle).should('have.length', 2);
+    cy.get(route.agendaSubmissions.row.shortTitle).contains(submissionAnotherNewCase.shortTitle)
+      .parents('tr')
+      .as('anotherSubmissionRow');
+    cy.get('@anotherSubmissionRow').find(route.agendaSubmissions.row.newCase);
+    cy.get('@anotherSubmissionRow').find(route.agendaSubmissions.row.limitedAccess)
+      .should('contain', limitedAccess);
+    cy.get('@anotherSubmissionRow').find(route.agendaSubmissions.row.submitter)
+      .contains(newLinkedMandatee.fullName);
+    cy.get('@anotherSubmissionRow').find(route.agendaSubmissions.row.mandatees)
+      .contains('-');
+    cy.get('@anotherSubmissionRow').find(route.agendaSubmissions.row.subcaseType)
+      .contains(submissionAnotherNewCase.subcaseType, {
+        matchCase: false,
+      });
+    cy.get('@anotherSubmissionRow').find(route.agendaSubmissions.row.status)
+      .should('contain', submittedStatus);
+    cy.get('@anotherSubmissionRow').find(route.agendaSubmissions.row.treatedBy)
+      .contains('-');
+    cy.get('@anotherSubmissionRow').find(route.agendaSubmissions.row.goToSubmission)
+      .click();
+    cy.takeInTreatment();
+  });
+
+  it('Accepting the second submission will not reorder already approved agendaitems', () => {
+    // open second submission via agenda view again, check treated by and status
+    cy.login('Kanselarij');
+    cy.openAgendaForDate(agendaDate);
+    // submissions via agenda for a change
+    cy.get(agenda.agendaTabs.tabs).contains('Indieningen')
+      .click();
+    cy.get(route.agendaSubmissions.row.shortTitle).contains(submissionAnotherNewCase.shortTitle)
+      .parents('tr')
+      .as('anotherSubmissionRow');
+    cy.get('@anotherSubmissionRow').find(route.agendaSubmissions.row.newCase);
+    cy.get('@anotherSubmissionRow').find(route.agendaSubmissions.row.limitedAccess)
+      .should('contain', limitedAccess);
+    cy.get('@anotherSubmissionRow').find(route.agendaSubmissions.row.submitter)
+      .contains(newLinkedMandatee.fullName);
+    cy.get('@anotherSubmissionRow').find(route.agendaSubmissions.row.mandatees)
+      .contains('-');
+    cy.get('@anotherSubmissionRow').find(route.agendaSubmissions.row.subcaseType)
+      .contains(submissionAnotherNewCase.subcaseType, {
+        matchCase: false,
+      });
+    // this changed
+    cy.get('@anotherSubmissionRow').find(route.agendaSubmissions.row.status)
+      .should('contain', inTreatmentStatus);
+    cy.get('@anotherSubmissionRow').find(route.agendaSubmissions.row.treatedBy)
+      .contains('Kanselarij Test');
+
+    cy.get('@anotherSubmissionRow').find(route.agendaSubmissions.row.goToSubmission)
+      .click();
+    cy.acceptSubmissionCreateSubcase(submissionAnotherNewCase);
+
+    // the accepted submission has higher mandatee priority but is only applicable to new agendaitems, not approved ones
+    // that is a "submit a subcase to meeting" thing, not a submission specific thing
+    cy.openAgendaForDate(agendaDate);
+    cy.get(agenda.agendaOverviewItem.subitem).should('have.length', 4);
+    cy.get(agenda.agendaOverviewItem.subitem).eq(0)
+      .contains('Goedkeuring van het verslag');
+    cy.get(agenda.agendaOverviewItem.subitem).eq(1)
+      .contains(submissionNewCase.shortTitle);
+    cy.get(agenda.agendaOverviewItem.subitem).eq(2)
+      .contains(submissionOtherSpecExistingCaseShortTitle);
+    // The new agendaitem has been put on the bottom below the approved ones
+    cy.get(agenda.agendaOverviewItem.subitem).eq(3)
+      .contains(submissionAnotherNewCaseShortTitle);
+  });
+});
+
+context('change back mandatees on organisation to second', () => {
+  // PM has 2 mandatee roles, we should link both
+  it('change mandatees on to second mandatee', () => {
+    cy.login('Admin');
+    cy.visit('instellingen/organisaties/40df7139-fdfb-4ab7-92cd-e73ceba32721');
+    // unlink first mandatee (2 entries)
+    cy.intercept('PATCH', '/user-organizations/**').as('patchorgs');
+    cy.get(settings.organization.technicalInfo.row.unlinkMandatee)
+      .eq(0)
+      .click();
+    cy.get(settings.organization.confirm.unlinkMandatee)
+      .click()
+      .wait('@patchorgs');
+    cy.get(settings.organization.technicalInfo.row.unlinkMandatee)
+      .eq(0)
+      .click();
+    cy.get(settings.organization.confirm.unlinkMandatee)
+      .click()
+      .wait('@patchorgs');
+
+    // link old mandatee (second)
+    cy.intercept('PATCH', '/user-organizations/**').as(
+      'patchUserOrganizations'
+    );
+    cy.get(settings.organization.technicalInfo.showSelectMandateeModal).click();
+    cy.get(appuniversum.loader).should('not.exist');
+    cy.get(utils.mandateeSelector.container).click();
+    cy.get(dependency.emberPowerSelect.optionLoadingMessage).should(
+      'not.exist'
+    );
+    cy.get(dependency.emberPowerSelect.optionTypeToSearchMessage).should(
+      'not.exist'
+    );
+    cy.get(dependency.emberPowerSelect.option)
+      .contains(oldLinkedMandatee.fullName)
+      .scrollIntoView()
+      .click();
+    cy.get(utils.mandateesSelector.add).should('not.be.disabled')
+      .click();
+    cy.wait('@patchUserOrganizations');
+  });
+});

--- a/cypress/e2e/unit/submission_Z_cleanup.cy.js
+++ b/cypress/e2e/unit/submission_Z_cleanup.cy.js
@@ -1,0 +1,27 @@
+/* global context, it, cy*/
+
+// / <reference types="Cypress" />
+import settings from '../../selectors/settings.selectors';
+
+
+context('cleanup mandatees from organisation', () => {
+  it('remove mandatees from organisation', () => {
+    cy.login('Admin');
+    cy.visit('instellingen/organisaties/40df7139-fdfb-4ab7-92cd-e73ceba32721');
+    // unlink first mandatee
+    cy.intercept('PATCH', '/user-organizations/**').as('patchorgs');
+    cy.get(settings.organization.technicalInfo.row.unlinkMandatee)
+      .eq(0)
+      .click();
+    cy.get(settings.organization.confirm.unlinkMandatee)
+      .click()
+      .wait('@patchorgs');
+    // unlink second mandatee
+    // cy.get(settings.organization.technicalInfo.row.unlinkMandatee).eq(0)
+    //   .click();
+    // cy.get(settings.organization.confirm.unlinkMandatee).click()
+    //   .wait('@patchorgs');
+    // cy.get(settings.organization.technicalInfo.row.mandatee).should('not.exist');
+    cy.logout();
+  });
+});

--- a/cypress/selectors/case.selectors.js
+++ b/cypress/selectors/case.selectors.js
@@ -110,6 +110,8 @@ const selectors = {
 
   // subcase-header
   subcaseHeader: {
+    createUpdateSubmission: '[data-test-subcase-header-create-update-submission]',
+    openCurrentSubmission: '[data-test-subcase-header-open-current-submission]',
     actionsDropdown: '[data-test-subcase-header-actions-dropdown]',
     actions: {
       showProposedAgendas: '[data-test-subcase-header-action-open-proposable-agendas]',

--- a/cypress/selectors/document.selectors.js
+++ b/cypress/selectors/document.selectors.js
@@ -71,6 +71,7 @@ const selectors = {
     container: '[data-test-uploaded-document-container]',
     nameInput: '[data-test-uploaded-document-name-input]',
     documentTypes: '[data-test-uploaded-document-types]',
+    accessLevel: '[data-test-uploaded-document-access-level]',
   },
 
   // add-existing-piece

--- a/cypress/selectors/document.selectors.js
+++ b/cypress/selectors/document.selectors.js
@@ -183,5 +183,17 @@ const selectors = {
     versionHistory: '[data-test-draft-document-card-version-history]',
   },
 
+  // component add-draft-document-card
+  addDraftDocumentCard: {
+    card: '[data-test-add-draft-document-card]',
+    type: '[data-test-add-draft-document-card-type]',
+    name: {
+      value: '[data-test-add-draft-document-card-name-value]',
+    },
+    primarySourceLink: '[data-test-add-draft-document-card-primary-source-link]',
+    uploadDraftPiece: '[data-test-add-draft-document-card-upload-new-draft-piece]',
+    deleteDraftPiece: '[data-test-add-draft-document-card-delete-draft-piece]',
+    versionHistory: '[data-test-add-draft-document-card-version-history]',
+  },
 };
 export default selectors;

--- a/cypress/selectors/route.selectors.js
+++ b/cypress/selectors/route.selectors.js
@@ -69,6 +69,22 @@ const selectors = {
     },
   },
 
+  // agenda/submissions/template
+  agendaSubmissions: {
+    dataTable: '[data-test-route-agenda-submissions-data-table]',
+    row: {
+      shortTitle: '[data-test-route-agenda-submissions-row-short-title]',
+      newCase: '[data-test-route-agenda-submissions-row-new-case]',
+      limitedAccess: '[data-test-route-agenda-submissions-row-limited-access]',
+      submitter: '[data-test-route-agenda-submissions-row-submitter]',
+      mandatees: '[data-test-route-agenda-submissions-row-mandatees]',
+      subcaseType: '[data-test-route-agenda-submissions-row-subcase-type]',
+      status: '[data-test-route-agenda-submissions-row-status]',
+      treatedBy: '[data-test-route-agenda-submissions-row-treated-by]',
+      goToSubmission: '[data-test-route-agenda-submissions-row-go-to-submission]',
+    },
+  },
+
   /**
     ROUTE CASES
   */

--- a/cypress/selectors/route.selectors.js
+++ b/cypress/selectors/route.selectors.js
@@ -125,6 +125,14 @@ const selectors = {
     },
   },
 
+  // cases/case/subcases/subcase/new-submission (update submissions)
+  draftUpdateSubmission: {
+    addDraftDocuments: '[data-test-route-cases--new-submission-add-documents]',
+    cancel: '[data-test-route-cases--new-submission-cancel]',
+    save: '[data-test-route-cases--new-submission-save]',
+    submitComment: '[data-test-route-cases--new-submission-submit-comment]',
+  },
+
   /**
     ROUTE SEARCH
   */

--- a/cypress/selectors/submission.selectors.js
+++ b/cypress/selectors/submission.selectors.js
@@ -101,6 +101,14 @@ const selectors = {
     save: '[data-test-submission-description-edit-save]',
   },
 
+  decisionmakingFlowSelector: {
+    existingCaseTitle: '[data-test-submission-decisionmaking-flow-selector-existing-case-title]',
+    useNewCase: '[data-test-submission-decisionmaking-flow-selector-use-new-case]',
+    useDifferentCase: '[data-test-submission-decisionmaking-flow-selector-use-different-case]',
+    newCaseTitle: '[data-test-submission-decisionmaking-flow-selector-new-case-title]',
+    useExistingCase: '[data-test-submission-decisionmaking-flow-selector-use-existing-case]',
+  },
+
   // status-change-activity
   statusChangeActivity: {
     item: '[data-test-submission-status-change-activity-item]',

--- a/cypress/selectors/utils.selectors.js
+++ b/cypress/selectors/utils.selectors.js
@@ -97,6 +97,11 @@ const selectors = {
     cancel: '[data-test-formally-ok-edit-cancel]',
   },
 
+  checkboxTree: {
+    toggleAll: '[data-test-checkbox-tree-toggle-all]',
+    toggleSingle: '[data-test-checkbox-tree-toggle-single]',
+  },
+
   /** Section VL-components **/
 
   // vl-modal-verify

--- a/cypress/support/commands/submission-commands.js
+++ b/cypress/support/commands/submission-commands.js
@@ -282,14 +282,24 @@ function createSubmission(submission) {
  * @function
  * @param {shortTitle: String}
 */
-function openSubmission(shortTitle) {
+function openSubmission(shortTitle, index = 0) {
   cy.log('openSubmission');
   cy.visit('indieningen?aantal=50');
-  cy.get(route.submissionsOverview.dataTable, {
-    timeout: 60000,
-  }).contains(shortTitle)
-    .parents('tr')
-    .click();
+  if (shortTitle) {
+    cy.get(route.submissionsOverview.dataTable, {
+      timeout: 60000,
+    }).contains(shortTitle)
+      .parents('tr')
+      .click();
+  } else {
+    // try to open the first row or index from params
+    // there could be 0 rows and this could fail
+    cy.get(route.submissionsOverview.dataTable, {
+      timeout: 60000,
+    }).eq(index)
+      .parents('tr')
+      .click();
+  }
   cy.get(appuniversum.loader).should('not.exist');
   cy.log('/openSubmission');
 }

--- a/cypress/support/commands/submission-commands.js
+++ b/cypress/support/commands/submission-commands.js
@@ -301,6 +301,7 @@ function openSubmission(shortTitle) {
  *  folder: String,
  *  fileName: String,
  *  fileExtension: String,
+ *  mimeType: String,
  *  newFileName: String,
  *  fileType: String,
  *  fileTypeParsed: Boolean,
@@ -320,7 +321,7 @@ function addDocumentsInSubmissionFileUpload(files) {
         'GET',
         '/concepts**559774e3-061c-4f4b-a758-57228d4b68cd**'
       ).as(`loadConceptsDocType_${randomInt}`);
-      cy.uploadDraftFile(file.folder, file.fileName, file.fileExtension);
+      cy.uploadDraftFile(file.folder, file.fileName, file.fileExtension, file.mimeType);
       // ensure the new uploadedDocument component is visible before trying to continue
       cy.get(document.uploadedDocument.nameInput, {
         timeout: 60000,
@@ -346,7 +347,7 @@ function addDocumentsInSubmissionFileUpload(files) {
       .find(document.uploadedDocument.documentTypes)
       .as('radioOptions');
     cy.get(utils.radioDropdown.input).should('exist'); // the radio buttons should be loaded before the within or the .length returns 0
-    if (!file.fileTypeParsed) {
+    if (!file.fileTypeParsed && file.fileType) {
       cy.get('@radioOptions').within(($t) => {
         if ($t.find(`input[type="radio"][value="${file.fileType}"]`).length) {
           cy.get(utils.radioDropdown.input).check(file.fileType, {

--- a/cypress/support/commands/submission-commands.js
+++ b/cypress/support/commands/submission-commands.js
@@ -10,6 +10,7 @@ import document from '../../selectors/document.selectors';
 import route from '../../selectors/route.selectors';
 import appuniversum from '../../selectors/appuniversum.selectors';
 import mandatee from '../../selectors/mandatee.selectors';
+import mandateeNames from '../../selectors/mandatee-names.selectors';
 import submissions from '../../selectors/submission.selectors';
 import utils from '../../selectors/utils.selectors';
 
@@ -289,6 +290,7 @@ function openSubmission(shortTitle) {
   }).contains(shortTitle)
     .parents('tr')
     .click();
+  cy.get(appuniversum.loader).should('not.exist');
   cy.log('/openSubmission');
 }
 
@@ -475,12 +477,59 @@ function takeInTreatment() {
   cy.log('/takeInTreatment');
 }
 
+/**
+ * Adds a mandatee to a submission when used in the submission view
+ * Pass a valid entry from 'mandatee-names.selectors.js'
+ * @name addSubmissionMandatee
+ * @memberOf Cypress.Chainable#
+ * @function
+ * @param {Number} mandateeNamesSelector - The mandatee to search, must be a valid entry from 'mandatee-names.selectors.js'. Defaults to first current mandatee
+ */
+function addSubmissionMandatee(mandateeNamesSelector = mandateeNames.current.first) {
+  cy.log('addSubmissionMandatee');
+  const randomInt = Math.floor(Math.random() * Math.floor(10000));
+  cy.intercept('GET', '/government-bodies?filter**').as(`getGovernmentBodies${randomInt}`);
+  cy.intercept('GET', '/mandatees?filter**government-body**').as(`getMandatees${randomInt}`);
+
+  cy.intercept('PATCH', '/submissions/*').as(`patchSubmission${randomInt}`);
+  cy.get(mandatee.mandateePanelView.actions.edit).click();
+  cy.get(mandatee.mandateePanelEdit.actions.add).click();
+  cy.wait(`@getGovernmentBodies${randomInt}`);
+  cy.wait(`@getMandatees${randomInt}`, {
+    timeout: 60000,
+  });
+  cy.get(utils.mandateeSelector.container).find(dependency.emberPowerSelect.trigger)
+    .click();
+  cy.get(dependency.emberPowerSelect.searchInput).type(mandateeNamesSelector.lastName);
+  cy.get(dependency.emberPowerSelect.optionLoadingMessage).should('not.exist');
+  cy.get(dependency.emberPowerSelect.optionTypeToSearchMessage).should('not.exist');
+
+  // when searching we select the result with a specific title
+  if (mandateeNamesSelector.searchTitle) {
+    cy.get(dependency.emberPowerSelect.option).contains(mandateeNamesSelector.searchTitle)
+      .click();
+  } else {
+    cy.get(dependency.emberPowerSelect.option).contains(mandateeNamesSelector.title)
+      .click();
+  }
+  cy.get(dependency.emberPowerSelect.option).should('not.exist', {
+    timeout: 60000,
+  });
+  cy.get(utils.mandateesSelector.add).click();
+  cy.get(mandatee.mandateePanelEdit.actions.save).click();
+  cy.wait(`@patchSubmission${randomInt}`, {
+    timeout: 40000,
+  });
+  cy.log('/addSubmissionMandatee');
+}
+
 // Commands
 
 Cypress.Commands.add('createSubmission', createSubmission); // used for new or existing case
 Cypress.Commands.add('openSubmission', openSubmission);
 Cypress.Commands.add('acceptSubmissionCreateSubcase', acceptSubmissionCreateSubcase);
 Cypress.Commands.add('takeInTreatment', takeInTreatment);
+Cypress.Commands.add('addSubmissionMandatee', addSubmissionMandatee);
 // Cypress.Commands.add('openSubmissionInAgenda', openSubmissionInAgenda);
 // Cypress.Commands.add('createUpdateSubmission', createUpdateSubmission);
 

--- a/cypress/support/commands/submission-commands.js
+++ b/cypress/support/commands/submission-commands.js
@@ -3,7 +3,7 @@
 
 // ***********************************************
 // Functions
-// import auk from '../../selectors/auk.selectors';
+import auk from '../../selectors/auk.selectors';
 import cases from '../../selectors/case.selectors';
 import dependency from '../../selectors/dependency.selectors';
 import document from '../../selectors/document.selectors';
@@ -321,10 +321,14 @@ function openSubmission(shortTitle, index = 0) {
  *  confidentialParsed: Boolean,
  * }[]} files
  */
-function addDocumentsInSubmissionFileUpload(files) {
+function addDocumentsInSubmissionFileUpload(files, updateView = false) {
   cy.log('addDocumentsInSubmissionFileUpload');
-  cy.get(submissions.documentUploadPanel.panel).as('fileUploadDialog');
-
+  if (updateView) {
+    cy.get(route.draftUpdateSubmission.addDraftDocuments).click();
+    cy.get(auk.auModal.container).as('fileUploadDialog');
+  } else {
+    cy.get(submissions.documentUploadPanel.panel).as('fileUploadDialog');
+  }
   const randomInt = Math.floor(Math.random() * Math.floor(10000));
 
   files.forEach((file, index) => {
@@ -381,6 +385,42 @@ function addDocumentsInSubmissionFileUpload(files) {
   });
 
   cy.log('/addDocumentsInSubmissionFileUpload');
+}
+
+/**
+ * @description Adds a new document for each file in the "files"-array to an opened document upload modal
+ * @name addDocumentsInUpdateSubmissionFileUpload
+ * @memberOf Cypress.Chainable#
+ * @function
+ * @param {{
+*  folder: String,
+*  fileName: String,
+*  fileExtension: String,
+*  mimeType: String,
+*  newFileName: String,
+*  fileType: String,
+*  fileTypeParsed: Boolean,
+*  confidential: Boolean,
+*  confidentialParsed: Boolean,
+* }[]} files
+*/
+function addDocumentsInUpdateSubmissionFileUpload(files) {
+  cy.log('addDocumentsInUpdateSubmissionFileUpload');
+  // we are in the update view, updateView = true
+  const randomInt = Math.floor(Math.random() * Math.floor(10000));
+  cy.intercept('POST', '/draft-document-containers').as(`createNewDraftDocumentContainer_${randomInt}`);
+  cy.intercept('POST', '/draft-pieces').as(`createNewDraftPiece_${randomInt}`);
+  cy.addDocumentsInSubmissionFileUpload(files, true);
+  cy.get(auk.confirmationModal.footer.confirm).should('not.be.disabled')
+    .click();
+  cy.wait(`@createNewDraftDocumentContainer_${randomInt}`, {
+    timeout: 24000,
+  });
+  cy.wait(`@createNewDraftPiece_${randomInt}`, {
+    timeout: 24000,
+  });
+
+  cy.log('/addDocumentsInUpdateSubmissionFileUpload');
 }
 
 
@@ -533,6 +573,40 @@ function addSubmissionMandatee(mandateeNamesSelector = mandateeNames.current.fir
   cy.log('/addSubmissionMandatee');
 }
 
+/**
+ * @description Add a new piece to a decision.
+ * @name addNewDraftPiece
+ * @memberOf Cypress.Chainable#
+ * @function
+ * @param {String} oldFileName - The relative path to the file in the cypress/fixtures folder excluding the fileName
+ * @param {String} file - The name of the file without the extension
+ */
+function addNewDraftPiece(oldFileName, file) {
+  cy.log('addNewDraftPiece');
+  const randomInt = Math.floor(Math.random() * Math.floor(10000));
+  cy.intercept('POST', '/draft-document-containers').as(`createNewDraftDocumentContainer_${randomInt}`);
+  cy.intercept('POST', '/draft-pieces').as(`createNewDraftPiece_${randomInt}`);
+
+  cy.get(document.addDraftDocumentCard.name.value).contains(oldFileName)
+    .parents(document.addDraftDocumentCard.card)
+    .find(document.addDraftDocumentCard.uploadDraftPiece)
+    .forceClick();
+
+  cy.get(auk.auModal.container).within(() => {
+    cy.uploadDraftFile(file.folder, file.fileName, file.fileExtension);
+    cy.get(document.vlUploadedDocument.filename).should('contain', file.fileName);
+
+    cy.get(auk.confirmationModal.footer.confirm).click({
+      force: true,
+    })
+      .wait(`@createNewDraftDocumentContainer_${randomInt}`)
+      .wait(`@createNewDraftPiece_${randomInt}`);
+  });
+  cy.get(auk.auModal.container).should('not.exist');
+  cy.get(appuniversum.loader).should('not.exist');
+  cy.log('/addNewDraftPiece');
+}
+
 // Commands
 
 Cypress.Commands.add('createSubmission', createSubmission); // used for new or existing case
@@ -540,8 +614,11 @@ Cypress.Commands.add('openSubmission', openSubmission);
 Cypress.Commands.add('acceptSubmissionCreateSubcase', acceptSubmissionCreateSubcase);
 Cypress.Commands.add('takeInTreatment', takeInTreatment);
 Cypress.Commands.add('addSubmissionMandatee', addSubmissionMandatee);
+
 // Cypress.Commands.add('openSubmissionInAgenda', openSubmissionInAgenda);
 // Cypress.Commands.add('createUpdateSubmission', createUpdateSubmission);
 
 Cypress.Commands.add('addDocumentsInSubmissionFileUpload', addDocumentsInSubmissionFileUpload);
+Cypress.Commands.add('addDocumentsInUpdateSubmissionFileUpload', addDocumentsInUpdateSubmissionFileUpload);
+Cypress.Commands.add('addNewDraftPiece', addNewDraftPiece);
 // Cypress.Commands.add('visitCaseWithLink', visitCaseWithLink);


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5040

WIP

- split up because there is no global setup, so tests are very dependent on initial setup and final cleanup for other tests. The best way I saw was to name them with the alphabet. Thinking if this is the way I want to go, I don't want 1 massive file with setup and cleanup and thousands of lines..
- Added negative testing (cancelling, adding / removing, confidential changes, ...) on the new-submission form.

TODO:
- Add negative testing for other views
- Add BIS update happy flow testing
- Add postpone/resubmit testing
- Add testing to send back from agenda and resubmitting
- Add testing of submission for agenda 1 and but being accepted for a different agenda
- more