### PR TITLE
KAS-5057 Add serializer for attributes to only save dirt agendaitem numbers

### DIFF
--- a/app/serializers/agendaitem.js
+++ b/app/serializers/agendaitem.js
@@ -2,11 +2,35 @@ import ApplicationSerializer from './application';
 
 const SKIP_SERIALIZED = ['previousVersion', 'nextVersion'];
 
+// we have to skip in order to determine if it's dirty or not.
+const SKIP_ATTRIBUTES = [
+  'number'
+];
+
+const SAVE_ONLY_DIRTY_ATTRIBUTES = [
+  'number'
+];
+
 export default class AgendaitemSerializer extends ApplicationSerializer {
   serializeBelongsTo(snapshot, json, relationship) {
     const key = relationship.key;
     if (!SKIP_SERIALIZED.includes(key)) {
       super.serializeBelongsTo(snapshot, json, relationship);
+    }
+  }
+
+  serializeAttribute(snapshot, json, key, attribute) {
+    if (!SKIP_ATTRIBUTES.includes(key)) {
+      super.serializeAttribute(snapshot, json, key, attribute);
+    }
+    else {
+      // only save attribute when it is dirty to avoid concurrency with backend.
+      const changedAttributes = snapshot?._changedAttributes;
+      for (const dirtyAttribute of SAVE_ONLY_DIRTY_ATTRIBUTES) {
+        if (changedAttributes[dirtyAttribute]) {
+          super.serializeAttribute(snapshot, json, key, attribute);
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
No ticket, recurring issue (this took like 10 min max to implement):

- Approving submissions creates agendaitems.
- New agendaitems may be a higher priority than existing agendaitems > we reorder all agendaitems in the list by updating  `agendaitem.number` 
- the frontend doesn't know about those constant changes to `agendaitem.number`. Any save of agendaitem in frontend can and will save stale  `agendaitem.number` if not refreshed or when multiple people are working concurrently.

This PR will address this by doing what we do on `piece.originalName`. Check if the attribute is dirty and only then allow it to save to the backend.

Concurrency still has some weird visual effects:
f.e. on agendaview sidebar, items 5 and 6 are swapped by user 1 (or tab 1) while user 2 (or tab 2) has agendaitem 5 open and saves slightly after the swapping (by editing titles). user 2 will now see the number change to 6 in the sidebar. so in that moment there will be 2 agendaitems with the number 6. This is only visual since agendaitem 6 is now 5 in database, just not in this users local store. Clicking on agendaitem 6 (now 5) will update the store and the sidebar.
We can't really fix this unless we constantly refresh unfocused models, which I wouldn't recommend.


Another thing we should maybe fix later is the editing of internal review comments.
In document-viewer this is a separate edit and save.
in agendaitem and subcase view this requires you to edit the entire model and also save agendaitem/subcase which could be stale at this point in time.