### PR TITLE
KAS-4847 add external links to draft-document-card

### DIFF
--- a/app/components/documents/draft-document-card.hbs
+++ b/app/components/documents/draft-document-card.hbs
@@ -46,6 +46,7 @@
             <LinkTo
               @route="document"
               @model={{this.piece.id}}
+              target="_blank"
               class="auk-h4"
               data-test-draft-document-card-name-value
             >
@@ -59,6 +60,7 @@
                   as |extension|
                 }}
                   {{this.piece.name}}{{#if extension}}.{{extension}}{{/if}}
+                  <AuIcon @icon="external-link" @alignment="right"/>
                 {{/let}}
               {{/if}}
             </LinkTo>
@@ -193,6 +195,7 @@
                   <Documents::DocumentVersionHistoryItem
                     @piece={{piece}}
                     @isEditable={{false}}
+                    @external={{true}}
                   />
                 </div>
               {{/each}}


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4847

Make links to documents external in submissions with icon:
- main link
- previous version links

![image](https://github.com/user-attachments/assets/64599b54-dc4f-430f-8e3c-0ffef649eb74)