### PR TITLE
KAS-4899 fix accessLevel choice not persisting on subcase documents

### DIFF
--- a/app/components/cases/new-submission.js
+++ b/app/components/cases/new-submission.js
@@ -303,7 +303,6 @@ export default class CasesNewSubmissionComponent extends Component {
       if (!piece.accessLevel) {
         piece.accessLevel = defaultAccessLevel;
       }
-      piece.accessLevelLastModified = new Date();
       piece.name = piece.name.trim();
       piece.submission = this.submission;
       await piece.save();

--- a/app/components/cases/subcases/document-upload-panel.hbs
+++ b/app/components/cases/subcases/document-upload-panel.hbs
@@ -2,7 +2,9 @@
   <Auk::Panel::Header class="au-u-background-gray-100">
     <h4 class="auk-panel__title">{{t "documents"}}</h4>
   </Auk::Panel::Header>
-  <Auk::Panel::Body>
+  <Auk::Panel::Body
+    {{did-update (perform this.onDidUpdate) @confidential}}
+  >
     <Auk::FileUploader
       @multiple={{true}}
       @reusable={{true}}

--- a/app/components/cases/subcases/document-upload-panel.js
+++ b/app/components/cases/subcases/document-upload-panel.js
@@ -9,6 +9,8 @@ import CONSTANTS from "frontend-kaleidos/config/constants";
 export default class DocumentUploadPlanel extends Component {
   @service store;
   @service conceptStore;
+  @service toaster;
+  @service intl;
 
   @action
   async uploadPiece(file) {
@@ -46,4 +48,33 @@ export default class DocumentUploadPlanel extends Component {
   *deletePiece(piece) {
     yield this.args.onDeletePiece(piece);
   }
+
+  onDidUpdate = task(async () => {
+    if (this.args.confidential && this.args.pieces.length) {
+      // Strengthen the accessLevel of the new pieces (not persisted yet) to vertrouwelijk
+      let changedAccessLevelOfPieces = false;
+      const confidential = await this.store.findRecordByUri(
+        'concept',
+        CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK,
+      );
+      const promises = this.args.pieces.map(async (piece) => {
+        const accessLevel = await piece.accessLevel;
+        if (
+          ![
+            CONSTANTS.ACCESS_LEVELS.INTERN_SECRETARIE,
+            CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK,
+          ].includes(accessLevel.uri)
+        ) {
+          piece.accessLevel = confidential;
+          changedAccessLevelOfPieces = true;
+        }
+      });
+      await Promise.all(promises);
+      if (changedAccessLevelOfPieces) {
+        this.toaster.success(
+          this.intl.t('uploaded-pieces-access-level-changed'),
+        );
+      }
+    }
+  });
 }

--- a/app/components/cases/subcases/new-subcase-form.hbs
+++ b/app/components/cases/subcases/new-subcase-form.hbs
@@ -180,6 +180,7 @@
             @disabled={{this.createSubcase.isRunning}}
           />
           <Cases::Subcases::DocumentUploadPanel
+            @confidential={{this.confidential}}
             @pieces={{this.sortedPieces}}
             @onAddPiece={{this.addPiece}}
             @onDeletePiece={{this.deletePiece}}

--- a/app/components/cases/subcases/new-subcase-form.js
+++ b/app/components/cases/subcases/new-subcase-form.js
@@ -326,7 +326,19 @@ export default class NewSubcaseForm extends Component {
   }
 
   @action
-  addPiece(piece) {
+  async addPiece(piece) {
+    // update accessLevel based on confidentiality
+    const pieceAccessLevel = await piece.accessLevel;
+    if (pieceAccessLevel?.uri != CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK) {      
+      const defaultAccessLevel = await this.store.findRecordByUri(
+        'concept',
+        this.confidential
+          ? CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK
+          : CONSTANTS.ACCESS_LEVELS.INTERN_REGERING
+      );
+      piece.accessLevel = defaultAccessLevel;
+    }
+
     addObject(this.pieces, piece);
   }
 
@@ -351,14 +363,7 @@ export default class NewSubcaseForm extends Component {
     const documentContainer = yield piece.documentContainer;
     documentContainer.position = index + 1;
     yield documentContainer.save();
-    const defaultAccessLevel = yield this.store.findRecordByUri(
-      'concept',
-      this.subcase.confidential
-        ? CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK
-        : CONSTANTS.ACCESS_LEVELS.INTERN_REGERING
-    );
-    piece.accessLevel = defaultAccessLevel;
-    piece.accessLevelLastModified = new Date();
+    // at this point in time, the piece already has an accessLevel
     piece.name = piece.name.trim();
     yield piece.save();
     try {


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4899

in the `new-subcase-form` and relevant components:
- removed logic to calculate accessLevel during subcase creation process (based on form value `confidential`)
- added logic to calculate accessLevel based on form value `confidential`
- added logic to recalculate accessLevel on all pieces when toggling form value `confidential` and strengthening if not "intern-secretarie" or "vertrouwelijk"

This seems the only place where we change the accessLevel in combination with an upload modal where you can manually edit the accessLevel.
Submissions has something similar, but we only attempt to set accessLevel if there was none before.
That shouldn't happen in the subcase story, since there are 2 places where we set accessLevel.
- On upload (parsing name) in `document-upload-panel`
https://github.com/kanselarij-vlaanderen/frontend-kaleidos/blob/development/app/components/cases/subcases/document-upload-panel.js#L38

- after upload (add to form pieces list) in `new-subcase-form` (new code from me)

sidetracking: removed setting `accessLevelLastModified` on `draft-piece` creation (property doesn't exist)