### PR TITLE
KAS-5068 add preventunload and decision report generation to agendaitem panel edit

### DIFF
--- a/app/components/agenda/agendaitem/agendaitem-case-panel/agendaitem-case-panel-edit.js
+++ b/app/components/agenda/agendaitem/agendaitem-case-panel/agendaitem-case-panel-edit.js
@@ -17,6 +17,9 @@ export default class AgendaitemCasePanelEdit extends Component {
   @service pieceAccessLevelService;
   @service agendaitemAndSubcasePropertiesSync;
   @service currentSession;
+  @service decisionReportGeneration;
+  @service store;
+  @service preventUnload;
 
   @tracked filter = Object.freeze({
     type: 'subcase-name',
@@ -35,6 +38,7 @@ export default class AgendaitemCasePanelEdit extends Component {
     this.isEditingSubcaseName = this.subcaseName?.length;
     this.loadInternalReview.perform();
     this.loadSubcaseType.perform();
+    this.preventUnload.enable();
   }
 
   get newsItem() {
@@ -65,19 +69,8 @@ export default class AgendaitemCasePanelEdit extends Component {
 
   @action
   cancelEditing() {
-    if (this.args.agendaitem.hasDirtyAttributes) {
-      this.args.agendaitem.rollbackAttributes();
-    }
-    // We change the value of confidental directly on subcase, so we should also roll it back
-    if (this.args.subcase?.hasDirtyAttributes) {
-      this.args.subcase.rollbackAttributes();
-    }
-    if (this.newsItem && this.newsItem.hasDirtyAttributes) {
-      this.newsItem.rollbackAttributes();
-    }
-    if (this.internalReview?.hasDirtyAttributes) {
-      this.internalReview.rollbackAttributes();
-    }
+    this.rollbackDirtyAttributes();
+    this.preventUnload.disable();
     this.args.onCancel();
   }
 
@@ -106,9 +99,18 @@ export default class AgendaitemCasePanelEdit extends Component {
       propertiesToSetOnSubcase,
       shouldResetFormallyOk,
     );
-    if (this.confidentialChanged && (this.args.subcase && this.args.subcase.confidential)) {
+    if (this.confidentialChanged && this.args.subcase?.confidential) {
       yield this.pieceAccessLevelService.updateDecisionsAccessLevelOfSubcase(this.args.subcase);
       yield this.pieceAccessLevelService.updateSubmissionAccessLevelOfSubcase(this.args.subcase);
+      // update report contents
+      const report = yield this.store.queryOne('report', {
+        'filter[:has-no:next-piece]': true,
+        'filter[:has:piece-parts]': true,
+        'filter[decision-activity][treatment][agendaitems][:id:]': this.args.agendaitem.id,
+      });
+      if (report) {
+        yield this.decisionReportGeneration.generateReplacementReport.perform(report);
+      }
     }
 
     if (this.newsItem) {
@@ -127,6 +129,7 @@ export default class AgendaitemCasePanelEdit extends Component {
       yield this.internalReview.hasMany('submissions').reload();
       yield this.internalReview.save();
     }
+    this.preventUnload.disable();
     this.args.onSave();
   }
 
@@ -153,5 +156,26 @@ export default class AgendaitemCasePanelEdit extends Component {
 
   pasteIntoTitle = (pasteEvent) => {
     this.args.agendaitem.title = cleanPasteInputForTextarea(pasteEvent, 'title-agendaitem', this.args.agendaitem.title);
+  }
+
+  rollbackDirtyAttributes = () => {
+    if (this.args.agendaitem.hasDirtyAttributes) {
+      this.args.agendaitem.rollbackAttributes();
+    }
+    // We change the value of confidental directly on subcase, so we should also roll it back
+    if (this.args.subcase?.hasDirtyAttributes) {
+      this.args.subcase.rollbackAttributes();
+    }
+    if (this.newsItem?.hasDirtyAttributes) {
+      this.newsItem.rollbackAttributes();
+    }
+    if (this.internalReview?.hasDirtyAttributes) {
+      this.internalReview.rollbackAttributes();
+    }
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+    this.rollbackDirtyAttributes();
   }
 }

--- a/app/services/prevent-unload.js
+++ b/app/services/prevent-unload.js
@@ -26,15 +26,45 @@ export default class PreventUnloadService extends Service {
     event.returnValue = true;
   }
 
-  __emberListener = (transition) => {
-    if (
-      !transition.to.find(route => route.name === this.router.currentRouteName) &&
-      transition.to.localName !== 'loading') {
-      if(!confirm('Als u de pagina nu verlaat bent u alle aanpassingen kwijt. Bent u zeker dat u weg wilt navigeren?')) {
-        transition.abort();
-      } else {
-        this.disable();
+  confirmTransition = (transition) => {
+    if(transition.to.localName !== 'loading' && !confirm('Als u de pagina nu verlaat bent u alle aanpassingen kwijt. Bent u zeker dat u weg wilt navigeren?')) {
+      transition.abort();
+    } else {
+      this.disable();
+    }
+  }
+
+  getParams = (transitionToOrFrom) => {
+    let params = transitionToOrFrom.params;
+    let parent = transitionToOrFrom.parent;
+    while (parent) {
+      if (parent.paramNames?.length) {
+        params = { ...params, ...parent.params };
       }
+      parent = parent.parent;
+    }
+    return params;
+  }
+
+  __emberListener = (transition) => {
+    // either the route changed entirely
+    const routeChanged = !transition.to.find(route => route.name === this.router.currentRouteName);
+    if (routeChanged) {
+      return this.confirmTransition(transition);
+    }
+    // or the params changed within the same route (for example when switching agendaitems)
+    let paramsChanged = false;
+    let fromParams = this.getParams(transition.from);
+    let toParams = this.getParams(transition.to);
+    for (const fromParamName in fromParams) {
+      if (!paramsChanged && fromParams.hasOwnProperty(fromParamName)) {
+        if (toParams[fromParamName] !== fromParams[fromParamName]) {
+          paramsChanged = true;
+        }
+      }
+    }
+    if (paramsChanged) {
+      return this.confirmTransition(transition);
     }
   }
 }

--- a/app/services/prevent-unload.js
+++ b/app/services/prevent-unload.js
@@ -29,9 +29,12 @@ export default class PreventUnloadService extends Service {
   __emberListener = (transition) => {
     if (
       !transition.to.find(route => route.name === this.router.currentRouteName) &&
-      transition.to.localName !== 'loading' &&
-      !confirm('Als u de pagina nu verlaat bent u alle aanpassingen kwijt. Bent u zeker dat u weg wilt navigeren?')) {
-      transition.abort();
+      transition.to.localName !== 'loading') {
+      if(!confirm('Als u de pagina nu verlaat bent u alle aanpassingen kwijt. Bent u zeker dat u weg wilt navigeren?')) {
+        transition.abort();
+      } else {
+        this.disable();
+      }
     }
   }
 }

--- a/app/services/prevent-unload.js
+++ b/app/services/prevent-unload.js
@@ -57,7 +57,7 @@ export default class PreventUnloadService extends Service {
     let fromParams = this.getParams(transition.from);
     let toParams = this.getParams(transition.to);
     for (const fromParamName in fromParams) {
-      if (!paramsChanged && fromParams.hasOwnProperty(fromParamName)) {
+      if (!paramsChanged && Object.prototype.hasOwnProperty.call(fromParams, fromParamName)) {
         if (toParams[fromParamName] !== fromParams[fromParamName]) {
           paramsChanged = true;
         }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5068

- added report generation (only when confidential changes to true, change to non confidential will require a manual change to decision report access which will trigger regeneration)
- added prevent unload to alert user before going away (they can still confirm and leave early anyway)
- changed prevent unload to remove the alert after confirming (it kept showing during any transition)
- added a `willDestroy` since you could leave without saving, leaving models dirty.