### PR TITLE
Add check to handle a logged out user who is still semi authenticated

### DIFF
--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -17,6 +17,7 @@ export default class CurrentSessionService extends Service {
   @tracked organization;
   @tracked membership;
   @tracked role;
+  @tracked isLoggedIn;
 
   constructor() {
     super(...arguments);
@@ -27,6 +28,7 @@ export default class CurrentSessionService extends Service {
   /* eslint-disable ember/no-get */
   async load() {
     if (this.session.isAuthenticated) {
+      this.isLoggedIn = true;
       const membershipId = get(this.session, 'data.authenticated.data.relationships.membership.data.id');
       if (membershipId) {
         this.membership = await this.store.findRecord('membership', membershipId, {
@@ -51,6 +53,7 @@ export default class CurrentSessionService extends Service {
     this.role = null;
     this.organization = null;
     this.impersonation.stopImpersonation();
+    this.isLoggedIn = false;
   }
 
   may(permission, checkImpersonator = false) {
@@ -87,6 +90,10 @@ export default class CurrentSessionService extends Service {
     return this.session.isAuthenticated;
   }
 
+  get isLoggedIn() {
+    return this.isLoggedIn;
+  }
+
   /*****
    * Polling for logged in status logic is below!
    */
@@ -94,7 +101,8 @@ export default class CurrentSessionService extends Service {
 
   async lifecycle() {
     // For as long as the user is logged in, we continue periodically polling
-    if (await this._checkLoggedInStatus()) {
+    this.isLoggedIn = await this._checkLoggedInStatus();
+    if (this.isLoggedIn) {
       later(this, this.lifecycle, this.updateInterval);
     }
   }

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -34,6 +34,12 @@ export default class ExtendedSessionService extends SessionService {
         params: params,
         paramNames: paramNames?.reverse()
        }));
+    } else {
+      // When checking if current session is valid in DB, we are still "authenticated" here but no longer have a valid currentSession
+      // When navigating once after the forced logout, we hit this function and invalidate the session 
+      if (!this.currentSession.isLoggedIn) {
+        return this.handleInvalidation();
+      }
     }
     return super.requireAuthentication(transition, routeOrCallback);
   }


### PR DESCRIPTION
Flag on ACC

After a forced logout, you still have a "valid" session since it is never completely invalidated.

Not a fan of using a "loggedIn" next to a "isAuthenticated" since it should mean the same thing.
Maybe renames are in order to better reflect what is happening.
