### PR TITLE
KAS-4980 add explicit loadingMessage param to all AuButtons that use loading

### DIFF
--- a/app/components/agenda/agenda-header/agenda-actions.hbs
+++ b/app/components/agenda/agenda-header/agenda-actions.hbs
@@ -384,6 +384,7 @@
       <AuButton
         @skin="primary"
         @loading={{this.emptyInteralReviewsOfAgendaitemThrottled.isRunning}}
+        @loadingMessage={{t "loading"}}
         {{on "click" this.emptyInteralReviews}}
       >
         {{t "empty-internal-review"}}

--- a/app/components/agenda/agenda-header/agenda-check.hbs
+++ b/app/components/agenda/agenda-header/agenda-check.hbs
@@ -117,6 +117,7 @@
               data-test-agenda-check-confirm
               @skin="primary"
               @loading={{this.fileNameMappings.isRunning}}
+              @loadingMessage={{t "loading"}}
               @disabled={{not this.fileNameMap}}
               {{on "click" this.onSave}}>
               {{@saveLabel}}

--- a/app/components/agenda/agendaitem-search.hbs
+++ b/app/components/agenda/agendaitem-search.hbs
@@ -22,6 +22,7 @@
             @skin="secondary"
             @hideText={{@hideButtonText}}
             @loading={{this.search.isRunning}}
+            @loadingMessage={{t "loading"}}
             @disabled={{@isEditingOverview}}
             {{on "click" @toggleIsEditingOverview}}
           >
@@ -35,6 +36,7 @@
             @icon="search"
             @hideText={{@hideButtonText}}
             @loading={{this.search.isRunning}}
+            @loadingMessage={{t "loading"}}
             {{on "click" (perform this.search)}}
           >
             {{t "search"}}

--- a/app/components/agenda/agendaitem/agendaitem-case-panel/agendaitem-case-panel-edit.hbs
+++ b/app/components/agenda/agendaitem/agendaitem-case-panel/agendaitem-case-panel-edit.hbs
@@ -166,6 +166,7 @@
             data-test-agendaitem-titles-edit-save={{true}}
             @skin="primary"
             @loading={{this.saveChanges.isRunning}}
+            @loadingMessage={{t "loading"}}
             {{on "click" (perform this.saveChanges)}}
           >
             {{t "save"}}

--- a/app/components/agenda/agendaitem/agendaitem-decision-edit.hbs
+++ b/app/components/agenda/agendaitem/agendaitem-decision-edit.hbs
@@ -15,6 +15,7 @@
     @icon="check"
     @hideText={{true}}
     @loading={{this.saveDecisionActivity.isRunning}}
+    @loadingMessage={{t "loading"}}
     {{on "click" (perform this.saveDecisionActivity)}}
     class="auk-u-ml"
   >
@@ -26,6 +27,7 @@
     @icon="x"
     @hideText={{true}}
     @loading={{this.saveDecisionActivity.isRunning}}
+    @loadingMessage={{t "loading"}}
     {{on "click" this.cancelEdit}}
   >
     {{t "cancel"}}

--- a/app/components/agenda/agendaitem/create-agendaitem.hbs
+++ b/app/components/agenda/agendaitem/create-agendaitem.hbs
@@ -117,6 +117,7 @@
       data-test-create-agendaitem-save
       @skin="primary"
       @loading={{this.addSubcasesToAgenda.isRunning}}
+      @loadingMessage={{t "loading"}}
       @disabled={{this.isSaveDisabled}}
       {{on "click" (perform this.addSubcasesToAgenda)}}
     >

--- a/app/components/agenda/agendaitem/decision/digital.hbs
+++ b/app/components/agenda/agendaitem/decision/digital.hbs
@@ -116,6 +116,7 @@
               @icon="renew"
               class="au-u-padding-left-none"
               @loading={{or this.loadDocuments.isRunning this.updateBetreftContent.isRunning}}
+              @loadingMessage={{t "loading"}}
               {{on "click" this.updateBetreftContent.perform}}
             >{{t "update-thing" thing=(t "content")}}</AuButton>
             <VersionsDropdown
@@ -137,6 +138,7 @@
               @icon="renew"
               class="au-u-padding-left-none"
               @loading={{or this.loadNota.isRunning this.updateBeslissingContent.isRunning}}
+              @loadingMessage={{t "loading"}}
               @disabled={{not (or this.nota @agendaitem.isApproval @decisionActivity.subcase.isBekrachtiging)}}
               {{on "click" this.updateBeslissingContent.perform}}
             >{{t "update-thing" thing=(t "content")}}</AuButton>
@@ -167,6 +169,7 @@
                 @disabled={{this.disableSaveButton}}
                 @skin="primary"
                 @loading={{this.onSaveReport.isRunning}}
+                @loadingMessage={{t "loading"}}
                 {{on "click" (perform this.onSaveReport)}}
               >
                 {{t "update"}}
@@ -205,6 +208,7 @@
                     @disabled={{this.disableSaveAnnotationButton}}
                     @skin="primary"
                     @loading={{this.onUpdateAnnotation.isRunning}}
+                    @loadingMessage={{t "loading"}}
                     {{on "click" (perform this.onUpdateAnnotation)}}
                   >
                     {{t "update"}}
@@ -261,6 +265,7 @@
                   @icon="renew"
                   class="au-u-padding-left-none"
                   @loading={{or this.loadDocuments.isRunning this.updateBetreftContent.isRunning}}
+                  @loadingMessage={{t "loading"}}
                   {{on "click" this.updateBetreftContent.perform}}
                 >{{t "update-thing" thing=(t "content")}}</AuButton>
                 <VersionsDropdown
@@ -288,6 +293,7 @@
                     @disabled={{this.disableSaveConcernButton}}
                     @skin="primary"
                     @loading={{this.onUpdateConcern.isRunning}}
+                    @loadingMessage={{t "loading"}}
                     {{on "click" (perform this.onUpdateConcern)}}
                   >
                     {{t "update"}}
@@ -341,6 +347,7 @@
                   @icon="renew"
                   class="au-u-padding-left-none"
                   @loading={{or this.loadNota.isRunning this.updateBeslissingContent.isRunning}}
+                  @loadingMessage={{t "loading"}}
                   @disabled={{not (or this.nota @agendaitem.isApproval @decisionActivity.subcase.isBekrachtiging)}}
                   {{on "click" this.updateBeslissingContent.perform}}
                 >{{t "update-thing" thing=(t "content")}}</AuButton>
@@ -369,6 +376,7 @@
                     @disabled={{this.disableSaveTreatmentButton}}
                     @skin="primary"
                     @loading={{this.onUpdateTreatment.isRunning}}
+                    @loadingMessage={{t "loading"}}
                     {{on "click" (perform this.onUpdateTreatment)}}
                   >
                     {{t "update"}}

--- a/app/components/agenda/formally-ok-edit.hbs
+++ b/app/components/agenda/formally-ok-edit.hbs
@@ -26,6 +26,7 @@
     @icon="check"
     @hideText={{true}}
     @loading={{this.onSave.isRunning}}
+    @loadingMessage={{t "loading"}}
     {{on "click" (perform this.onSave)}}
     class="auk-u-ml"
   >
@@ -37,6 +38,7 @@
     @icon="x"
     @hideText={{true}}
     @loading={{this.onSave.isRunning}}
+    @loadingMessage={{t "loading"}}
     {{on "click" @cancelEdit}}
   >
     {{t "cancel"}}

--- a/app/components/auk/editor.hbs
+++ b/app/components/auk/editor.hbs
@@ -28,6 +28,7 @@
             <AuButton
               @skin="primary"
               @loading={{@onSaveTask.isRunning}}
+              @loadingMessage={{t "loading"}}
               @disabled={{@fullScreenSaveDisabled}}
               {{on "click" (perform @onSaveTask)}}
             >

--- a/app/components/cases/edit-case.hbs
+++ b/app/components/cases/edit-case.hbs
@@ -28,6 +28,7 @@
       @skin="primary"
       @disabled={{this.isSaveDisabled}}
       @loading={{this.save.isRunning}}
+      @loadingMessage={{t "loading"}}
       {{on "click" (perform this.save)}}
     >
       {{t "save"}}

--- a/app/components/cases/subcases/proposable-agendas-modal.hbs
+++ b/app/components/cases/subcases/proposable-agendas-modal.hbs
@@ -87,6 +87,7 @@
           this.loadAgendas.isRunning
           (and this.saveSubcaseAndSubmitToAgenda.isRunning this.selectedAgenda)
         }}
+        @loadingMessage={{t "loading"}}
         {{on "click" this.saveSubcase}}
       >
         {{t "save-without-agenda"}}
@@ -100,6 +101,7 @@
         this.loadAgendas.isRunning
         (and this.saveSubcaseAndSubmitToAgenda.isRunning this.selectedAgenda)
       }}
+      @loadingMessage={{t "loading"}}
       {{on "click" (perform this.saveSubcaseAndSubmitToAgenda)}}
     >
       {{t "place-on-agenda"}}

--- a/app/components/cases/submissions/notifications.hbs
+++ b/app/components/cases/submissions/notifications.hbs
@@ -226,6 +226,7 @@
               data-test-submission-notifications-save
               @skin="primary"
               @loading={{this.saveNotificationData.isRunning}}
+              @loadingMessage={{t "loading"}}
               @disabled={{this.saveNotificationData.isRunning}}
               {{on "click" (perform this.saveNotificationData)}}
             >

--- a/app/components/cases/submissions/proposable-agendas-modal.hbs
+++ b/app/components/cases/submissions/proposable-agendas-modal.hbs
@@ -78,6 +78,7 @@
         this.loadAgendas.isRunning
         (and this.saveSubmissionAndSubmitToAgenda.isRunning this.selectedAgenda)
       }}
+      @loadingMessage={{t "loading"}}
       {{on "click" (perform this.saveSubmissionAndSubmitToAgenda)}}
     >
       {{t "propose-for-agenda"}}

--- a/app/components/confirmation-modal.hbs
+++ b/app/components/confirmation-modal.hbs
@@ -47,6 +47,7 @@
               @alert={{@alert}}
               @disabled={{@disabled}}
               @loading={{@loading}}
+              @loadingMessage={{t "loading"}}
               @icon={{@confirmIcon}}
               {{on "click" @onConfirm}}
             >

--- a/app/components/documents/batch-details/batch-documents-details-modal.hbs
+++ b/app/components/documents/batch-details/batch-documents-details-modal.hbs
@@ -71,6 +71,7 @@
         @skin="primary"
         @disabled={{this.isSaveDisabled}}
         @loading={{this.save.isRunning}}
+        @loadingMessage={{t "loading"}}
         {{on "click" (perform this.save)}}
       >
         {{t "save"}}

--- a/app/components/documents/document-details-panel.hbs
+++ b/app/components/documents/document-details-panel.hbs
@@ -120,6 +120,7 @@
               @skin="primary"
               @disabled={{this.isProcessing}}
               @loading={{this.saveDetails.isRunning}}
+              @loadingMessage={{t "loading"}}
               {{on "click" (perform this.saveDetails)}}
             >
               {{t "save"}}

--- a/app/components/mandatees/mandatees-panel/mandatees-panel-edit.hbs
+++ b/app/components/mandatees/mandatees-panel/mandatees-panel-edit.hbs
@@ -87,6 +87,7 @@
             data-test-mandatee-panel-edit-save
             @skin="primary"
             @loading={{this.save.isRunning}}
+            @loadingMessage={{t "loading"}}
             {{on "click" (perform this.save)}}
           >
             {{t "save"}}

--- a/app/components/mandatees/mandatees-selector-modal.hbs
+++ b/app/components/mandatees/mandatees-selector-modal.hbs
@@ -48,6 +48,7 @@
       @icon="plus"
       @disabled={{not this.canAdd}}
       @loading={{this.onAdd.isRunning}}
+      @loadingMessage={{t "loading"}}
       {{on "click" (perform this.onAdd)}}
     >
       {{t "add"}}

--- a/app/components/mandatees/secretary-panel/edit.hbs
+++ b/app/components/mandatees/secretary-panel/edit.hbs
@@ -35,6 +35,7 @@
             data-test-secretary-panel-edit-save
             @skin="primary"
             @loading={{this.save.isRunning}}
+            @loadingMessage={{t "loading"}}
             @disabled={{not this.secretary}}
             {{on "click" (perform this.save)}}
           >

--- a/app/components/meeting/document-publication-planning-modal.hbs
+++ b/app/components/meeting/document-publication-planning-modal.hbs
@@ -67,6 +67,7 @@
       @skin="primary"
       @disabled={{this.isDisabledSave}}
       @loading={{this.save.isRunning}}
+      @loadingMessage={{t "loading"}}
       {{on "click" (perform this.save)}}
     >
       {{t "confirm"}}

--- a/app/components/meeting/edit-meeting-modal.hbs
+++ b/app/components/meeting/edit-meeting-modal.hbs
@@ -153,6 +153,7 @@
       @skin="primary"
       @disabled={{this.savingIsDisabled}}
       @loading={{this.saveMeeting.isRunning}}
+      @loadingMessage={{t "loading"}}
       {{on "click" (perform this.saveMeeting)}}
     >
       {{#if this.isNew}}

--- a/app/components/news-item/edit-panel.hbs
+++ b/app/components/news-item/edit-panel.hbs
@@ -100,6 +100,7 @@
                     <AuButton
                       data-test-news-item-edit-item-save-fullscreen
                       @loading={{this.confirmSave.isRunning}}
+                      @loadingMessage={{t "loading"}}
                       {{on "click" this.save}}
                     >
                       {{t "save"}}
@@ -173,6 +174,7 @@
               <AuButton
                 data-test-news-item-edit-item-save
                 @loading={{this.confirmSave.isRunning}}
+                @loadingMessage={{t "loading"}}
                 {{on "click" this.save}}
               >
                 {{t "save"}}

--- a/app/components/publications/documents/reference-document-upload-modal.hbs
+++ b/app/components/publications/documents/reference-document-upload-modal.hbs
@@ -29,6 +29,7 @@
       @skin="primary"
       @disabled={{this.isSaveDisabled}}
       @loading={{this.save.isRunning}}
+      @loadingMessage={{t "loading"}}
       {{on "click" (perform this.save)}}
     >
       {{t "save"}}

--- a/app/components/publications/new-publication-modal.hbs
+++ b/app/components/publications/new-publication-modal.hbs
@@ -144,6 +144,7 @@
       data-test-new-publication-create
       @skin="primary"
       @loading={{this.save.isRunning}}
+      @loadingMessage={{t "loading"}}
       @disabled={{not this.isValid}}
       {{on "click" (perform this.save)}}
     >

--- a/app/components/publications/publication-status-modal.hbs
+++ b/app/components/publications/publication-status-modal.hbs
@@ -51,6 +51,7 @@
       data-test-publication-status-save
       @skin="primary"
       @loading={{this.savePublicationStatus.isRunning}}
+      @loadingMessage={{t "loading"}}
       @disabled={{this.isDisabledSave}}
       {{on "click" (perform this.savePublicationStatus)}}
     >

--- a/app/components/publications/publication/case/contact-persons/contact-person-add-modal.hbs
+++ b/app/components/publications/publication/case/contact-persons/contact-person-add-modal.hbs
@@ -99,6 +99,7 @@
       @icon="plus"
       @disabled={{not this.validators.areValid}}
       @loading={{this.save.isRunning}}
+      @loadingMessage={{t "loading"}}
       {{on "click" (perform this.save)}}
     >
       {{t "add"}}

--- a/app/components/publications/publication/case/contact-persons/organization-add-modal.hbs
+++ b/app/components/publications/publication/case/contact-persons/organization-add-modal.hbs
@@ -49,6 +49,7 @@
       @icon="plus"
       @disabled={{not this.validators.areValid}}
       @loading={{this.save.isRunning}}
+      @loadingMessage={{t "loading"}}
      {{on "click" (perform this.save)}}
     >
       {{t "add"}}

--- a/app/components/publications/publication/case/info/publication-case-info-panel.hbs
+++ b/app/components/publications/publication/case/info/publication-case-info-panel.hbs
@@ -388,6 +388,7 @@
               data-test-publication-case-info-panel-cancel
               @skin="naked"
               @loading={{this.closeEditingPanel.isRunning}}
+              @loadingMessage={{t "loading"}}
               @disabled={{this.save.isRunning}}
               {{on "click" (perform this.closeEditingPanel)}}
             >
@@ -401,6 +402,7 @@
               data-test-publication-case-info-panel-save
               @skin="primary"
               @loading={{this.save.isRunning}}
+              @loadingMessage={{t "loading"}}
               @disabled={{or
                 (not this.isValid)
                 this.closeEditingPanel.isRunning

--- a/app/components/publications/publication/case/inscription/inscription-panel.hbs
+++ b/app/components/publications/publication/case/inscription/inscription-panel.hbs
@@ -66,6 +66,7 @@
               data-test-inscription-edit-save
               @skin="primary"
               @loading={{this.save.isRunning}}
+              @loadingMessage={{t "loading"}}
               @disabled={{not this.isShortTitleValid}}
               {{on "click" (perform this.save)}}
             >

--- a/app/components/publications/publication/case/remark/remark-panel.hbs
+++ b/app/components/publications/publication/case/remark/remark-panel.hbs
@@ -82,6 +82,7 @@
               data-test-remark-panel-save
               @skin="primary"
               @loading={{this.save.isRunning}}
+              @loadingMessage={{t "loading"}}
               {{on "click" (perform this.save)}}
             >
               {{t "save"}}

--- a/app/components/publications/publication/decisions/info/decisions-info-panel.hbs
+++ b/app/components/publications/publication/decisions/info/decisions-info-panel.hbs
@@ -222,6 +222,7 @@
               data-test-decisions-info-panel-edit-save
               @skin="primary"
               @loading={{this.save.isRunning}}
+              @loadingMessage={{t "loading"}}
               @disabled={{or
                 (not this.isValid)
                 this.closeEditingPanel.isRunning

--- a/app/components/publications/publication/proofs/proof-info-panel.hbs
+++ b/app/components/publications/publication/proofs/proof-info-panel.hbs
@@ -84,6 +84,7 @@
               data-test-publication-proof-info-panel-save
               @skin="primary"
               @loading={{this.save.isRunning}}
+              @loadingMessage={{t "loading"}}
               {{on "click" (perform this.save)}}
             >
               {{t "save"}}

--- a/app/components/publications/publication/proofs/proof-received-panel.hbs
+++ b/app/components/publications/publication/proofs/proof-received-panel.hbs
@@ -102,6 +102,7 @@
         @skin="primary"
         @disabled={{this.isSaveDisabled}}
         @loading={{this.save.isRunning}}
+        @loadingMessage={{t "loading"}}
         {{on "click" (perform this.save)}}
       >
         {{t "save"}}

--- a/app/components/publications/publication/proofs/proof-request-modal.hbs
+++ b/app/components/publications/publication/proofs/proof-request-modal.hbs
@@ -78,6 +78,7 @@
       @skin="primary"
       @disabled={{this.isSaveDisabled}}
       @loading={{this.save.isRunning}}
+      @loadingMessage={{t "loading"}}
       {{on "click" (perform this.save)}}
     >
       {{t "request-it"}}

--- a/app/components/publications/publication/proofs/proof-upload-modal.hbs
+++ b/app/components/publications/publication/proofs/proof-upload-modal.hbs
@@ -55,6 +55,7 @@
       @skin="primary"
       @disabled={{this.isSaveDisabled}}
       @loading={{this.save.isRunning}}
+      @loadingMessage={{t "loading"}}
       {{on "click" (perform this.save)}}
     >
       {{t "save"}}

--- a/app/components/publications/publication/publication-activities/publication-edit-modal.hbs
+++ b/app/components/publications/publication/publication-activities/publication-edit-modal.hbs
@@ -31,6 +31,7 @@
       @skin="primary"
       @disabled={{this.isSaveDisabled}}
       @loading={{this.save.isRunning}}
+      @loadingMessage={{t "loading"}}
       {{on "click" (perform this.save)}}
     >
       {{t "save"}}

--- a/app/components/publications/publication/publication-activities/publication-registration-modal.hbs
+++ b/app/components/publications/publication/publication-activities/publication-registration-modal.hbs
@@ -35,6 +35,7 @@
       @skin="primary"
       @disabled={{this.isSaveDisabled}}
       @loading={{this.save.isRunning}}
+      @loadingMessage={{t "loading"}}
       {{on "click" (perform this.save)}}
     >
       {{t "save"}}

--- a/app/components/publications/publication/publication-activities/publication-request-modal.hbs
+++ b/app/components/publications/publication/publication-activities/publication-request-modal.hbs
@@ -77,6 +77,7 @@
       @skin="primary"
       @disabled={{this.isSaveDisabled}}
       @loading={{this.save.isRunning}}
+      @loadingMessage={{t "loading"}}
       {{on "click" (perform this.save)}}
     >
       {{t "request-it"}}

--- a/app/components/publications/publication/publication-activities/publications-info-panel.hbs
+++ b/app/components/publications/publication/publication-activities/publications-info-panel.hbs
@@ -102,6 +102,7 @@
               data-test-publications-info-panel-save
               @skin="primary"
               @loading={{this.save.isRunning}}
+              @loadingMessage={{t "loading"}}
               {{on "click" (perform this.save)}}
             >
               {{t "save"}}

--- a/app/components/publications/publication/translations/translation-request-modal.hbs
+++ b/app/components/publications/publication/translations/translation-request-modal.hbs
@@ -120,6 +120,7 @@
       @skin="primary"
       @disabled={{this.isSaveDisabled}}
       @loading={{this.save.isRunning}}
+      @loadingMessage={{t "loading"}}
       {{on "click" (perform this.save)}}
     >
       {{t "request-it"}}

--- a/app/components/publications/publication/translations/translation-upload-modal.hbs
+++ b/app/components/publications/publication/translations/translation-upload-modal.hbs
@@ -45,6 +45,7 @@
       @skin="primary"
       @disabled={{this.isSaveDisabled}}
       @loading={{this.save.isRunning}}
+      @loadingMessage={{t "loading"}}
       {{on "click" (perform this.save)}}
     >
       {{t "save"}}

--- a/app/components/publications/publication/translations/translations-info-panel.hbs
+++ b/app/components/publications/publication/translations/translations-info-panel.hbs
@@ -72,6 +72,7 @@
               data-test-publication-translations-info-panel-save
               @skin="primary"
               @loading={{this.save.isRunning}}
+              @loadingMessage={{t "loading"}}
               {{on "click" (perform this.save)}}
             >
               {{t "save"}}

--- a/app/components/signatures/create-sign-flow/piece.hbs
+++ b/app/components/signatures/create-sign-flow/piece.hbs
@@ -24,6 +24,7 @@
             @skin="secondary"
             @icon="pencil"
             @loading={{this.loadSigners.isPending}}
+            @loadingMessage={{t "loading"}}
             {{on "click" this.startEditSigners}}
           >
             {{t "edit-list"}}

--- a/app/components/signatures/select-ministers-modal.hbs
+++ b/app/components/signatures/select-ministers-modal.hbs
@@ -15,6 +15,7 @@
     <AuButton
       data-test-signatures-select-ministers-apply
       @loading={{@loading}}
+      @loadingMessage={{t "loading"}}
       {{on "click" (fn @onConfirm this.selectedMinisters)}}
     >
       {{t "apply"}}

--- a/app/components/subcase/bekrachtiging-description-panel/edit.hbs
+++ b/app/components/subcase/bekrachtiging-description-panel/edit.hbs
@@ -101,6 +101,7 @@
           <AuButton
             @skin="primary"
             @loading={{this.isSaving}}
+            @loadingMessage={{t "loading"}}
             {{on "click" this.saveChanges}}
           >
             {{t "save"}}

--- a/app/components/subcase/description-panel/edit.hbs
+++ b/app/components/subcase/description-panel/edit.hbs
@@ -172,6 +172,7 @@
             data-test-subcase-description-edit-save
             @skin="primary"
             @loading={{this.isSaving}}
+            @loadingMessage={{t "loading"}}
             {{on "click" this.saveChanges}}
           >
             {{t "save"}}

--- a/app/components/submission/description-panel/edit.hbs
+++ b/app/components/submission/description-panel/edit.hbs
@@ -194,6 +194,7 @@
             data-test-submission-description-edit-save
             @skin="primary"
             @loading={{this.isSaving}}
+            @loadingMessage={{t "loading"}}
             {{on "click" this.saveChanges}}
           >
             {{t "save"}}

--- a/app/components/themis-publications/publish-confirmation-modal.hbs
+++ b/app/components/themis-publications/publish-confirmation-modal.hbs
@@ -14,6 +14,7 @@
     <AuButton
       @skin="primary"
       @loading={{this.confirmPublish.isRunning}}
+      @loadingMessage={{t "loading"}}
       {{on "click" (perform this.confirmPublish)}}
     >
       {{t "publish-to-public"}}

--- a/app/components/themis-publications/unpublish-confirmation-modal.hbs
+++ b/app/components/themis-publications/unpublish-confirmation-modal.hbs
@@ -31,6 +31,7 @@
     <AuButton
       @skin="primary"
       @loading={{this.confirmUnpublish.isRunning}}
+      @loadingMessage={{t "loading"}}
       {{on "click" (perform this.confirmUnpublish)}}
     >
       {{t "retract-from-public"}}

--- a/app/components/utils/generic/alert-dialog.hbs
+++ b/app/components/utils/generic/alert-dialog.hbs
@@ -20,6 +20,7 @@
       @icon={{this.confirmIcon}}
       @disabled={{this.isLoading}}
       @loading={{this.confirm.isRunning}}
+      @loadingMessage={{t "loading"}}
       {{on "click" (perform this.confirm)}}
     >
       {{this.confirmText}}

--- a/app/components/utils/government-areas/edit-government-areas-modal.hbs
+++ b/app/components/utils/government-areas/edit-government-areas-modal.hbs
@@ -38,6 +38,7 @@
       data-test-edit-government-fields-modal-save
       @skin="primary"
       @loading={{this.save.isRunning}}
+      @loadingMessage={{t "loading"}}
       {{on "click" (perform this.save)}}
     >
       {{t "save"}}

--- a/app/components/web-components/vl-modal-verify.hbs
+++ b/app/components/web-components/vl-modal-verify.hbs
@@ -43,6 +43,7 @@
                 @alert={{this.isAlertButton}}
                 @icon={{if this.showDestructiveIcon "trash"}}
                 @loading={{@isLoading}}
+                @loadingMessage={{t "loading"}}
                 {{on "click" @onVerify}}
               >
                 {{this.verifyButtonText}}

--- a/app/templates/agenda/agendaitems/agendaitem/documents.hbs
+++ b/app/templates/agenda/agendaitems/agendaitem/documents.hbs
@@ -14,6 +14,7 @@
             data-test-route-agenda---agendaitem-documents-batch-edit
             @icon="pencil"
             @loading={{this.ensureFreshData.isRunning}}
+            @loadingMessage={{t "loading"}}
             {{on "click" this.openBatchDetails}}
           >
             {{t "batch-edit"}}

--- a/app/templates/agenda/minutes.hbs
+++ b/app/templates/agenda/minutes.hbs
@@ -54,6 +54,7 @@
                   @icon="renew"
                   class="au-u-padding-left-none"
                   @loading={{this.updateEditorContent.isRunning}}
+                  @loadingMessage={{t "loading"}}
                   @disabled={{this.saveMinutes.isRunning}}
                   {{on "click" this.updateEditorContent.perform}}
                 >{{t "update-thing" thing=(t "content")}}</AuButton>
@@ -64,6 +65,7 @@
                     @icon="renew"
                     class="au-u-padding-left-none"
                     @loading={{this.updateEditorNotas.isRunning}}
+                    @loadingMessage={{t "loading"}}
                     @disabled={{this.saveMinutes.isRunning}}
                     {{on "click" this.updateEditorNotas.perform}}
                   >{{t "update-thing" thing=(t "agendaitems-subtitle")}}</AuButton>
@@ -74,6 +76,7 @@
                     @icon="renew"
                     class="au-u-padding-left-none"
                     @loading={{this.updateEditorAnnouncements.isRunning}}
+                    @loadingMessage={{t "loading"}}
                     @disabled={{this.saveMinutes.isRunning}}
                     {{on "click" this.updateEditorAnnouncements.perform}}
                   >{{t "update-thing" thing=(t "announcements-subtitle")}}</AuButton>
@@ -106,6 +109,7 @@
                     data-test-route-agenda-minutes-editor-save
                     @skin="primary"
                     @loading={{this.saveMinutes.isRunning}}
+                    @loadingMessage={{t "loading"}}
                     @disabled={{this.saveDisabled}}
                     {{on "click" (perform this.saveMinutes)}}
                   >

--- a/app/templates/settings/emails.hbs
+++ b/app/templates/settings/emails.hbs
@@ -195,6 +195,7 @@
                 @skin="primary"
                 @disabled={{this.isDisabled}}
                 @loading={{this.save.isRunning}}
+                @loadingMessage={{t "loading"}}
                 {{on "click" (perform this.save)}}
               >
                 {{t "save"}}

--- a/app/templates/settings/organizations/organization.hbs
+++ b/app/templates/settings/organizations/organization.hbs
@@ -174,6 +174,7 @@
           data-test-route-settings---organization-confirm-block-organization
           @alert={{true}}
           @loading={{this.blockOrganization.isRunning}}
+          @loadingMessage={{t "loading"}}
           {{on
             "click"
             (queue
@@ -222,6 +223,7 @@
           data-test-route-settings---organization-confirm-unblock-organization
           @alert={{true}}
           @loading={{this.unblockOrganization.isRunning}}
+          @loadingMessage={{t "loading"}}
           {{on
             "click"
             (queue
@@ -266,6 +268,7 @@
         <AuButton
           data-test-route-settings---organization-confirm-unlink-mandatee
           @loading={{this.unlinkMandatee.isRunning}}
+          @loadingMessage={{t "loading"}}
           @alert={{true}}
           {{on
             "click"

--- a/app/templates/settings/users/user.hbs
+++ b/app/templates/settings/users/user.hbs
@@ -237,6 +237,7 @@
           data-test-route-settings---user-confirm-block-membership
           @alert={{true}}
           @loading={{this.blockMembership.isRunning}}
+          @loadingMessage={{t "loading"}}
           {{on
             "click"
             (queue
@@ -285,6 +286,7 @@
           data-test-route-settings---user-confirm-unblock-membership
           @alert={{true}}
           @loading={{this.unblockMembership.isRunning}}
+          @loadingMessage={{t "loading"}}
           {{on
             "click"
             (queue
@@ -330,6 +332,7 @@
           data-test-route-settings---user-confirm-block-user
           @alert={{true}}
           @loading={{this.blockUser.isRunning}}
+          @loadingMessage={{t "loading"}}
           {{on
             "click"
             (queue (perform this.blockUser) (toggle "showBlockUser" this))
@@ -376,6 +379,7 @@
           data-test-route-settings---user-confirm-unblock-user
           @alert={{true}}
           @loading={{this.unblockUser.isRunning}}
+          @loadingMessage={{t "loading"}}
           {{on
             "click"
             (queue (perform this.unblockUser) (toggle "showUnblockUser" this))

--- a/app/templates/signatures/decisions.hbs
+++ b/app/templates/signatures/decisions.hbs
@@ -186,6 +186,7 @@
               <AuButton
                 data-test-route-signatures-decisions-sidebar-start-signflow
                 @loading={{or this.createSignFlow.isRunning this.removeSignFlow.isRunning}}
+                @loadingMessage={{t "loading"}}
                 @disabled={{not this.signers.length}}
                 {{on "click" this.createSignFlow.perform}}
               >
@@ -198,6 +199,7 @@
                 @alert={{true}}
                 @skin="naked"
                 @loading={{or this.createSignFlow.isRunning this.removeSignFlow.isRunning}}
+                @loadingMessage={{t "loading"}}
                 {{on "click" this.removeSignFlow.perform}}
               >
                 {{t "stop-sign-flow"}}

--- a/app/templates/signatures/index.hbs
+++ b/app/templates/signatures/index.hbs
@@ -222,6 +222,7 @@
                   this.createSignFlow.isRunning
                   this.removeSignFlow.isRunning
                 }}
+                @loadingMessage={{t "loading"}}
                 @disabled={{or
                   (not this.signers.length)
                   (not this.allSignersHaveEmail.value)
@@ -237,6 +238,7 @@
                 @alert={{true}}
                 @skin="naked"
                 @loading={{or this.createSignFlow.isRunning this.removeSignFlow.isRunning}}
+                @loadingMessage={{t "loading"}}
                 {{on "click" this.removeSignFlow.perform}}
               >
                 {{t "stop-sign-flow"}}

--- a/app/templates/signatures/ratifications.hbs
+++ b/app/templates/signatures/ratifications.hbs
@@ -168,6 +168,7 @@
             <Group>
               <AuButton
                 @loading={{or this.createSignFlow.isRunning this.removeSignFlow.isRunning}}
+                @loadingMessage={{t "loading"}}
                 @disabled={{not this.signers.length}}
                 {{on "click" this.createSignFlow.perform}}
               >
@@ -179,6 +180,7 @@
                 @alert={{true}}
                 @skin="naked"
                 @loading={{or this.createSignFlow.isRunning this.removeSignFlow.isRunning}}
+                @loadingMessage={{t "loading"}}
                 {{on "click" this.removeSignFlow.perform}}
               >
                 {{t "stop-sign-flow"}}

--- a/app/templates/styleguide/button-loading.hbs
+++ b/app/templates/styleguide/button-loading.hbs
@@ -6,6 +6,6 @@
         @snippet="button-loading.hbs"
 >
   {{!-- BEGIN-SNIPPET button-loading --}}
-  <Auk::Button @loading={{true}} />
+  <Auk::Button @loading={{true}} @loadingMessage={{t "loading"}}/>
   {{!-- END-SNIPPET --}}
 </StyleguideSample>


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4980

Very straightforward.

Default message from the `<AuButton/>` ('aan het laden') is going away soon.
We were silently relying on it.
Now we have to set it explicitly
just searched for `@loading` and added the line to all the AuButtons.
Not applicable on `<Auk::Button/>`, that uses a `<Auk::Loader/>` which does `{{t "loading"}}` anyway

It would be possible to customize the messages but don't think anyone is asking to do that.
So all the same it is. (confirmationModels `@loadingMessage` could be overridden if needed, but again, nobody wants that so didn't bother making that an `@loadingMessage`)