### PR TITLE
KAS-5049 add check for legacy meetings to just show documents

### DIFF
--- a/app/components/agenda/agenda-overview/agenda-overview-item.js
+++ b/app/components/agenda/agenda-overview/agenda-overview-item.js
@@ -105,6 +105,11 @@ export default class AgendaOverviewItem extends AgendaSidebarItem {
     }
     // no decisionResult after release
     this.documentsAreVisible = this.currentSession.may('view-documents-before-release');
+
+    // any legacy has no decisionResultCode, the document access level will determine who can view
+    if (this.args.meeting.isPreKaleidos) {
+      this.documentsAreVisible = true;
+    }
     return;
   }
 

--- a/app/routes/agenda/agendaitems/agendaitem/documents.js
+++ b/app/routes/agenda/agendaitems/agendaitem/documents.js
@@ -91,6 +91,11 @@ export default class DocumentsAgendaitemAgendaitemsAgendaRoute extends Route {
     }
     // no decisionResult after release
     this.documentsAreVisible = this.currentSession.may('view-documents-before-release');
+
+    // any legacy has no decisionResultCode, the document access level will determine who can view
+    if (this.meeting.isPreKaleidos) {
+      this.documentsAreVisible = true;
+    }
     return;
   }
 


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5049

- added preKaleidos check in 2 places (both agenda views overview and details)
I think that should do it, need to test still. (subcase doesn't check decisionResultCode)


NOTE: I didn't see the "hotfix to production" so I will have to cherry pick this comment rather than merging.
making draft PR to avoid merging
