### PR TITLE
Feature/kas 3044 agenda print view

### DIFF
--- a/app/components/agenda/agenda-header/agenda-check.hbs
+++ b/app/components/agenda/agenda-header/agenda-check.hbs
@@ -94,6 +94,9 @@
                         {{/if}}
                       {{/let}}
                     </div>
+                    <Agenda::PrintableAgenda::ListSection::ItemGroup::Item::Comment
+                      @item={{announcement}}
+                    />
                   {{/each}}
                 </div>
               </div>

--- a/app/components/agenda/agenda-header/agenda-check.hbs
+++ b/app/components/agenda/agenda-header/agenda-check.hbs
@@ -17,7 +17,14 @@
       </Auk::Toolbar>
     </Auk::Panel::Header>
     <Auk::Panel::Body>
-      {{#if (or this.fileNameMappings.isRunning this.agendaitems.isRunning this.newAgendaitems.isRunning)}}
+      {{#if
+        (or
+          this.fileNameMappings.isRunning
+          this.agendaitems.isRunning
+          this.newAgendaitems.isRunning
+          this.newPieces.isRunning
+        )
+      }}
         <Auk::Loader />
       {{else}}
         <div class="auk-u-mx-2">
@@ -62,6 +69,7 @@
                       @fileNameMappings={{this.fileNameMap}}
                       @hideNotFormallyOk={{true}}
                       @newAgendaitems={{this.newAgendaitems.value}}
+                      @highlightedPieces={{this.newPieces.value}}
                     />
                   {{/each}}
                 </div>
@@ -92,6 +100,7 @@
                           <Agenda::PrintableAgenda::ListSection::ItemGroup::Item::DocumentList
                             @pieces={{pieces}}
                             @fileNameMappings={{this.fileNameMap}}
+                            @highlightedPieces={{this.newPieces.value}}
                           />
                         {{/if}}
                       {{/let}}

--- a/app/components/agenda/agenda-header/agenda-check.hbs
+++ b/app/components/agenda/agenda-header/agenda-check.hbs
@@ -17,7 +17,7 @@
       </Auk::Toolbar>
     </Auk::Panel::Header>
     <Auk::Panel::Body>
-      {{#if (or this.fileNameMappings.isRunning this.agendaitems.isRunning)}}
+      {{#if (or this.fileNameMappings.isRunning this.agendaitems.isRunning this.newAgendaitems.isRunning)}}
         <Auk::Loader />
       {{else}}
         <div class="auk-u-mx-2">
@@ -61,6 +61,7 @@
                       @items={{notaGroup}}
                       @fileNameMappings={{this.fileNameMap}}
                       @hideNotFormallyOk={{true}}
+                      @newAgendaitems={{this.newAgendaitems.value}}
                     />
                   {{/each}}
                 </div>
@@ -83,6 +84,7 @@
                       <div class="auk-u-non-breakable-group@print">
                         <Agenda::PrintableAgenda::ListSection::ItemGroup::Item::Content
                           @item={{announcement}}
+                          @isNew={{includes announcement this.newAgendaitems.value}}
                         />
                       </div>
                       {{#let (await announcement.pieces) as |pieces|}}

--- a/app/components/agenda/agenda-header/agenda-check.js
+++ b/app/components/agenda/agenda-header/agenda-check.js
@@ -14,6 +14,7 @@ import { inject as service } from '@ember/service';
 export default class AgendaHeaderAgendaCheck extends Component {
   @service toaster;
   @service intl;
+  @service agendaService;
 
   getAgendaitems = task(async () => {
     const notas = [];
@@ -57,6 +58,17 @@ export default class AgendaHeaderAgendaCheck extends Component {
   });
 
   fileNameMappings = trackedTask(this, this.getFileNameMappings);
+
+  getNewAgendaitems = task(async () => {
+    const previousAgenda = await this.args.agenda.previousVersion;
+    let newAgendaitems;
+    if (previousAgenda) {
+      newAgendaitems = await this.agendaService.newAgendaItems(this.args.agenda.id, previousAgenda.id);
+    }
+    return newAgendaitems;
+  });
+
+  newAgendaitems = trackedTask(this, this.getNewAgendaitems);
 
   get fileNameMap() {
     // this is always truthy if mappings exist (empty or not) (to enable approve button)

--- a/app/components/agenda/agenda-header/agenda-check.js
+++ b/app/components/agenda/agenda-header/agenda-check.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { trackedTask } from 'reactiveweb/ember-concurrency';
-import { task } from 'ember-concurrency';
+import { task, all } from 'ember-concurrency';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 import { getNotaGroups } from 'frontend-kaleidos/utils/agendaitem-utils';
 import { inject as service } from '@ember/service';
@@ -80,6 +80,28 @@ export default class AgendaHeaderAgendaCheck extends Component {
     // this is falsy (to disabled approve button, not loaded yet or error)
     return null;
   }
+
+  getNewPieces = task(async () => {
+    const agendaitems = await this.args.agenda.agendaitems;
+    const previousAgenda = await this.args.agenda.previousVersion;
+    const pieces = [];
+    const agendaitemNewPieces = agendaitems.map(async (agendaitem) => {
+      if (previousAgenda) {
+        const newPieces = await this.agendaService.changedPieces(
+          this.args.agenda.id,
+          previousAgenda.id,
+          agendaitem.id
+        );
+        if (newPieces.length > 0) {
+          pieces.push(...newPieces);
+        }
+      }
+    });
+    await all(agendaitemNewPieces);
+    return pieces;
+  });
+
+  newPieces = trackedTask(this, this.getNewPieces);
 
   @action
   onSave() {

--- a/app/components/agenda/printable-agenda/list-section/item-group.hbs
+++ b/app/components/agenda/printable-agenda/list-section/item-group.hbs
@@ -69,6 +69,7 @@
                   @pieces={{pieces}}
                   @fileNameMappings={{@fileNameMappings}}
                   @isBekrachtiging={{this.isBekrachtiging}}
+                  @highlightedPieces={{@highlightedPieces}}
                 />
               {{/if}}
             {{/if}}
@@ -115,6 +116,7 @@
                     @pieces={{pieces}}
                     @fileNameMappings={{@fileNameMappings}}
                     @isBekrachtiging={{this.isBekrachtiging}}
+                    @highlightedPieces={{@highlightedPieces}}
                   />
                 {{/if}}
               {{/if}}

--- a/app/components/agenda/printable-agenda/list-section/item-group.hbs
+++ b/app/components/agenda/printable-agenda/list-section/item-group.hbs
@@ -73,6 +73,9 @@
             {{/if}}
           {{/let}}
         {{/let}}
+        <Agenda::PrintableAgenda::ListSection::ItemGroup::Item::Comment
+          @item={{first}}
+        />
       </div>
     {{/if}}
   {{/let}}
@@ -115,6 +118,9 @@
               {{/if}}
             {{/let}}
           {{/let}}
+          <Agenda::PrintableAgenda::ListSection::ItemGroup::Item::Comment
+            @item={{agendaitem}}
+          />
         </div>
       </div>
     {{/if}}

--- a/app/components/agenda/printable-agenda/list-section/item-group.hbs
+++ b/app/components/agenda/printable-agenda/list-section/item-group.hbs
@@ -42,6 +42,7 @@
           <div value={{first.number}}>
             <Agenda::PrintableAgenda::ListSection::ItemGroup::Item::Content
               @item={{first}}
+              @isNew={{includes first @newAgendaitems}}
             />
           </div>
         </div>
@@ -88,6 +89,7 @@
           <div class="auk-u-non-breakable-group@print">
             <Agenda::PrintableAgenda::ListSection::ItemGroup::Item::Content
               @item={{agendaitem}}
+              @isNew={{includes agendaitem @newAgendaitems}}
             />
           </div>
           {{#let (await (this.getPiecesForAgendaitem agendaitem)) as |pieces|}}

--- a/app/components/agenda/printable-agenda/list-section/item-group/item/comment.hbs
+++ b/app/components/agenda/printable-agenda/list-section/item-group/item/comment.hbs
@@ -1,0 +1,8 @@
+{{#if @item.comment}}
+  <p>
+    <strong class="auk-u-text-bold">
+      {{t "comment-title"}}:
+    </strong>
+    {{@item.comment}}
+  </p>
+{{/if}}

--- a/app/components/agenda/printable-agenda/list-section/item-group/item/content.hbs
+++ b/app/components/agenda/printable-agenda/list-section/item-group/item/content.hbs
@@ -5,6 +5,12 @@
   {{! The following line is formatted on a single line because of the way browsers treat whitespaces & breaks in combination with `white-space: pre-line` }}
   {{! prettier-ignore }}
   <h4 class="auk-u-m-0 auk-u-text-pre-line"><SanitizeHtml @raw={{true}} @value={{if @item.shortTitle @item.shortTitle @item.title}}/></h4>
+  {{#if @isNew}}
+    <span class="auk-u-text-small au-u-muted auk-u-text-nowrap auk-u-ml-2">
+      <Auk::ColorBadge @skin="success" />
+      {{t "new-agendaitem"}}
+    </span>
+  {{/if}}
 </div>
 <div class="auk-u-mb-4 l-printable-agenda__item-indented">
   {{#if @item.title}}

--- a/app/components/agenda/printable-agenda/list-section/item-group/item/document-list.hbs
+++ b/app/components/agenda/printable-agenda/list-section/item-group/item/document-list.hbs
@@ -6,6 +6,7 @@
           @piece={{piece}}
           @accessLevel={{piece.accessLevel}}
           @fileNameMappings={{@fileNameMappings}}
+          @isHighlighted={{includes piece @highlightedPieces}}
         />
       </span>
     </li>

--- a/app/components/agenda/printable-agenda/list-section/item-group/item/document.hbs
+++ b/app/components/agenda/printable-agenda/list-section/item-group/item/document.hbs
@@ -1,4 +1,10 @@
 <span>{{this.pieceName}}</span>
+{{#if @isHighlighted}}
+    <span class="auk-u-text-small au-u-muted auk-u-text-nowrap auk-u-ml-2">
+      <Auk::ColorBadge @skin="success" class="au-u-padding-right-none" />
+      <span>{{t "new-document"}}</span>
+    </span>
+  {{/if}}
 {{#if this.showAccessLevel}}
   <div class="auk-u-ml-2">
     <AccessLevelPill @accessLevel={{@accessLevel}} />

--- a/app/routes/agenda/print.js
+++ b/app/routes/agenda/print.js
@@ -32,7 +32,7 @@ export default class AgendaPrintRoute extends Route {
     const decisionPublicationActivity = await meeting.internalDecisionPublicationActivity;
     const decisionPublicationStatus = await decisionPublicationActivity?.status;
     const decisionsAreReleased = decisionPublicationStatus?.uri === CONSTANTS.RELEASE_STATUSES.RELEASED;
-    await this.loadDocuments.perform(agendaitems);
+    await this.loadDocuments.perform(sortedAgendaitems);
 
     const previousAgenda = await agenda.previousVersion;
     let newAgendaitems;
@@ -40,13 +40,28 @@ export default class AgendaPrintRoute extends Route {
       newAgendaitems = await this.agendaService.newAgendaItems(agenda.id, previousAgenda.id);
     }
 
+    const newPiecesOnAgenda = [];
+    const agendaitemNewPieces = sortedAgendaitems.map(async (agendaitem) => {
+      if (previousAgenda) {
+        const newPieces = await this.agendaService.changedPieces(
+          agenda.id,
+          previousAgenda.id,
+          agendaitem.id
+        );
+        if (newPieces.length > 0) {
+          newPiecesOnAgenda.push(...newPieces);
+        }
+      }
+    });
+    await all(agendaitemNewPieces);
+
     return {
       meeting,
       notas,
       announcements,
       decisionsAreReleased,
       newAgendaitems,
-      previousAgenda
+      newPiecesOnAgenda
     };
   }
 

--- a/app/routes/agenda/print.js
+++ b/app/routes/agenda/print.js
@@ -6,6 +6,7 @@ import CONSTANTS from 'frontend-kaleidos/config/constants';
 export default class AgendaPrintRoute extends Route {
   @service store;
   @service throttledLoadingService;
+  @service agendaService;
 
   async model() {
     const { meeting, agenda } = this.modelFor('agenda');
@@ -33,11 +34,19 @@ export default class AgendaPrintRoute extends Route {
     const decisionsAreReleased = decisionPublicationStatus?.uri === CONSTANTS.RELEASE_STATUSES.RELEASED;
     await this.loadDocuments.perform(agendaitems);
 
+    const previousAgenda = await agenda.previousVersion;
+    let newAgendaitems;
+    if (previousAgenda) {
+      newAgendaitems = await this.agendaService.newAgendaItems(agenda.id, previousAgenda.id);
+    }
+
     return {
       meeting,
       notas,
       announcements,
-      decisionsAreReleased
+      decisionsAreReleased,
+      newAgendaitems,
+      previousAgenda
     };
   }
 

--- a/app/styles/layout/_printable-agenda.scss
+++ b/app/styles/layout/_printable-agenda.scss
@@ -50,11 +50,11 @@
 
 .l-printable-agenda__item-header {
   font-size: 1.6rem;
-  font-weight: 500;
   line-height: 1.5;
 
   .l-printable-agenda__header-prefix {
     min-width: 2.5rem;
+    font-weight: 500;
   }
 }
 

--- a/app/templates/agenda/print.hbs
+++ b/app/templates/agenda/print.hbs
@@ -35,6 +35,7 @@
               {{#each this.notaGroups.value as |notaGroup|}}
                 <Agenda::PrintableAgenda::ListSection::ItemGroup
                   @items={{notaGroup}}
+                  @newAgendaitems={{@model.newAgendaitems}}
                   @decisionsAreReleased={{@model.decisionsAreReleased}}
                 />
               {{/each}}
@@ -56,6 +57,7 @@
                   <div class="auk-u-non-breakable-group@print">
                     <Agenda::PrintableAgenda::ListSection::ItemGroup::Item::Content
                       @item={{announcement}}
+                      @isNew={{includes announcement @model.newAgendaitems}}
                     />
                   </div>
                   {{#let (await announcement.treatment.decisionActivity) as |decisionActivity| }}

--- a/app/templates/agenda/print.hbs
+++ b/app/templates/agenda/print.hbs
@@ -70,6 +70,9 @@
                       {{/let}}
                     {{/if}}
                   {{/let}}
+                  <Agenda::PrintableAgenda::ListSection::ItemGroup::Item::Comment
+                    @item={{announcement}}
+                  />
                 </div>
               {{/each}}
             </div>

--- a/app/templates/agenda/print.hbs
+++ b/app/templates/agenda/print.hbs
@@ -37,6 +37,7 @@
                   @items={{notaGroup}}
                   @newAgendaitems={{@model.newAgendaitems}}
                   @decisionsAreReleased={{@model.decisionsAreReleased}}
+                  @highlightedPieces={{@model.newPiecesOnAgenda}}
                 />
               {{/each}}
             </div>
@@ -67,6 +68,7 @@
                         {{#if pieces}}
                           <Agenda::PrintableAgenda::ListSection::ItemGroup::Item::DocumentList
                             @pieces={{pieces}}
+                            @highlightedPieces={{@model.newPiecesOnAgenda}}
                           />
                         {{/if}}
                       {{/let}}


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3044

- added comments to agenda print view
- added new agendaitem marking to agenda print view
- added new document marking to agenda print view

note:
- some of the above was happening to agenda check views (by using that same components) so made sure it was fully implemented there aswell (so it wasn't halfly implemented as a side effect)
- when looking at designagenda A > no markings of "new" since everything is new