### PR TITLE
KAS-5089 Improved publication pills

### DIFF
--- a/app/components/agenda/agenda-header/publication-pills.hbs
+++ b/app/components/agenda/agenda-header/publication-pills.hbs
@@ -10,6 +10,15 @@
           }}
         </AuPill>
       {{/if}}
+      {{#if (and this.isReleasedThemisNewsitemPublicationActivity (not this.isRetractedThemisNewsitemPublicationActivity))}}
+        <AuPill @skin="success" @icon="check" class="auk-u-mr-2 auk-u-mt-2">
+          {{t
+            "newsitems-were-published-at"
+            date=(date this.latestThemisNewsitemPublicationActivity.plannedDate)
+            time=(time this.latestThemisNewsitemPublicationActivity.plannedDate)
+          }}
+        </AuPill>
+      {{/if}}
     {{/if}}
     {{#if (user-may "manage-document-publications")}}
       {{#if this.internalDocumentPublicationActivity.startDate}}
@@ -33,20 +42,20 @@
       {{/if}}
     {{/if}}
     {{#if (user-may "manage-themis-publications")}}
-      {{#if (and this.isReleasedThemisPublicationActivity this.themisPublicationIncludesDocuments)}}
+      {{#if (and this.isReleasedThemisDocumentPublicationActivity (not this.isRetractedThemisDocumentPublicationActivity))}}
         <AuPill @skin="success" @icon="check" class="auk-u-mr-2 auk-u-mt-2">
           {{t
             "documents-were-published-at"
-            date=(date this.latestThemisPublicationActivity.plannedDate)
-            time=(time this.latestThemisPublicationActivity.plannedDate)
+            date=(date this.latestThemisDocumentPublicationActivity.plannedDate)
+            time=(time this.latestThemisDocumentPublicationActivity.plannedDate)
           }}
         </AuPill>
-      {{else if this.isConfirmedThemisPublicationActivity}}
+      {{else if this.isConfirmedThemisDocumentPublicationActivity}}
         <AuPill @skin="default" @icon="clock" class="auk-u-mr-2 auk-u-mt-2">
           {{t
             "documents-are-planned-to-publish-at"
-            date=(date this.latestThemisPublicationActivity.plannedDate)
-            time=(time this.latestThemisPublicationActivity.plannedDate)
+            date=(date this.latestThemisDocumentPublicationActivity.plannedDate)
+            time=(time this.latestThemisDocumentPublicationActivity.plannedDate)
           }}
         </AuPill>
       {{/if}}

--- a/app/components/agenda/agenda-header/publication-pills.js
+++ b/app/components/agenda/agenda-header/publication-pills.js
@@ -10,7 +10,9 @@ import { PUBLICATION_ACTIVITY_REFRESH_INTERVAL_MS } from 'frontend-kaleidos/conf
 export default class AgendaAgendaHeaderPublicationPillsComponent extends Component {
   @service store;
 
-  @tracked latestThemisPublicationActivity;
+  @tracked latestThemisNewsitemPublicationActivity;
+  @tracked latestThemisDocumentPublicationActivity;
+  @tracked retractedThemisNewsitemPublicationActivity;
   @tracked internalDecisionPublicationActivity;
   @tracked internalDocumentPublicationActivity;
 
@@ -28,16 +30,33 @@ export default class AgendaAgendaHeaderPublicationPillsComponent extends Compone
     return this.internalDocumentPublicationActivity?.status.get('uri') == CONSTANTS.RELEASE_STATUSES.CONFIRMED;
   }
 
-  get isReleasedThemisPublicationActivity() {
-    return this.latestThemisPublicationActivity?.status.get('uri') == CONSTANTS.RELEASE_STATUSES.RELEASED;
+  get isReleasedThemisDocumentPublicationActivity() {
+    return this.latestThemisDocumentPublicationActivity?.status.get('uri') == CONSTANTS.RELEASE_STATUSES.RELEASED;
   }
 
-  get isConfirmedThemisPublicationActivity() {
-    return this.latestThemisPublicationActivity?.status.get('uri') == CONSTANTS.RELEASE_STATUSES.CONFIRMED;
+  get isReleasedThemisNewsitemPublicationActivity() {
+    return this.latestThemisNewsitemPublicationActivity?.status.get('uri') == CONSTANTS.RELEASE_STATUSES.RELEASED;
   }
 
-  get themisPublicationIncludesDocuments() {
-    return this.latestThemisPublicationActivity?.scope.includes(CONSTANTS.THEMIS_PUBLICATION_SCOPES.DOCUMENTS);
+  get isConfirmedThemisDocumentPublicationActivity() {
+    return this.latestThemisDocumentPublicationActivity?.status.get('uri') == CONSTANTS.RELEASE_STATUSES.CONFIRMED;
+  }
+
+  // when we retract everything, we publish a new publicationActivity with empty scope
+  get isRetractedThemisNewsitemPublicationActivity() {
+    return this.latestThemisNewsitemPublicationActivity?.status.get('uri') == CONSTANTS.RELEASE_STATUSES.RELEASED &&
+      this.retractedThemisNewsitemPublicationActivity?.status.get('uri') == CONSTANTS.RELEASE_STATUSES.RELEASED &&
+      this.latestThemisNewsitemPublicationActivity?.startDate < this.retractedThemisNewsitemPublicationActivity?.startDate;
+  }
+
+  // when we retract only documents, we publish a new publicationActivity with scope "newsitems"
+  get isRetractedThemisDocumentPublicationActivity() {
+    return this.latestThemisNewsitemPublicationActivity?.status.get('uri') == CONSTANTS.RELEASE_STATUSES.RELEASED &&
+      this.latestThemisDocumentPublicationActivity?.status.get('uri') == CONSTANTS.RELEASE_STATUSES.RELEASED &&
+      (
+        this.latestThemisDocumentPublicationActivity?.startDate < this.latestThemisNewsitemPublicationActivity?.startDate ||
+        this.latestThemisDocumentPublicationActivity?.startDate < this.retractedThemisNewsitemPublicationActivity?.startDate
+      );
   }
 
   schedulePublicationActivitiesRefresh() {
@@ -63,8 +82,24 @@ export default class AgendaAgendaHeaderPublicationPillsComponent extends Compone
       include: 'status',
     });
 
-    this.latestThemisPublicationActivity = yield this.store.queryOne('themis-publication-activity', {
+    this.latestThemisNewsitemPublicationActivity = yield this.store.queryOne('themis-publication-activity', {
       'filter[meeting][:uri:]': this.args.meeting.uri,
+      'filter[scope]': 'newsitems',
+      sort: '-start-date',
+      include: 'status',
+    });
+
+    this.latestThemisDocumentPublicationActivity = yield this.store.queryOne('themis-publication-activity', {
+      'filter[meeting][:uri:]': this.args.meeting.uri,
+      'filter[scope]': 'documents',
+      sort: '-start-date',
+      include: 'status',
+    });
+
+    // check if the newsitems weren't retracted at a later time
+    this.retractedThemisNewsitemPublicationActivity = yield this.store.queryOne('themis-publication-activity', {
+      'filter[meeting][:uri:]': this.args.meeting.uri,
+      'filter[:has-no:scope]': 't',
       sort: '-start-date',
       include: 'status',
     });

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1082,6 +1082,7 @@
   "close-fullscreen": "Sluit volledig scherm",
   "previous-versions": "Vorige versies",
   "decisions-were-released-at": "Beslissingen zijn vrijgegeven op {date} om {time}",
+  "newsitems-were-published-at": "Beslissingen zijn gepubliceerd op {date} om {time}",
   "documents-were-released-at": "Documenten zijn vrijgegeven op {date} om {time}",
   "documents-are-planned-to-release-at": "Vrijgave van documenten gepland op {date} om {time}",
   "documents-were-published-at": "Documenten zijn gepubliceerd op {date} om {time}",


### PR DESCRIPTION
The old pills didn't account for republishing before documents were published, nor did they account for retractions.
This improved version gives a much more accurate view on the current publication status.