### PR TITLE
KAS-4810 Add util to clean pasted data in AuTextarea components

### DIFF
--- a/app/components/agenda/agendaitem/agendaitem-case-panel/agendaitem-case-panel-edit.hbs
+++ b/app/components/agenda/agendaitem/agendaitem-case-panel/agendaitem-case-panel-edit.hbs
@@ -13,25 +13,27 @@
         </AuFormRow>
       {{/if}}
       <AuFormRow>
-        <AuLabel for="name-subcase">{{t "name-subcase"}}</AuLabel>
+        <AuLabel for="short-title-agendaitem">{{t "name-subcase"}}</AuLabel>
         <AuTextarea
           data-test-agendaitem-titles-edit-shorttitle={{true}}
-          id="name-subcase"
+          id="short-title-agendaitem"
           rows="2"
           value={{@agendaitem.shortTitle}}
           @width="block"
           {{on "input" (pick "target.value" (set @agendaitem "shortTitle"))}}
+          {{on "paste" this.pasteIntoShortTitle}}
         />
       </AuFormRow>
       <AuFormRow>
-        <AuLabel for="title-subcase">{{t "title-subcase"}}</AuLabel>
+        <AuLabel for="title-agendaitem">{{t "title-subcase"}}</AuLabel>
         <AuTextarea
           data-test-agendaitem-titles-edit-title={{true}}
-          id="title-subcase"
+          id="title-agendaitem"
           rows="4"
           value={{@agendaitem.title}}
           @width="block"
           {{on "input" (pick "target.value" (set @agendaitem "title"))}}
+          {{on "paste" this.pasteIntoTitle}}
         />
       </AuFormRow>
        {{#if @subcase}}

--- a/app/components/agenda/agendaitem/agendaitem-case-panel/agendaitem-case-panel-edit.js
+++ b/app/components/agenda/agendaitem/agendaitem-case-panel/agendaitem-case-panel-edit.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { trimText } from 'frontend-kaleidos/utils/trim-util';
+import { trimText, cleanPasteInputForTextarea } from 'frontend-kaleidos/utils/trim-util';
 import { task } from 'ember-concurrency';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 
@@ -145,5 +145,13 @@ export default class AgendaitemCasePanelEdit extends Component {
   clearSubcaseName() {
     this.selectedShortcut = null;
     this.subcaseName = null;
+  }
+
+  pasteIntoShortTitle = (pasteEvent) => {
+    this.args.agendaitem.shortTitle = cleanPasteInputForTextarea(pasteEvent, 'short-title-agendaitem', this.args.agendaitem.shortTitle);
+  }
+
+  pasteIntoTitle = (pasteEvent) => {
+    this.args.agendaitem.title = cleanPasteInputForTextarea(pasteEvent, 'title-agendaitem', this.args.agendaitem.title);
   }
 }

--- a/app/components/cases/edit-case.hbs
+++ b/app/components/cases/edit-case.hbs
@@ -7,12 +7,14 @@
   <Auk::Modal::Body>
     <div class="au-c-form">
       <AuFormRow>
-        <AuLabel>{{t "short-title-case"}}</AuLabel>
+        <AuLabel for="case-short-title">{{t "short-title-case"}}</AuLabel>
         <AuTextarea
+          id="case-short-title"
           data-test-edit-case-shorttitle
           value={{this.shortTitle}}
           @width="block"
           {{on "input" (pick "target.value" (set this "shortTitle"))}}
+          {{on "paste" this.pasteIntoShortTitle}}
         />
       </AuFormRow>
     </div>

--- a/app/components/cases/edit-case.js
+++ b/app/components/cases/edit-case.js
@@ -3,6 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { isBlank } from '@ember/utils';
 import { task } from 'ember-concurrency';
+import { cleanPasteInputForTextarea } from 'frontend-kaleidos/utils/trim-util';
 
 /**
  * @param {Case} case
@@ -32,5 +33,9 @@ export default class EditCase extends Component {
   @action
   close() {
     this.args.onClose();
+  }
+
+  pasteIntoShortTitle = (pasteEvent) => {
+    this.shortTitle = cleanPasteInputForTextarea(pasteEvent, 'case-short-title', this.shortTitle);
   }
 }

--- a/app/components/cases/new-case.hbs
+++ b/app/components/cases/new-case.hbs
@@ -16,6 +16,7 @@
           value={{this.shortTitle}}
           @width="block"
           {{on "input" (pick "target.value" (set this "shortTitle"))}}
+          {{on "paste" this.pasteIntoShortTitle}}
         />
       </AuFormRow>
     </div>

--- a/app/components/cases/new-case.js
+++ b/app/components/cases/new-case.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import { isBlank } from '@ember/utils';
+import { cleanPasteInputForTextarea } from 'frontend-kaleidos/utils/trim-util';
 
 /**
   * @argument didSave: action, passes down the newly created decisionmakingFlow
@@ -34,4 +35,8 @@ export default class NewCase extends Component {
     await decisionmakingFlow.save();
     return this.args.didSave(decisionmakingFlow);
   });
+
+  pasteIntoShortTitle = (pasteEvent) => {
+    this.shortTitle = cleanPasteInputForTextarea(pasteEvent, 'case-short-title', this.shortTitle);
+  }
 }

--- a/app/components/cases/new-submission.hbs
+++ b/app/components/cases/new-submission.hbs
@@ -44,14 +44,15 @@
                 />
               </div>
               <div class="auk-form-group">
-                <AuLabel for="shortTitle" @required={{true}} @inline={{true}}>{{t "name-subcase"}}</AuLabel>
+                <AuLabel for="short-title" @required={{true}} @inline={{true}}>{{t "name-subcase"}}</AuLabel>
                 <AuTextarea
                   data-test-cases-new-submission-form-short-title
                   @rows="2"
                   @width="block"
-                  id="shortTitle"
+                  id="short-title"
                   value={{this.shortTitle}}
-                  {{on "change" (pick "target.value" (fn (mut this.shortTitle)))}}
+                  {{on "input" (pick "target.value" (set this "shortTitle"))}}
+                  {{on "paste" this.pasteIntoShortTitle}}
                 />
               </div>
               <div class="auk-form-group">

--- a/app/components/cases/new-submission.js
+++ b/app/components/cases/new-submission.js
@@ -3,7 +3,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { TrackedArray } from 'tracked-built-ins';
 import { task, dropTask, timeout } from 'ember-concurrency';
-import { trimText } from 'frontend-kaleidos/utils/trim-util';
+import { trimText, cleanPasteInputForTextarea } from 'frontend-kaleidos/utils/trim-util';
 import { containsConfidentialPieces } from 'frontend-kaleidos/utils/documents';
 import {
   addObject,
@@ -331,4 +331,8 @@ export default class CasesNewSubmissionComponent extends Component {
 
     this.showProposableAgendaModal = true;
   });
+
+  pasteIntoShortTitle = (pasteEvent) => {
+    this.shortTitle = cleanPasteInputForTextarea(pasteEvent, 'short-title', this.shortTitle);
+  }
 }

--- a/app/components/cases/subcases/new-subcase-form.hbs
+++ b/app/components/cases/subcases/new-subcase-form.hbs
@@ -59,15 +59,16 @@
                   />
                 </AuFormRow>
                 <AuFormRow>
-                  <AuLabel for="name-subcase">
+                  <AuLabel for="short-title-subcase">
                     {{t "name-subcase"}}</AuLabel>
                   <AuTextarea
                     data-test-new-subcase-form-shorttitle
-                    id="name-subcase"
+                    id="short-title-subcase"
                     rows="2"
                     value={{this.shortTitle}}
                     @width="block"
                     {{on "input" (pick "target.value" (set this "shortTitle"))}}
+                    {{on "paste" this.pasteIntoShortTitle}}
                   />
                 </AuFormRow>
                 <AuFormRow>
@@ -80,6 +81,7 @@
                     value={{this.title}}
                     @width="block"
                     {{on "input" (pick "target.value" (set this "title"))}}
+                    {{on "paste" this.pasteIntoTitle}}
                   />
                 </AuFormRow>
                 <AuFormRow>

--- a/app/components/cases/subcases/new-subcase-form.js
+++ b/app/components/cases/subcases/new-subcase-form.js
@@ -3,7 +3,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
-import { trimText } from 'frontend-kaleidos/utils/trim-util';
+import { trimText, cleanPasteInputForTextarea } from 'frontend-kaleidos/utils/trim-util';
 import { TrackedArray } from 'tracked-built-ins';
 import { dropTask, task, all } from 'ember-concurrency';
 import {
@@ -410,5 +410,13 @@ export default class NewSubcaseForm extends Component {
     if (typesRequired) return;
 
     this.showProposableAgendaModal = true;
+  }
+
+  pasteIntoShortTitle = (pasteEvent) => {
+    this.shortTitle = cleanPasteInputForTextarea(pasteEvent, 'short-title-subcase', this.shortTitle);
+  }
+
+  pasteIntoTitle = (pasteEvent) => {
+    this.title = cleanPasteInputForTextarea(pasteEvent, 'title-subcase', this.title);
   }
 }

--- a/app/components/subcase/bekrachtiging-description-panel/edit.hbs
+++ b/app/components/subcase/bekrachtiging-description-panel/edit.hbs
@@ -49,6 +49,7 @@
           value={{@subcase.shortTitle}}
           @width="block"
           {{on "input" (pick "target.value" (set @subcase "shortTitle"))}}
+          {{on "paste" this.pasteIntoShortTitle}}
         />
       </AuFormRow>
       <AuFormRow>
@@ -60,6 +61,7 @@
           value={{@subcase.title}}
           @width="block"
           {{on "input" (pick "target.value" (set @subcase "title"))}}
+          {{on "paste" this.pasteIntoTitle}}
         />
       </AuFormRow>
       <AuFormRow>

--- a/app/components/subcase/bekrachtiging-description-panel/edit.js
+++ b/app/components/subcase/bekrachtiging-description-panel/edit.js
@@ -4,7 +4,7 @@ import CONSTANTS from 'frontend-kaleidos/config/constants';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import { action } from '@ember/object';
-import { trimText } from 'frontend-kaleidos/utils/trim-util';
+import { trimText, cleanPasteInputForTextarea } from 'frontend-kaleidos/utils/trim-util';
 
 export default class SubcaseBekrachtigingDescriptionPanelEdit extends Component {
   /**
@@ -123,5 +123,13 @@ export default class SubcaseBekrachtigingDescriptionPanelEdit extends Component 
     this.args.onSave();
 
     this.isSaving = false;
+  }
+
+  pasteIntoShortTitle = (pasteEvent) => {
+    this.args.subcase.shortTitle = cleanPasteInputForTextarea(pasteEvent, 'short-title-subcase', this.args.subcase.shortTitle);
+  }
+
+  pasteIntoTitle = (pasteEvent) => {
+    this.args.subcase.title = cleanPasteInputForTextarea(pasteEvent, 'title-subcase', this.args.subcase.title);
   }
 }

--- a/app/components/subcase/description-panel/edit.hbs
+++ b/app/components/subcase/description-panel/edit.hbs
@@ -55,6 +55,7 @@
           value={{@subcase.shortTitle}}
           @width="block"
           {{on "input" (pick "target.value" (set @subcase "shortTitle"))}}
+          {{on "paste" this.pasteIntoShortTitle}}
         />
       </AuFormRow>
       <AuFormRow>
@@ -67,6 +68,7 @@
           value={{@subcase.title}}
           @width="block"
           {{on "input" (pick "target.value" (set @subcase "title"))}}
+          {{on "paste" this.pasteIntoTitle}}
         />
       </AuFormRow>
       <AuFormRow>

--- a/app/components/subcase/description-panel/edit.js
+++ b/app/components/subcase/description-panel/edit.js
@@ -4,7 +4,7 @@ import CONSTANTS from 'frontend-kaleidos/config/constants';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import { action } from '@ember/object';
-import { trimText } from 'frontend-kaleidos/utils/trim-util';
+import { trimText, cleanPasteInputForTextarea } from 'frontend-kaleidos/utils/trim-util';
 import addLeadingZeros from 'frontend-kaleidos/utils/add-leading-zeros';
 import { reorderAgendaitemsOnAgenda } from 'frontend-kaleidos/utils/agendaitem-utils';
 
@@ -316,5 +316,13 @@ export default class SubcaseDescriptionEdit extends Component {
       decisionActivity.decisionResultCode = acknowledgedResult;
     }
     await decisionActivity.save();
+  }
+
+  pasteIntoShortTitle = (pasteEvent) => {
+    this.args.subcase.shortTitle = cleanPasteInputForTextarea(pasteEvent, 'short-title-subcase', this.args.subcase.shortTitle);
+  }
+
+  pasteIntoTitle = (pasteEvent) => {
+    this.args.subcase.title = cleanPasteInputForTextarea(pasteEvent, 'title-subcase', this.args.subcase.title);
   }
 }

--- a/app/components/submission/description-panel/edit.hbs
+++ b/app/components/submission/description-panel/edit.hbs
@@ -67,6 +67,7 @@
           value={{@submission.shortTitle}}
           @width="block"
           {{on "input" (pick "target.value" (set @submission "shortTitle"))}}
+          {{on "paste" this.pasteIntoShortTitle}}
         />
       </AuFormRow>
       {{#if (user-may "treat-and-accept-submissions")}}
@@ -80,6 +81,7 @@
             value={{@submission.title}}
             @width="block"
             {{on "input" (pick "target.value" (set @submission "title"))}}
+            {{on "paste" this.pasteIntoTitle}}
           />
         </AuFormRow>
       {{/if}}

--- a/app/components/submission/description-panel/edit.js
+++ b/app/components/submission/description-panel/edit.js
@@ -4,7 +4,7 @@ import CONSTANTS from 'frontend-kaleidos/config/constants';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import { action } from '@ember/object';
-import { trimText } from 'frontend-kaleidos/utils/trim-util';
+import { trimText, cleanPasteInputForTextarea } from 'frontend-kaleidos/utils/trim-util';
 
 export default class SubmissionDescriptionPanelEditComponent extends Component {
   /**
@@ -144,4 +144,12 @@ export default class SubmissionDescriptionPanelEditComponent extends Component {
       (type) => type.uri !== CONSTANTS.SUBCASE_TYPES.BEKRACHTIGING
     );
   };
+
+  pasteIntoShortTitle = (pasteEvent) => {
+    this.args.submission.shortTitle = cleanPasteInputForTextarea(pasteEvent, 'short-title-submission', this.args.submission.shortTitle);
+  }
+
+  pasteIntoTitle = (pasteEvent) => {
+    this.args.submission.title = cleanPasteInputForTextarea(pasteEvent, 'title-submission', this.args.submission.title);
+  }
 }

--- a/app/utils/trim-util.js
+++ b/app/utils/trim-util.js
@@ -11,6 +11,43 @@ function trimText(text) {
   return text;
 }
 
+/**
+ * @name replaceEnters
+ * @description Vervangt enters van een string door spaties
+ * @param {String} text De tekst om enters in te vervangen
+ * @returns {String}
+ */
+function replaceEnters(text) {
+  if (text) {
+    text = text.replace(/\n/g, ' ');
+    // dubbele spaties weghalen
+    text = text.replace(/\s+/g, " ");
+    return trimText(text);
+  }
+  return text;
+}
+
+/**
+ * @name cleanPasteInputForTextarea
+ * @description Paste event tegenhouden en de geplakte tekst aanpassen
+ * @param {ClipboardEvent} pasteEvent het event {{on paste}}
+ * @param {String} elementId Het element van de AuTextarea
+ * @param {String} originalText De originele tekst van de AuTextArea (kan undefined of null zijn)
+ * @returns {String}
+ */
+function cleanPasteInputForTextarea(pasteEvent, elementId, originalText = '') {
+  pasteEvent.preventDefault();
+  const textarea = document.getElementById(elementId);
+  const start = textarea.selectionStart;
+  const end = textarea.selectionEnd;
+  const data = pasteEvent.clipboardData.getData('text/plain');
+  const cleanData = replaceEnters(data);
+  // unicode karakters strippen kan hier
+  return originalText.substring(0, start) + cleanData + originalText.substring(end);
+}
+
 export {
-  trimText
+  trimText,
+  replaceEnters,
+  cleanPasteInputForTextarea
 };


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4810

- Added a util
   - that can take a `ClipboardEvent` and prevent it from happening.
   - Using the AuTextareas cursor position, determine where the user pasted (and if it's a range or a single point)
   - Get the text from the ClipboardEvent and replace enters / reduce whitespace inside / trim whitespace on the edges
   - insert that text in the correct position of the original text
   - return the new "original" text to be set on model.property
- implemented that util in `subcase/description-panel/edit` and `submission/description-panel/edit`

note: any other AuTextarea where this needs to be implemented? Do we strip unicode? 