### PR TITLE
KAS-5045 add better feedback when call fails

### DIFF
--- a/app/services/file-conversion-service.js
+++ b/app/services/file-conversion-service.js
@@ -65,8 +65,11 @@ export default class FileConversionService extends Service {
           if (response.headers.get('Content-Type').includes('application/vnd.api+json')) {
             const { errors } = await response.json();
             errorMessage = JSON.stringify(errors);
+          } else {
+            // we don't get these headers when the http call times out
+            errorMessage= this.intl.t('document-failed-to-convert', {name: sourceFile.filename} )
           }
-          throw new Error(`An exception occurred while converting a file: ${errorMessage}`);
+          throw new Error(errorMessage);
         }
       } catch (error) {
         // errors are caught where this method is used and an error toast is shown

--- a/app/services/file-conversion-service.js
+++ b/app/services/file-conversion-service.js
@@ -60,15 +60,15 @@ export default class FileConversionService extends Service {
             this.toaster.success(this.intl.t('document-converted'));
           }
         } else {
-          console.warn(`Couldn't convert file with id ${sourceFile.id}`);
-          let errorMessage = response.status;
+          let errorMessage = this.intl.t('document-failed-to-convert', {name: sourceFile.filename});
           if (response.headers.get('Content-Type').includes('application/vnd.api+json')) {
             const { errors } = await response.json();
-            errorMessage = JSON.stringify(errors);
+            errorMessage += JSON.stringify(errors);
           } else {
             // we don't get these headers when the http call times out
-            errorMessage= this.intl.t('document-failed-to-convert', {name: sourceFile.filename} )
+            errorMessage= this.intl.t('document-failed-to-convert-timed-out', {name: sourceFile.filename} )
           }
+          console.warn(errorMessage);
           throw new Error(errorMessage);
         }
       } catch (error) {

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1514,5 +1514,6 @@
   "convert-to-pdf": "Converteer naar PDF",
   "document-being-converted": "Document omzetten naar PDF",
   "document-converted": "Document omgezet naar PDF",
-  "document-failed-to-convert": "Document {name} kan mogelijk niet worden omgezet naar pdf. Vermoedelijk is het bron document te groot of zitten er objecten in die niet kunnen worden omgevormd. Dit document moet manueel worden opgezet naar pdf en daarna opgeladen als afgeleid bestand."
+  "document-failed-to-convert": "Document \"{name}\" kan niet worden omgezet naar pdf. Reden: ",
+  "document-failed-to-convert-timed-out": "Document \"{name}\" kan mogelijk niet worden omgezet naar pdf. Vermoedelijk is het bron document te groot of zitten er objecten in die niet kunnen worden omgevormd. Dit document moet manueel worden opgezet naar pdf en daarna opgeladen als afgeleid bestand."
 }

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1515,5 +1515,5 @@
   "document-being-converted": "Document omzetten naar PDF",
   "document-converted": "Document omgezet naar PDF",
   "document-failed-to-convert": "Document \"{name}\" kan niet worden omgezet naar pdf. Reden: ",
-  "document-failed-to-convert-timed-out": "Document \"{name}\" kan mogelijk niet worden omgezet naar pdf. Vermoedelijk is het bron document te groot of zitten er objecten in die niet kunnen worden omgevormd. Dit document moet manueel worden opgezet naar pdf en daarna opgeladen als afgeleid bestand."
+  "document-failed-to-convert-timed-out": "Document \"{name}\" kon niet automatisch geconverteerd worden naar pdf."
 }

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1513,5 +1513,6 @@
   "your-session-is-invalid": "Uw sessie is verlopen, en u wordt zo meteen automatisch uitgelogd. Onvoltooid werk zal niet opgeslagen kunnen worden in Kaleidos. Gelieve dit indien nodig op uw eigen apparaat op te slaan alvorens deze pagina te verlaten.",
   "convert-to-pdf": "Converteer naar PDF",
   "document-being-converted": "Document omzetten naar PDF",
-  "document-converted": "Document omgezet naar PDF"
+  "document-converted": "Document omgezet naar PDF",
+  "document-failed-to-convert": "Document {name} kan mogelijk niet worden omgezet naar pdf. Vermoedelijk is het bron document te groot of zitten er objecten in die niet kunnen worden omgevormd. Dit document moet manueel worden opgezet naar pdf en daarna opgeladen als afgeleid bestand."
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5045

Not sure if this is enough? All I can really see is that the response is empty when a timeout happens and we seem to get no proper response.
Added a clear message (needs user feedback/input) to indicate that the docx probably wont convert.
![image](https://github.com/user-attachments/assets/1b4862f2-abf3-4e70-9364-d7e5f5c12af9)

If the service actually fails (like with the broken drive issue) we still get a proper response with that error
![image](https://github.com/user-attachments/assets/d31767d1-3648-4aea-9068-54179ca2ea66)
