### PR TITLE
Feature/cypress fixes

### DIFF
--- a/app/components/agenda/agendaitem/agendaitem-decision-edit.hbs
+++ b/app/components/agenda/agendaitem/agendaitem-decision-edit.hbs
@@ -6,7 +6,7 @@
 >
   <AuLabel class="auk-u-sr-only">{{t "result-decision"}}</AuLabel>
   <Decision::DecisionResultSelect
-    @selected={{this.decisionActivity.decisionResultCode}}
+    @selected={{this.decisionResultCode}}
     @onChange={{this.changeDecisionResultCode}}
   />
   <AuButton
@@ -14,9 +14,9 @@
     @skin="naked"
     @icon="check"
     @hideText={{true}}
-    @loading={{this.saveDecisionActivity.isRunning}}
+    @loading={{or this.saveDecisionActivity.isRunning this.loadDecisionActivityResult.isRunning}}
     @loadingMessage={{t "loading"}}
-    {{on "click" (perform this.saveDecisionActivity)}}
+    {{on "click" this.saveDecisionActivity.perform}}
     class="auk-u-ml"
   >
     {{t "save"}}
@@ -26,7 +26,7 @@
     @skin="naked"
     @icon="x"
     @hideText={{true}}
-    @loading={{this.saveDecisionActivity.isRunning}}
+    @loading={{or this.saveDecisionActivity.isRunning this.loadDecisionActivityResult.isRunning}}
     @loadingMessage={{t "loading"}}
     {{on "click" this.cancelEdit}}
   >

--- a/app/components/agenda/agendaitem/agendaitem-decision-edit.js
+++ b/app/components/agenda/agendaitem/agendaitem-decision-edit.js
@@ -4,16 +4,27 @@ import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 
 export default class AgendaitemDecisionEditComponent extends Component {
-  @tracked decisionActivity = this.args.decisionActivity;
+  @tracked decisionResultCode;
+
+  constructor() {
+    super(...arguments);
+    this.loadDecisionActivityResult.perform();
+  }
+
+  @task
+  *loadDecisionActivityResult() {
+    this.decisionResultCode = yield this.args.decisionActivity?.decisionResultCode;
+  }
 
   @action
   changeDecisionResultCode(resultCode) {
-    this.decisionActivity.set('decisionResultCode', resultCode);
+    this.decisionResultCode = resultCode;
   }
 
   @task
   *saveDecisionActivity() {
-    yield this.decisionActivity.save();
+    this.args.decisionActivity.decisionResultCode = this.decisionResultCode;
+    yield this.args.decisionActivity.save();
     if (this.args.onSave) {
       this.args.onSave();
     }
@@ -21,10 +32,8 @@ export default class AgendaitemDecisionEditComponent extends Component {
 
   @action
   cancelEdit() {
-    this.decisionActivity.belongsTo('decisionResultCode').reload(); // "rollback relationship"
     if (this.args.onCancel) {
       this.args.onCancel();
     }
-    return this.decisionActivity;
   }
 }

--- a/app/components/agenda/agendaitem/decision/digital.js
+++ b/app/components/agenda/agendaitem/decision/digital.js
@@ -100,7 +100,7 @@ export default class AgendaAgendaitemDecisionDigitalComponent extends Component 
     if ([
       CONSTANTS.DECISION_RESULT_CODE_URIS.UITGESTELD,
       CONSTANTS.DECISION_RESULT_CODE_URIS.INGETROKKEN,
-    ].includes(resultCode.uri)) {
+    ].includes(resultCode?.uri)) {
       yield this.newsletterService.updateNewsItemVisibility(this.args.agendaitem);
     }
   }
@@ -251,7 +251,7 @@ export default class AgendaAgendaitemDecisionDigitalComponent extends Component 
     const decisionResultCode = await this.args.decisionActivity
       .decisionResultCode;
     if (
-      decisionResultCode.uri === CONSTANTS.DECISION_RESULT_CODE_URIS.INGETROKKEN
+      decisionResultCode?.uri === CONSTANTS.DECISION_RESULT_CODE_URIS.INGETROKKEN
     ) {
       const pieces = await this.args.agendaitem.pieces;
       for (const piece of pieces.slice()) {

--- a/app/components/agenda/agendaitem/decision/legacy.js
+++ b/app/components/agenda/agendaitem/decision/legacy.js
@@ -79,7 +79,7 @@ export default class AgendaAgendaitemDecisionLegacyComponent extends Component {
     const decisionResultCode = await this.args.decisionActivity
       .decisionResultCode;
     if (
-      decisionResultCode.uri === CONSTANTS.DECISION_RESULT_CODE_URIS.INGETROKKEN
+      decisionResultCode?.uri === CONSTANTS.DECISION_RESULT_CODE_URIS.INGETROKKEN
     ) {
       const pieces = await this.args.agendaitem.pieces;
       for (const piece of pieces.slice()) {

--- a/app/components/subcase/description-panel/edit.js
+++ b/app/components/subcase/description-panel/edit.js
@@ -310,7 +310,7 @@ export default class SubcaseDescriptionEdit extends Component {
     } else if (
       this.agendaItemType.uri === CONSTANTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT
       && (!oldDecisionResultCode
-        || oldDecisionResultCode.uri === CONSTANTS.DECISION_RESULT_CODE_URIS.GOEDGEKEURD)
+        || oldDecisionResultCode?.uri === CONSTANTS.DECISION_RESULT_CODE_URIS.GOEDGEKEURD)
     ) {
       const acknowledgedResult = await this.store.findRecordByUri('concept', CONSTANTS.DECISION_RESULT_CODE_URIS.KENNISNAME);
       decisionActivity.decisionResultCode = acknowledgedResult;

--- a/app/components/subcases/side-nav/subcase.js
+++ b/app/components/subcases/side-nav/subcase.js
@@ -29,7 +29,7 @@ export default class SubcaseSideNavSubcaseComponent extends Component {
 
   loadData = task(async () => {
     this.decisionActivity = await this.subcaseService.getLatestDecisionActivity(this.args.subcase);
-    this.decisionResultCode = await this.decisionActivity?.decisionResultCode;
+    this.decisionResultCode = await this.decisionActivity?.belongsTo('decisionResultCode').reload();
   });
 
   loadLabel = async () => {

--- a/cypress/e2e/unit/delete-BIS.cy.js
+++ b/cypress/e2e/unit/delete-BIS.cy.js
@@ -103,7 +103,9 @@ context('Delete BIS tests', () => {
 
     cy.reload();
     cy.get(appuniversum.loader);
-    cy.get(appuniversum.loader).should('not.exist');
+    cy.get(appuniversum.loader, {
+      timeout: 60000,
+    }).should('not.exist');
     cy.get(document.documentCard.versionHistory).find(auk.accordion.header.button)
       .should('not.be.disabled');
 


### PR DESCRIPTION
no ticket, trying to fix some flakyness:

- decisionActivity doesn't always have result code. needs optional param "?.uri"
- editing decision result on pill improved, only set on model when saving (also prevents unsaved model changes when not cancelling)
- subcase view might not be updated if decision result changed, added reload like we did on other locations

didn't fix:
- newsitem zebra view showing 1 item when there should be 2. I think this is an issue with sorting on dates where there are undefined dates. The best way might be to stop relying on sorting via query and sort in frontend (so we only have to load the list of agendaitems once, and keep sorting after without more queries but we need to implement in properly to support all sorting combinations
- sign flow tests, the document to sign should be there but isn't. (it is there beginning of the test, we try to start SH flow by forcing through "no email" blocking, then we expect the document to come back in the view (automated processes reset it) but it doesn't always show back up.
- after each issues. Sometimes when logging out the adapters are still attempting to load data. That causes the after each to fail and tests are skipped.
