### PR TITLE
KAS-5056 add check on extension if mimetype check fails

### DIFF
--- a/app/config/config.js
+++ b/app/config/config.js
@@ -53,6 +53,15 @@ export const SUBMISSION_ALLOWED_MIME_TYPES = [
   'application/zip', // DOCX (Google Docs), XLSX (Google Docs, LibreOffice)
   'application/pdf' // PDF
 ];
+
+// mimetype was not enough for zip, using extension as backup
+export const SUBMISSION_ALLOWED_EXTENSION = [
+  'docx',
+  'xlsx',
+  'zip',
+  'pdf'
+];
+
 export const EMAIL_ATTACHMENT_WARN_SIZE = 10 * 1000000; // 10 MB
 export const EMAIL_ATTACHMENT_MAX_SIZE = 30 * 1000000; // 30 MB
 

--- a/app/services/draft-submission-service.js
+++ b/app/services/draft-submission-service.js
@@ -1,7 +1,7 @@
 import Service, { inject as service } from '@ember/service';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 import { isEnabledCabinetSubmissions } from 'frontend-kaleidos/utils/feature-flag';
-import { SUBMISSION_ALLOWED_MIME_TYPES } from 'frontend-kaleidos/config/config';
+import { SUBMISSION_ALLOWED_MIME_TYPES, SUBMISSION_ALLOWED_EXTENSION } from 'frontend-kaleidos/config/config';
 
 export default class DraftSubmissionService extends Service {
   @service store;
@@ -199,10 +199,14 @@ export default class DraftSubmissionService extends Service {
 
   // for submissions we want to limit the amount of types certain profiles are allowed to upload
   validateUploadedFile = (file) => {
-    const allowed = SUBMISSION_ALLOWED_MIME_TYPES.includes(file.type);
+    const mimetypeAllowed = SUBMISSION_ALLOWED_MIME_TYPES.includes(file.type);
+    // extension is in the name
+    const extension = file?.name?.split('.').pop();
+    const extensionAllowed = SUBMISSION_ALLOWED_EXTENSION.includes(extension);
     if (
       !this.currentSession.may('upload-any-submission-document-extension') &&
-      !allowed
+      !mimetypeAllowed &&
+      !extensionAllowed
     ) {
       this.toaster.error(
         this.intl.t('submission-document-incorrect-type', { name: file.name }),

--- a/app/services/draft-submission-service.js
+++ b/app/services/draft-submission-service.js
@@ -201,8 +201,8 @@ export default class DraftSubmissionService extends Service {
   validateUploadedFile = (file) => {
     const mimetypeAllowed = SUBMISSION_ALLOWED_MIME_TYPES.includes(file.type);
     // extension is in the name
-    const extension = file?.name?.split('.').pop();
-    const extensionAllowed = SUBMISSION_ALLOWED_EXTENSION.includes(extension.toLowercase());
+    const extension = file.name.split('.').pop();
+    const extensionAllowed = SUBMISSION_ALLOWED_EXTENSION.includes(extension?.toLowerCase());
     if (
       !this.currentSession.may('upload-any-submission-document-extension') &&
       !mimetypeAllowed &&

--- a/app/services/draft-submission-service.js
+++ b/app/services/draft-submission-service.js
@@ -202,7 +202,7 @@ export default class DraftSubmissionService extends Service {
     const mimetypeAllowed = SUBMISSION_ALLOWED_MIME_TYPES.includes(file.type);
     // extension is in the name
     const extension = file?.name?.split('.').pop();
-    const extensionAllowed = SUBMISSION_ALLOWED_EXTENSION.includes(extension);
+    const extensionAllowed = SUBMISSION_ALLOWED_EXTENSION.includes(extension.toLowercase());
     if (
       !this.currentSession.may('upload-any-submission-document-extension') &&
       !mimetypeAllowed &&


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5056

check extension if mimetype fails (mainly zips)
since the extension is in the name, we have to extract it first.
Just in case, also check the lowercase of the extension.