### PR TITLE
KAS-4720 catch failed file uploads, allow user to continue

### DIFF
--- a/app/components/auk/file-uploader.js
+++ b/app/components/auk/file-uploader.js
@@ -20,6 +20,8 @@ import { isEnabledCabinetSubmissions } from '../../utils/feature-flag';
 export default class FileUploader extends Component {
   @service store;
   @service('file-queue') fileQueueService;
+  @service toaster;
+  @service intl;
 
   @tracked uploadedFileLength; // The amount of files that have been uploaded successfully
 
@@ -67,11 +69,22 @@ export default class FileUploader extends Component {
         file.name = originalName.slice(0, uppercasePDFIndex) + '.pdf';
       }
       this.args.onQueueUpdate?.(this.queueInfo);
-      const response = yield file.upload(
-        (this.args.isSubmission && isEnabledCabinetSubmissions())
-          ? '/draft-files'
-          : '/files'
-      );
+      let response;
+      try {
+        response = yield file.upload(
+          (this.args.isSubmission && isEnabledCabinetSubmissions())
+            ? '/draft-files'
+            : '/files'
+        );
+      } catch (error) {
+        this.toaster.error(
+          this.intl.t('could-not-upload-file', {name: file.name, error: error.message}),
+          this.intl.t('warning-title')
+        );
+        // manually remove failed file from queue to unblock the queue
+        this.fileQueue.remove(file);
+        throw error;
+      }
       const body = yield response.json();
       const fileFromStore = yield this.store.findRecord(
         (this.args.isSubmission && isEnabledCabinetSubmissions())

--- a/cypress/e2e/unit/file-upload.cy.js
+++ b/cypress/e2e/unit/file-upload.cy.js
@@ -23,6 +23,10 @@ context('Add files to an agenda', () => { // At the meeting-level
 
     // Open the modal, add files
     cy.get(route.agendaDocuments.addDocuments).click();
+    // can fake a bad upload, use later
+    // cy.intercept('POST', '/files', {
+    //   forceNetworkError: true,
+    // }).as('uploadPecesError');
     cy.addNewDocumentsInUploadModal([{
       folder: 'files', fileName: 'test', fileExtension: 'pdf', newFileName: 'test pdf', fileType: 'Nota',
     }], 'meeting');

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1511,5 +1511,5 @@
   "delete-all-decisions-sign-flow-data-counter":"{count} van {total} ondertekenflows verwijderd.",
   "verify-delete-all-decisions-sign-flow-data": "Bent u zeker dat u de ondertekenflows van alle beslissingen van deze agenda in Kaleidos wilt verwijderen? Deze actie kan niet ongedaan gemaakt worden. Vergeet niet om de flows ook in het platform Digitaal Ondertekenen stop te zetten. Dit gebeurt niet automatisch.",
   "your-session-is-invalid": "Uw sessie is verlopen, en u wordt zo meteen automatisch uitgelogd. Onvoltooid werk zal niet opgeslagen kunnen worden in Kaleidos. Gelieve dit indien nodig op uw eigen apparaat op te slaan alvorens deze pagina te verlaten.",
-  "could-not-upload-file": "Volgend bestand kon niet worden opgeladen: {name}. Mogelijk zijn er netwerk problemen of heeft u dit bestand open staan. Sluit het bestand in alle applicaties en probeer het opnieuw. Als het probleem niet opgelost is, neem dan contact op met kaleidos.servicedesk@vlaanderen.be. Gelieve volgende boodschap te vermelden: {error}" 
+  "could-not-upload-file": "Volgend bestand kon niet worden opgeladen: {name}. Sluit het bestand in alle applicaties en probeer opnieuw. Als het probleem zich opnieuw voordoet, neem dan contact op met kaleidos.servicedesk@vlaanderen.be. Gelieve volgende boodschap te vermelden: {error}" 
 }

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1510,5 +1510,6 @@
   "delete-all-decisions-sign-flow-data":"Ondertekenflows voor alle beslissingen verwijderen",
   "delete-all-decisions-sign-flow-data-counter":"{count} van {total} ondertekenflows verwijderd.",
   "verify-delete-all-decisions-sign-flow-data": "Bent u zeker dat u de ondertekenflows van alle beslissingen van deze agenda in Kaleidos wilt verwijderen? Deze actie kan niet ongedaan gemaakt worden. Vergeet niet om de flows ook in het platform Digitaal Ondertekenen stop te zetten. Dit gebeurt niet automatisch.",
-  "your-session-is-invalid": "Uw sessie is verlopen, en u wordt zo meteen automatisch uitgelogd. Onvoltooid werk zal niet opgeslagen kunnen worden in Kaleidos. Gelieve dit indien nodig op uw eigen apparaat op te slaan alvorens deze pagina te verlaten."
+  "your-session-is-invalid": "Uw sessie is verlopen, en u wordt zo meteen automatisch uitgelogd. Onvoltooid werk zal niet opgeslagen kunnen worden in Kaleidos. Gelieve dit indien nodig op uw eigen apparaat op te slaan alvorens deze pagina te verlaten.",
+  "could-not-upload-file": "Volgend bestand kon niet worden opgeladen: {name}. Mogelijk zijn er netwerk problemen of heeft u dit bestand open staan. Sluit het bestand in alle applicaties en probeer het opnieuw. Als het probleem niet opgelost is, neem dan contact op met kaleidos.servicedesk@vlaanderen.be. Gelieve volgende boodschap te vermelden: {error}" 
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4720

- Catch the failing of uploads (file is open with onedrive or maybe network errors/interrupts)
- remove file from queue, it unblocks the UI and more can be uploaded.
- added error message in a toast, needs user feedback/tweaks.

note: I may be able to determine if the error was because a file was open based on the error message "Source file not found" but this error would be so infrequent a general message may just be better.
"Close file, Try again and contact us". 