### PR TITLE
KAS-4818 add use existing piece name when uploading new document in s…

### DIFF
--- a/app/controllers/cases/case/subcases/subcase/new-submission.js
+++ b/app/controllers/cases/case/subcases/subcase/new-submission.js
@@ -5,6 +5,7 @@ import { TrackedArray } from 'tracked-built-ins';
 import { task, dropTask, all } from 'ember-concurrency';
 import { addObject, removeObject } from 'frontend-kaleidos/utils/array-helpers';
 import VRCabinetDocumentName from 'frontend-kaleidos/utils/vr-cabinet-document-name';
+import VRDocumentName from 'frontend-kaleidos/utils/vr-document-name';
 import { findDocType } from 'frontend-kaleidos/utils/document-type';
 import { containsConfidentialPieces } from 'frontend-kaleidos/utils/documents';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
@@ -108,9 +109,12 @@ export default class CasesCaseSubcasesSubcaseNewSubmissionController extends Con
   }
 
   uploadPiece = async (file) => {
+    const existingPieceName = this.pieces[0].name
+    const existingSubject = new VRDocumentName(existingPieceName).subjectOnly();
     const name = file.filenameWithoutExtension;
     const parsed = new VRCabinetDocumentName(name).parsed;
     const type = await findDocType(this.conceptStore, parsed.type);
+    const nameToSet = existingSubject ? existingSubject : parsed.subject;
     const accessLevel = parsed.confidential ? await this.store.findRecordByUri(
       'concept', CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK
     ) : this.defaultAccessLevel;
@@ -126,7 +130,7 @@ export default class CasesCaseSubcasesSubcaseNewSubmissionController extends Con
       modified: now,
       file: file,
       accessLevel: accessLevel,
-      name: parsed.subject,
+      name: nameToSet,
       documentContainer: documentContainer,
     });
     this.newPieces.push(piece);

--- a/app/controllers/cases/case/subcases/subcase/new-submission.js
+++ b/app/controllers/cases/case/subcases/subcase/new-submission.js
@@ -109,7 +109,7 @@ export default class CasesCaseSubcasesSubcaseNewSubmissionController extends Con
   }
 
   uploadPiece = async (file) => {
-    const existingPieceName = this.pieces[0].name
+    const existingPieceName = this.pieces[0].name;
     const existingSubject = new VRDocumentName(existingPieceName).subjectOnly();
     const name = file.filenameWithoutExtension;
     const parsed = new VRCabinetDocumentName(name).parsed;

--- a/app/controllers/cases/submissions/submission.js
+++ b/app/controllers/cases/submissions/submission.js
@@ -231,7 +231,7 @@ export default class CasesSubmissionsSubmissionController extends Controller {
 
   @action
   async uploadPiece(file) {
-    const existingPieceName = this.pieces[0].name;
+    const existingPieceName = this.pieces[0]?.name || '';
     const existingSubject = new VRDocumentName(existingPieceName).subjectOnly();
     const name = file.filenameWithoutExtension;
     const parsed = new VRCabinetDocumentName(name).parsed;

--- a/app/controllers/cases/submissions/submission.js
+++ b/app/controllers/cases/submissions/submission.js
@@ -6,6 +6,7 @@ import { TrackedArray } from 'tracked-built-ins';
 import { task, timeout } from 'ember-concurrency';
 import { removeObject } from 'frontend-kaleidos/utils/array-helpers';
 import VRCabinetDocumentName from 'frontend-kaleidos/utils/vr-cabinet-document-name';
+import VRDocumentName from 'frontend-kaleidos/utils/vr-document-name';
 import { findDocType } from 'frontend-kaleidos/utils/document-type';
 import { containsConfidentialPieces, sortPieces } from 'frontend-kaleidos/utils/documents';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
@@ -230,9 +231,12 @@ export default class CasesSubmissionsSubmissionController extends Controller {
 
   @action
   async uploadPiece(file) {
+    const existingPieceName = this.pieces[0].name;
+    const existingSubject = new VRDocumentName(existingPieceName).subjectOnly();
     const name = file.filenameWithoutExtension;
     const parsed = new VRCabinetDocumentName(name).parsed;
     const type = await findDocType(this.conceptStore, parsed.type);
+    const nameToSet = this.isUpdate && existingSubject ? existingSubject : parsed.subject;
 
     const now = new Date();
     const confidential = this.model.confidential || false;
@@ -259,7 +263,7 @@ export default class CasesSubmissionsSubmissionController extends Controller {
       file: file,
       confidential: confidential,
       accessLevel: defaultAccessLevel,
-      name: parsed.subject,
+      name: nameToSet,
       documentContainer: documentContainer,
       submission: this.model,
     });

--- a/app/utils/vr-document-name.js
+++ b/app/utils/vr-document-name.js
@@ -88,6 +88,12 @@ export default class VRDocumentName {
     return this.name.replace(new RegExp(`${VRDocumentName.regexGroups.versionSuffix}$`, 'ui'), '');
   }
 
+  get withSubjectAndDocType() {
+    const regexGroup = VRDocumentName.regexGroups;
+    // return new RegExp(`VR ${regexGroup.date}${regexGroup.casePrefix} ${regexGroup.docType}\\.${regexGroup.caseNr}([/-]${regexGroup.index})?(?<subject>.*?)?(?<docLabel> - .*?)${regexGroup.versionSuffix}?$`);
+    return new RegExp(`VR ${regexGroup.date}${regexGroup.casePrefix} ${regexGroup.docType}\\.${regexGroup.caseNr}([/-]${regexGroup.index})?(?<subject>.*?)${regexGroup.versionSuffix}?$`);
+  }
+
   withOtherVersionSuffix(pieceNr) {
     return `${this.withoutVersionSuffix.trim()} ${CONFIG.latinAdverbialNumberals[pieceNr].toUpperCase()}`;
   }
@@ -120,6 +126,20 @@ export default class VRDocumentName {
     } catch(error) {
       return this.vrNumberWithSuffix();
     }
+  }
+
+  subjectOnly() {
+    const match = this.withSubjectAndDocType.exec(this.name);
+    if (!match || !match.groups.subject) {
+      return;
+    }
+    // remove document label
+    const subjectRegex = new RegExp(`(?<subject>.*)(?:.*(?<docLabel> - .*?))$`);
+    const match2 = subjectRegex.exec(match.groups.subject);
+    if (!match2 || !match2.groups.subject) {
+      return;
+    }
+    return match2.groups.subject.trim();
   }
 }
 

--- a/app/utils/vr-document-name.js
+++ b/app/utils/vr-document-name.js
@@ -90,7 +90,6 @@ export default class VRDocumentName {
 
   get withSubjectAndDocType() {
     const regexGroup = VRDocumentName.regexGroups;
-    // return new RegExp(`VR ${regexGroup.date}${regexGroup.casePrefix} ${regexGroup.docType}\\.${regexGroup.caseNr}([/-]${regexGroup.index})?(?<subject>.*?)?(?<docLabel> - .*?)${regexGroup.versionSuffix}?$`);
     return new RegExp(`VR ${regexGroup.date}${regexGroup.casePrefix} ${regexGroup.docType}\\.${regexGroup.caseNr}([/-]${regexGroup.index})?(?<subject>.*?)${regexGroup.versionSuffix}?$`);
   }
 


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4818

- added a way to extract the subject from a VR number with the `VRDocumentName` util.
- couldn't get it all in 1 regex because I needed a look forward to get the document type label out of the subject (a dash in the subject ` - ` would match incorrectly and add too much to the document type label match group. I need to only find the last dash and that should be the document-type.
- In cases where a match does fail, fallback to the filename that was uploaded.
- implemented on a new update submission form
- implemented on an existing update submission