### PR TITLE
KAS-5059 remove file type choice on decision download

### DIFF
--- a/app/components/agenda/agenda-header/agenda-actions.hbs
+++ b/app/components/agenda/agenda-header/agenda-actions.hbs
@@ -348,25 +348,6 @@
           @onChange={{set this "selectedMandatees"}}
         />
       </AuFormRow>
-      <AuFieldset as |Fieldset|>
-        <Fieldset.legend>{{t "file-types"}}</Fieldset.legend>
-        <Fieldset.content>
-          <AuRadioGroup
-            @alignment="inline"
-            @selected={{this.selectedDownloadOption}}
-            @onChange={{this.onChangeDownloadOption}}
-            as |Group|
-          >
-            {{#each this.downloadOptions as |option|}}
-            <Group.Radio
-              @value={{option.value}}
-              >
-              {{option.label}}
-            </Group.Radio>
-            {{/each}}
-          </AuRadioGroup>
-        </Fieldset.content>
-      </AuFieldset>
     </div>
   </:body>
 </ConfirmationModal>

--- a/app/utils/zip-agenda-files.js
+++ b/app/utils/zip-agenda-files.js
@@ -40,6 +40,7 @@ async function fetchArchivingJob(agenda, mandateeIds, decisions= false, pdfOnly)
 }
 
 async function fetchArchivingJobForAgenda(agenda, mandateeIds, decisions, store, pdfOnly) {
+  // pdfOnly is not applicable to decisions since KAS-5059
   const job = await fetchArchivingJob(agenda, mandateeIds, decisions, pdfOnly);
   if (job) {
     return registerJobToStore(job, store);


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5059


- remove the fieldset

note: since we are reusing code, it was harder to cleanup here.
I made it so the service doesn't take `pdfOnly` into account when we are downloading decisions.
Added a comment in the frontend service to make that clear

- [ ] https://github.com/kanselarij-vlaanderen/file-bundling-job-creation-service/pull/17