### PR TITLE
add env property to disable session polling and add to cypress-test env

### DIFF
--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -4,6 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { isPresent } from '@ember/utils';
 import { later } from '@ember/runloop';
 import { findGroupByRole } from 'frontend-kaleidos/config/permissions';
+import { isDisabledSessionPolling } from 'frontend-kaleidos/utils/feature-flag';
 
 export default class CurrentSessionService extends Service {
   @service session;
@@ -21,7 +22,10 @@ export default class CurrentSessionService extends Service {
 
   constructor() {
     super(...arguments);
-
+  
+    if (isDisabledSessionPolling()) {
+      return;
+    }
     this.lifecycle();
   }
 

--- a/app/utils/feature-flag.js
+++ b/app/utils/feature-flag.js
@@ -21,8 +21,16 @@ function isEnabledCabinetSubmissions() {
   );
 }
 
+function isDisabledSessionPolling() {
+  return (
+    ENV.APP.DISABLE_SESSION_POLLING === 'true' ||
+    ENV.APP.DISABLE_SESSION_POLLING === true
+  );
+}
+
 export {
   isEnabledVlaamsParlement,
   isEnabledImpersonation,
   isEnabledCabinetSubmissions,
+  isDisabledSessionPolling,
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -22,6 +22,7 @@ module.exports = function (environment) {
       ENABLE_DEBUG: '{{ENABLE_DEBUG}}',
       ENABLE_VLAAMS_PARLEMENT: '{{ENABLE_VLAAMS_PARLEMENT}}',
       ENABLE_CABINET_SUBMISSIONS: '{{ENABLE_CABINET_SUBMISSIONS}}',
+      DISABLE_SESSION_POLLING: '{{DISABLE_SESSION_POLLING}}',
       // Here you can pass flags/options to your application instance
       // when it is created
     },
@@ -87,6 +88,7 @@ module.exports = function (environment) {
     ENV.APP.ENABLE_VLAAMS_PARLEMENT = true;
     ENV.APP.ENABLE_CABINET_SUBMISSIONS = true;
     ENV.APP.ENABLE_DEBUG = false;
+    ENV.APP.DISABLE_SESSION_POLLING = true;
     ENV.torii.providers["acmidm-oauth2"].logoutUrl = "/mock-login";
   }
 


### PR DESCRIPTION
No ticket, cypress is less stable lately and often on sessions

Checking if disabling session polling helps
