### PR TITLE
KAS-5024 add manual docx conversion on document-card and draft-document-card

### DIFF
--- a/app/components/documents/document-card.hbs
+++ b/app/components/documents/document-card.hbs
@@ -201,7 +201,7 @@
                 @icon="three-dots"
                 @title={{t "more"}}
                 @hideText={{true}}
-                @disabled={{this.loadPieceRelatedData.isRunning}}
+                @disabled={{or this.loadPieceRelatedData.isRunning this.loadFiles.isRunning}}
                 @alignment="right"
               >
                 {{#if @showCreateNewVersion}}
@@ -243,6 +243,16 @@
                     role="menuitem"
                   >
                     {{t "present-for-signing"}}
+                  </AuButton>
+                {{/if}}
+                {{#if this.mayConvertSourceFile}}
+                  <AuButton
+                    @skin="link"
+                    @disabled={{this.convertSourceFile.isRunning}}
+                    {{on "click" this.convertSourceFile.perform}}
+                    role="menuitem"
+                  >
+                    {{t "convert-to-pdf"}}
                   </AuButton>
                 {{/if}}
                 {{#if this.hasMarkedSignFlow}}

--- a/app/components/documents/document-card.js
+++ b/app/components/documents/document-card.js
@@ -40,6 +40,7 @@ export default class DocumentsDocumentCardComponent extends Component {
   @service intl;
   @service pieceAccessLevelService;
   @service signatureService;
+  @service fileConversionService;
 
   @tracked isOpenUploadModal = false;
   @tracked isOpenVerifyDeleteModal = false;
@@ -62,6 +63,9 @@ export default class DocumentsDocumentCardComponent extends Component {
 
   @tracked dateToShowAltLabel;
   @tracked altDateToShow;
+
+  @tracked sourceFile;
+  @tracked derived;
 
   // model "report" only
   @tracked hasConfidentialityChanged = false;
@@ -132,6 +136,7 @@ export default class DocumentsDocumentCardComponent extends Component {
       && this.deleteMarkedSignFlow.isIdle
       && this.loadSignatureRelatedData.isIdle
       && this.loadSignatureRelatedData.performCount > 0
+      && this.loadFiles.isIdle
       && (!this.hasSignFlow || this.hasMarkedSignFlow)
     );
   }
@@ -160,6 +165,16 @@ export default class DocumentsDocumentCardComponent extends Component {
       !this.args.hideDelete &&
       (this.retrievedPieces?.length === 0 || this.currentSession.may('remove-piece-from-parliament'))
     );
+  }
+
+  get mayConvertSourceFile() {
+    const canConvertSourceFile = this.fileConversionService.canConvertSourceFile(this.sourceFile);
+    return (
+      this.loadPieceRelatedData.isIdle &&
+      this.loadFiles.isIdle &&
+      canConvertSourceFile &&
+      !this.derived?.id
+    )
   }
 
   @task
@@ -220,8 +235,8 @@ export default class DocumentsDocumentCardComponent extends Component {
 
   @task
   *loadFiles() {
-    const sourceFile = yield this.args.piece.file;
-    yield sourceFile?.belongsTo('derived').reload();
+    this.sourceFile = yield this.args.piece.file;
+    this.derived = yield this.sourceFile?.belongsTo('derived').reload();
   }
 
 
@@ -422,6 +437,19 @@ export default class DocumentsDocumentCardComponent extends Component {
     );
     yield this.loadPieceRelatedData.perform();
   }
+
+  convertSourceFile = task(async () => {
+    try {
+      await this.fileConversionService.convertSourceFile(this.sourceFile, true);
+      await this.loadPieceRelatedData.perform();
+      await this.loadFiles.perform();
+    } catch (error) {
+      this.toaster.error(
+        this.intl.t('error-convert-file', { message: error.message }),
+        this.intl.t('warning-title'),
+      );
+    }
+  });
 
   @action
   async changeAccessLevel(accessLevel) {

--- a/app/components/documents/draft-document-card.hbs
+++ b/app/components/documents/draft-document-card.hbs
@@ -124,6 +124,16 @@
                     {{t "edit"}}
                   </AuButton>
                 {{/if}}
+                {{#if this.mayConvertSourceFile}}
+                  <AuButton
+                    @skin="link"
+                    @disabled={{this.convertSourceFile.isRunning}}
+                    {{on "click" this.convertSourceFile.perform}}
+                    role="menuitem"
+                  >
+                    {{t "convert-to-pdf"}}
+                  </AuButton>
+                {{/if}}
                 <AuHr />
                 <AuButton
                   data-test-draft-document-card-delete

--- a/app/components/documents/draft-document-card.js
+++ b/app/components/documents/draft-document-card.js
@@ -33,6 +33,7 @@ export default class DocumentsDraftDocumentCardComponent extends Component {
   @service intl;
   @service pieceAccessLevelService;
   @service draftSubmissionService;
+  @service fileConversionService;
 
   @tracked isOpenUploadModal = false;
   @tracked isOpenVerifyDeleteModal = false;
@@ -48,6 +49,9 @@ export default class DocumentsDraftDocumentCardComponent extends Component {
   @tracked dateToShowAltLabel;
   @tracked altDateToShow;
 
+  @tracked sourceFile;
+  @tracked derived;
+
   constructor() {
     super(...arguments);
     this.loadPieceRelatedData.perform();
@@ -55,7 +59,12 @@ export default class DocumentsDraftDocumentCardComponent extends Component {
   }
 
   get mayEdit() {
-    return this.args.isEditable && this.args.piece.constructor.modelName === 'draft-piece';
+    return (
+      this.args.isEditable &&
+      this.args.piece.constructor.modelName === 'draft-piece' &&
+      this.loadPieceRelatedData.isIdle &&
+      this.loadFiles.isIdle
+    );
   }
 
   get mayShowAddNewVersion() {
@@ -133,8 +142,8 @@ export default class DocumentsDraftDocumentCardComponent extends Component {
 
   @task
   *loadFiles() {
-    const sourceFile = yield this.args.piece.file;
-    yield sourceFile?.derived;
+    this.sourceFile = yield this.args.piece.file;
+    this.derived = yield this.sourceFile?.belongsTo('derived').reload();
   }
 
   @task
@@ -171,6 +180,16 @@ export default class DocumentsDraftDocumentCardComponent extends Component {
   get visiblePieces() {
     const idx = this.reverseSortedPieces.indexOf(this.piece) + 1;
     return this.reverseSortedPieces.slice(idx);
+  }
+
+  get mayConvertSourceFile() {
+    const canConvertSourceFile = this.fileConversionService.canConvertSourceFile(this.sourceFile);
+    return (
+      this.loadPieceRelatedData.isIdle &&
+      this.loadFiles.isIdle &&
+      canConvertSourceFile &&
+      !this.derived?.id
+    )
   }
 
   @task
@@ -263,6 +282,19 @@ export default class DocumentsDraftDocumentCardComponent extends Component {
     yield deleteDocumentContainer(this.documentContainer);
     this.args.didDeleteContainer?.(this.documentContainer);
   }
+
+  convertSourceFile = task(async () => {
+    try {
+      await this.fileConversionService.convertSourceFile(this.sourceFile, true);
+      await this.loadPieceRelatedData.perform();
+      await this.loadFiles.perform();
+    } catch (error) {
+      this.toaster.error(
+        this.intl.t('error-convert-file', { message: error.message }),
+        this.intl.t('warning-title'),
+      );
+    }
+  });
 
   canViewConfidentialPiece = async () => {
     return await this.pieceAccessLevelService.canViewConfidentialPiece(this.args.piece);

--- a/app/services/file-conversion-service.js
+++ b/app/services/file-conversion-service.js
@@ -7,42 +7,76 @@ import {
 
 export default class FileConversionService extends Service {
   @service store;
+  @service toaster;
+  @service intl;
 
-  async convertSourceFile(sourceFile) {
-    if (
-      DOCUMENT_CONVERSION_SUPPORTED_MIME_TYPES.some(
-        (mimeType) => sourceFile.format.includes(mimeType)
-      )
-        && DOCUMENT_CONVERSION_SUPPORTED_EXTENSIONS.includes(sourceFile.extension)
-    ) {
-      const oldDerivedFile = await sourceFile.derived;
-      const response = await fetch(`/files/${sourceFile.id}/convert`, {
-        method: 'POST',
-        headers: {
-          'Accept': 'application/vnd.api+json',
-          'Content-Type': 'application/vnd.api+json',
-        },
-      });
+  canConvertSourceFile(sourceFile) {
+    if (!sourceFile?.extension) {
+      return false;
+    }
+    return (
+      DOCUMENT_CONVERSION_SUPPORTED_MIME_TYPES.some((mimeType) =>
+        sourceFile.format.includes(mimeType),
+      ) &&
+      DOCUMENT_CONVERSION_SUPPORTED_EXTENSIONS.includes(sourceFile.extension)
+    );
+  }
 
-      if (response.ok) {
-        if (oldDerivedFile) {
-          oldDerivedFile.source = null;
-          await oldDerivedFile.save();
-          await oldDerivedFile.destroyRecord();
+  async convertSourceFile(sourceFile, showFullProgress) {
+    let convertToast;
+    if (this.canConvertSourceFile(sourceFile)) {
+      try {
+        const oldDerivedFile = await sourceFile.derived;
+        if (showFullProgress) {
+          convertToast = this.toaster.loading(
+            this.intl.t('document-being-converted'),
+            null,
+            {
+              timeOut: 60000,
+              closable: false,
+            }
+          );
         }
-        const result = await response.json();
-        const modelName = sourceFile.constructor.modelName;
-        const derivedFile = await this.store.findRecord(modelName, result.data[0].id);
-        sourceFile.derived = derivedFile;
-        await sourceFile.save();
-      } else {
-        console.warn(`Couldn't convert file with id ${sourceFile.id}`);
-        let errorMessage = response.status;
-        if (response.headers.get('Content-Type').includes('application/vnd.api+json')) {
-          const { errors } = await response.json();
-          errorMessage = JSON.stringify(errors);
+        const response = await fetch(`/files/${sourceFile.id}/convert`, {
+          method: 'POST',
+          headers: {
+            'Accept': 'application/vnd.api+json',
+            'Content-Type': 'application/vnd.api+json',
+          },
+        });
+  
+        if (response.ok) {
+          if (oldDerivedFile) {
+            oldDerivedFile.source = null;
+            await oldDerivedFile.save();
+            await oldDerivedFile.destroyRecord();
+          }
+          const result = await response.json();
+          const modelName = sourceFile.constructor.modelName;
+          const derivedFile = await this.store.findRecord(modelName, result.data[0].id);
+          sourceFile.derived = derivedFile;
+          await sourceFile.save();
+          if (showFullProgress) {
+            this.toaster.success(this.intl.t('document-converted'));
+          }
+        } else {
+          console.warn(`Couldn't convert file with id ${sourceFile.id}`);
+          let errorMessage = response.status;
+          if (response.headers.get('Content-Type').includes('application/vnd.api+json')) {
+            const { errors } = await response.json();
+            errorMessage = JSON.stringify(errors);
+          }
+          throw new Error(`An exception occurred while converting a file: ${errorMessage}`);
         }
-        throw new Error(`An exception occurred while converting a file: ${errorMessage}`);
+      } catch (error) {
+        // errors are caught where this method is used and an error toast is shown
+        // maybe we should only do that toast here once rather than duplicating
+        console.log('Could not convert document, possibly timed out');
+        throw error;
+      } finally {
+        if (showFullProgress) {
+          this.toaster.close(convertToast);
+        }
       }
     }
   }

--- a/app/services/file-conversion-service.js
+++ b/app/services/file-conversion-service.js
@@ -44,7 +44,7 @@ export default class FileConversionService extends Service {
             'Content-Type': 'application/vnd.api+json',
           },
         });
-  
+
         if (response.ok) {
           if (oldDerivedFile) {
             oldDerivedFile.source = null;
@@ -74,7 +74,7 @@ export default class FileConversionService extends Service {
       } catch (error) {
         // errors are caught where this method is used and an error toast is shown
         // maybe we should only do that toast here once rather than duplicating
-        console.log('Could not convert document, possibly timed out');
+        console.warn('Could not convert document, possibly timed out');
         throw error;
       } finally {
         if (showFullProgress) {

--- a/app/services/file-conversion-service.js
+++ b/app/services/file-conversion-service.js
@@ -65,8 +65,11 @@ export default class FileConversionService extends Service {
           if (response.headers.get('Content-Type').includes('application/vnd.api+json')) {
             const { errors } = await response.json();
             errorMessage = JSON.stringify(errors);
+          } else {
+            // we don't get these headers when the http call times out
+            errorMessage= this.intl.t('document-failed-to-convert', {name: sourceFile.filename} )
           }
-          throw new Error(`An exception occurred while converting a file: ${errorMessage}`);
+          throw new Error(errorMessage);
         }
       } catch (error) {
         // errors are caught where this method is used and an error toast is shown

--- a/app/services/file-conversion-service.js
+++ b/app/services/file-conversion-service.js
@@ -60,15 +60,15 @@ export default class FileConversionService extends Service {
             this.toaster.success(this.intl.t('document-converted'));
           }
         } else {
-          console.warn(`Couldn't convert file with id ${sourceFile.id}`);
-          let errorMessage = response.status;
+          let errorMessage = this.intl.t('document-failed-to-convert', {name: sourceFile.filename});
           if (response.headers.get('Content-Type').includes('application/vnd.api+json')) {
             const { errors } = await response.json();
-            errorMessage = JSON.stringify(errors);
+            errorMessage += JSON.stringify(errors);
           } else {
             // we don't get these headers when the http call times out
-            errorMessage= this.intl.t('document-failed-to-convert', {name: sourceFile.filename} )
+            errorMessage= this.intl.t('document-failed-to-convert-timed-out', {name: sourceFile.filename} )
           }
+          console.warn(errorMessage);
           throw new Error(errorMessage);
         }
       } catch (error) {

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1514,5 +1514,6 @@
   "convert-to-pdf": "Converteer naar PDF",
   "document-being-converted": "Document omzetten naar PDF",
   "document-converted": "Document omgezet naar PDF",
-  "document-failed-to-convert": "Document {name} kan mogelijk niet worden omgezet naar pdf. Vermoedelijk is het bron document te groot of zitten er objecten in die niet kunnen worden omgevormd. Dit document moet manueel worden opgezet naar pdf en daarna opgeladen als afgeleid bestand."
+  "document-failed-to-convert": "Document \"{name}\" kan niet worden omgezet naar pdf. Reden: ",
+  "document-failed-to-convert-timed-out": "Document \"{name}\" kan mogelijk niet worden omgezet naar pdf. Vermoedelijk is het bron document te groot of zitten er objecten in die niet kunnen worden omgevormd. Dit document moet manueel worden opgezet naar pdf en daarna opgeladen als afgeleid bestand."
 }

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1515,5 +1515,5 @@
   "document-being-converted": "Document omzetten naar PDF",
   "document-converted": "Document omgezet naar PDF",
   "document-failed-to-convert": "Document \"{name}\" kan niet worden omgezet naar pdf. Reden: ",
-  "document-failed-to-convert-timed-out": "Document \"{name}\" kan mogelijk niet worden omgezet naar pdf. Vermoedelijk is het bron document te groot of zitten er objecten in die niet kunnen worden omgevormd. Dit document moet manueel worden opgezet naar pdf en daarna opgeladen als afgeleid bestand."
+  "document-failed-to-convert-timed-out": "Document \"{name}\" kon niet automatisch geconverteerd worden naar pdf."
 }

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1510,5 +1510,8 @@
   "delete-all-decisions-sign-flow-data":"Ondertekenflows voor alle beslissingen verwijderen",
   "delete-all-decisions-sign-flow-data-counter":"{count} van {total} ondertekenflows verwijderd.",
   "verify-delete-all-decisions-sign-flow-data": "Bent u zeker dat u de ondertekenflows van alle beslissingen van deze agenda in Kaleidos wilt verwijderen? Deze actie kan niet ongedaan gemaakt worden. Vergeet niet om de flows ook in het platform Digitaal Ondertekenen stop te zetten. Dit gebeurt niet automatisch.",
-  "your-session-is-invalid": "Uw sessie is verlopen, en u wordt zo meteen automatisch uitgelogd. Onvoltooid werk zal niet opgeslagen kunnen worden in Kaleidos. Gelieve dit indien nodig op uw eigen apparaat op te slaan alvorens deze pagina te verlaten."
+  "your-session-is-invalid": "Uw sessie is verlopen, en u wordt zo meteen automatisch uitgelogd. Onvoltooid werk zal niet opgeslagen kunnen worden in Kaleidos. Gelieve dit indien nodig op uw eigen apparaat op te slaan alvorens deze pagina te verlaten.",
+  "convert-to-pdf": "Converteer naar PDF",
+  "document-being-converted": "Document omzetten naar PDF",
+  "document-converted": "Document omgezet naar PDF"
 }

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1513,5 +1513,6 @@
   "your-session-is-invalid": "Uw sessie is verlopen, en u wordt zo meteen automatisch uitgelogd. Onvoltooid werk zal niet opgeslagen kunnen worden in Kaleidos. Gelieve dit indien nodig op uw eigen apparaat op te slaan alvorens deze pagina te verlaten.",
   "convert-to-pdf": "Converteer naar PDF",
   "document-being-converted": "Document omzetten naar PDF",
-  "document-converted": "Document omgezet naar PDF"
+  "document-converted": "Document omgezet naar PDF",
+  "document-failed-to-convert": "Document {name} kan mogelijk niet worden omgezet naar pdf. Vermoedelijk is het bron document te groot of zitten er objecten in die niet kunnen worden omgevormd. Dit document moet manueel worden opgezet naar pdf en daarna opgeladen als afgeleid bestand."
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5024

- added conversion button to document-card (indirectly based on the permission 'manage-documents')
- added conversion button to draft-document-card (based on the ability to edit, not permission, if you can delete the document, you can also convert manually). Is this ok? was not specified.
- extracted the check if a source may be converted at all so it can be used separately. (Did not enforce extension or mime-type limits for dossierbeheerders since they already have upload restrictions, there should not be an "incorrect mime-type" document in a submission anymore")
- added more toasts in the manual conversion scenario. Felt like more feedback was needed since the progress can take up to 60 seconds (until timeout issue)