### PR TITLE
KAS-5084 cancel task that yields incorrect data when exiting controller

### DIFF
--- a/app/controllers/agenda/agendaitems.js
+++ b/app/controllers/agenda/agendaitems.js
@@ -129,7 +129,7 @@ export default class AgendaAgendaitemsController extends Controller {
     this.router.refresh('agenda.agendaitems');
   }
 
-  @task
+  @task({ maxConcurrency: 1, restartable: true })
   *groupNotasOnGroupName() {
     const agendaitemsArray = this.model.notas.slice();
     const agendaitemGroups = [];

--- a/app/routes/agenda/agendaitems.js
+++ b/app/routes/agenda/agendaitems.js
@@ -23,6 +23,7 @@ export default class AgendaAgendaitemsRoute extends Route {
 
   @service agendaService;
   @service store;
+  @service throttledLoadingService;
 
   async model(params) {
     const {
@@ -137,6 +138,7 @@ export default class AgendaAgendaitemsRoute extends Route {
       // when rapidly switching to an agenda with 0 notas
       controller.groupNotasOnGroupName.cancelAll();
       controller.loadDocuments.cancelAll();
+      this.throttledLoadingService.loadPieces.cancelAll(); // loadDocuments task started a lot of these
     }
   }
 

--- a/app/routes/agenda/agendaitems.js
+++ b/app/routes/agenda/agendaitems.js
@@ -4,7 +4,7 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { PAGE_SIZE } from 'frontend-kaleidos/config/config';
 import search from 'frontend-kaleidos/utils/mu-search';
-import { animationFrame } from 'ember-concurrency';
+import { animationFrame, didCancel } from 'ember-concurrency';
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 
 export default class AgendaAgendaitemsRoute extends Route {
@@ -116,8 +116,15 @@ export default class AgendaAgendaitemsRoute extends Route {
       // Documents are only shown in agendaitems overview and not in agendaitems sidebar
       promises.push(controller.loadDocuments.perform());
     }
-    await Promise.all(promises);
-
+    try {
+      await Promise.all(promises);
+    } catch (error) {
+      if (!didCancel(error)) {
+        // tasks may be cancelled to reduce excessive loads and incorrect data viewed
+        // re-throw the non-cancelation error
+        throw error;
+      }
+    }
     await animationFrame(); // make sure rendering has happened before trying to scroll
     controller.scrollToAnchor();
   }
@@ -126,6 +133,10 @@ export default class AgendaAgendaitemsRoute extends Route {
     if (isExiting) {
       // isExiting would be false if only the route's model was changing
       controller.set('filter', null);
+      // cancel the task to group notas to prevent this task from completing with incorrect notas
+      // when rapidly switching to an agenda with 0 notas
+      controller.groupNotasOnGroupName.cancelAll();
+      controller.loadDocuments.cancelAll();
     }
   }
 

--- a/app/routes/agenda/print.js
+++ b/app/routes/agenda/print.js
@@ -69,7 +69,7 @@ export default class AgendaPrintRoute extends Route {
   *loadDocuments(agendaitems) {
     yield all(
       agendaitems.map(async (agendaitem) => {
-        await this.throttledLoadingService.loadPieces.linked().perform(agendaitem);
+        await this.throttledLoadingService.loadPieces.perform(agendaitem);
       })
     );
   }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5084

what happened:
- we load the **agendaitems** data in the `agenda.agendaitems` **route**
- we start a **task** in the **controller** to calculate the group names in a **promise** (`groupNotasOnGroupName`) and use the `lastValue` with the current **model**
- before that promise is resolved (it takes a while) we exit the controller
- the controller is still running that task (even though we are no longer on that route)
- when opening a different agenda with 0 notas, we start a new task instance which resolves instantly
- however the other task that was still running also returns a result and that one is used instead.

How to be sure: test with slow network.
Open agenda with some notas, wait for the "0 van X agendaitems geladen" shows up, then go to agendas and open the agenda without notas.
If you add a task modifier `drop: true` you can see this is what is happening since it reproduces the issue pretty much 100%

Fix:
- cancelling the task on exit of the `agenda.agendaitems` route seems to work.
- I also cancelled loading the documents of the agendaitems, thought it might reduce loading times on switching
- since they are performed as promises, had to catch the errors thrown by the promise.
This fix alone seemed to be enough after testing a bunch

but thinking about it, there could be an alternative fix which I might want to add as a failsafe:
- limiting the task to max 1 instance and making that 1 task restartable (it should mean we drop the running task and start a new one with the new model everytime we transition into `agenda.agendaitems` route)