### PR TITLE
KAS-4448 add pre-line classes on subcase long titles, add html BR

### DIFF
--- a/app/components/news-item/edit-panel.hbs
+++ b/app/components/news-item/edit-panel.hbs
@@ -57,7 +57,7 @@
             <AuLabel>{{t "title"}}</AuLabel>
             <p
               data-test-news-item-edit-item-long-title
-              class="auk-u-text-pre-line"
+              class="auk-o-flex--inline auk-u-text-pre-line"
             >
               {{@agendaitem.title}}
             </p>

--- a/app/components/news-item/edit-panel.hbs
+++ b/app/components/news-item/edit-panel.hbs
@@ -55,7 +55,10 @@
         <div class="au-c-form">
           <AuFormRow>
             <AuLabel>{{t "title"}}</AuLabel>
-            <p data-test-news-item-edit-item-long-title>
+            <p
+              data-test-news-item-edit-item-long-title
+              class="auk-u-text-pre-line"
+            >
               {{@agendaitem.title}}
             </p>
           </AuFormRow>

--- a/app/components/news-item/print.hbs
+++ b/app/components/news-item/print.hbs
@@ -35,7 +35,10 @@
             {{/if}}
           </div>
           {{#if (and (not @newsItem) @agendaitem.title)}}
-            <div class="auk-u-mt auk-u-border-left l-printable-newsletter__title">
+            <div
+              class="auk-u-mt auk-u-border-left l-printable-newsletter__title
+              auk-o-flex--inline auk-u-text-pre-line"
+            >
               {{@agendaitem.title}}
             </div>
           {{/if}}

--- a/app/components/subcase/bekrachtiging-description-panel/view.hbs
+++ b/app/components/subcase/bekrachtiging-description-panel/view.hbs
@@ -40,7 +40,11 @@
         </AuHeading>
       </div>
       {{#if @subcase.title}}
-        <p>{{capitalize @subcase.title}}</p>
+        <p
+          class="auk-o-flex--inline auk-u-text-pre-line"
+        >
+          {{capitalize @subcase.title}}
+        </p>
       {{/if}}
       {{#if (and @subcase.isBekrachtiging @subcase.parliamentRetrievalActivity)}}
         <AuHelpText @skin="secondary">{{t "from-parliament"}}</AuHelpText>

--- a/app/components/subcase/description-panel/view.hbs
+++ b/app/components/subcase/description-panel/view.hbs
@@ -56,7 +56,12 @@
         </div>
       </div>
       {{#if @subcase.title}}
-        <p data-test-subcase-description-title>{{capitalize @subcase.title}}</p>
+        <p
+          data-test-subcase-description-title
+          class="auk-o-flex--inline auk-u-text-pre-line"
+        >
+          {{capitalize @subcase.title}}
+        </p>
       {{/if}}
       {{#if @subcase.parliamentRetrievalActivity}}
         <AuHelpText @skin="secondary">{{t "from-parliament"}}</AuHelpText>

--- a/app/components/submission/description-panel/view.hbs
+++ b/app/components/submission/description-panel/view.hbs
@@ -55,7 +55,12 @@
       </div>
     </div>
     {{#if (user-may "treat-and-accept-submissions")}}
-      <p data-test-submission-description-title>{{capitalize @submission.title}}</p>
+      <p
+        data-test-submission-description-title
+        class="auk-o-flex--inline auk-u-text-pre-line"
+      >
+        {{capitalize @submission.title}}
+      </p>
     {{/if}}
   </Auk::Panel::Body>
   <Auk::Panel::Body>

--- a/app/controllers/agenda/minutes.js
+++ b/app/controllers/agenda/minutes.js
@@ -147,7 +147,7 @@ async function getMinutesListItem(meeting, agendaitem, intl, store) {
   return `
   <h4 ${pagebreak}><u>${
     agendaitem.number
-  }. ${betreft.toUpperCase()}</u></h4>
+  }. ${betreft.toUpperCase().replace(/\n/g, '<br />')}</u></h4>
   <p>${text}</p>`
 }
 function capitalizeFirstLetter(string) {

--- a/app/services/newsletter-service.js
+++ b/app/services/newsletter-service.js
@@ -130,7 +130,7 @@ export default class NewsletterService extends Service {
     const agendaItemType = await agendaitem.type;
     if (agendaItemType.uri === CONSTANTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT) {
       const content = agendaitem.title;
-      const contentWithBreaks = content.replace(/\n/g, "<br />")
+      const contentWithBreaks = content.replace(/\n/g, '<br />');
       news.title = agendaitem.shortTitle || content;
       news.htmlContent = contentWithBreaks;
       news.finished = true;

--- a/app/services/newsletter-service.js
+++ b/app/services/newsletter-service.js
@@ -130,8 +130,9 @@ export default class NewsletterService extends Service {
     const agendaItemType = await agendaitem.type;
     if (agendaItemType.uri === CONSTANTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT) {
       const content = agendaitem.title;
+      const contentWithBreaks = content.replace(/\n/g, "<br />")
       news.title = agendaitem.shortTitle || content;
-      news.htmlContent = content;
+      news.htmlContent = contentWithBreaks;
       news.finished = true;
       // We should check if the decision activity has "postponed" or "retracted" or subcase is confidential
       // but right now, we always create newsitems for announcements in the `agenda-submission` service


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4448

- looked for instances for `agendaitem.title` or `subcase.title` where we were not using the css to wrap new lines and added the css (also css so we don't have extra padding/margin when wrapping)
- changed minutes agendaitem concerns with replacement of line feeds to `<br />` for html
- changed newsletter content to be `agendaitem.title` with replacement of line feeds to `<br />` for html

Decisions was fine in the frontend, not in the backend when regenerating the concerns part

- [ ] https://github.com/kanselarij-vlaanderen/decision-report-generation-service/pull/27
 