### PR TITLE
KAS-5072 refactor draft-piece edit-modal

### DIFF
--- a/app/components/auk/file-uploader.hbs
+++ b/app/components/auk/file-uploader.hbs
@@ -38,7 +38,7 @@
           {{on "click" this.clickInput}}
           {{on "key-up" this.clickInputOnEnter}}
         >
-          {{t "upload-files" numFiles=(if @multiple "multiple" "one")}}
+          {{t "upload-files" numFiles=(if @multiple "multiple" "1")}} 
         </AuButton>
       {{else if this.uploadIsRunning}}
         {{t "uploading-files" numFiles=this.fileQueue.files.length}}
@@ -59,7 +59,7 @@
         {{#if dropzone.active}}
           {{t "drop-text"}}
         {{else if dropzone.supported}}
-          {{t "drag-or-click-for-upload" numFiles=(if @multiple "many" "one")}}
+          {{t "drag-or-click-for-upload" numFiles=(if @multiple "many" "1")}}
         {{/if}}
       </p>
     {{/if}}

--- a/app/components/documents/draft-document-card/edit-modal.hbs
+++ b/app/components/documents/draft-document-card/edit-modal.hbs
@@ -8,31 +8,26 @@
   @disabled={{this.isDisabled}}
 >
   <:body>
-    <AuCard
-      @flex={{true}}
-      @size="small"
-      as |c|
-    >
-      <c.header
-        @badgeIcon={{document-icon @piece.file.extension}}
-      >
-        <p class="vlc-subline au-u-medium au-u-muted">
-          {{uppercase @piece.file.extension}}
-        </p>
-        <div class="au-u-flex au-u-flex--spaced-small">
-          <AuInput
-            value={{this.name}}
-            @width="block"
-            {{on "input" (pick "target.value" (set this "name"))}}
-          />
-          <AuButtonGroup class="au-u-flex--no-wrap">
-            <AuButton
-              @skin="secondary"
-              {{on "click" this.toggleUploadReplacementSourceFile}}
-            >
-              {{t "replace"}}
-            </AuButton>
-          </AuButtonGroup>
+    <AuCard @size="small" class="au-u-margin-top-small" as |c|>
+      <c.header>
+        <div class="auk-form-group">
+          <AuLabel for="name">{{t "name-document"}}</AuLabel>
+          <div class="au-u-flex au-u-flex--spaced-small">
+            <AuInput
+              value={{this.name}}
+              @width="block"
+              {{on "input" (pick "target.value" (set this "name"))}}
+            />
+            <AuButtonGroup class="au-u-flex--no-wrap">
+              <AuButton
+                @skin="secondary"
+                @disabled={{this.isDisabled}}
+                {{on "click" this.toggleUploadReplacementFile}}
+              >
+                {{t "replace"}}
+              </AuButton>
+            </AuButtonGroup>
+          </div>
         </div>
         {{#if @piece.created}}
           <AuHelpText @skin="secondary">
@@ -41,137 +36,30 @@
           </AuHelpText>
         {{/if}}
       </c.header>
-      {{#if this.isReplacingSourceFile}}
+      {{#if this.isReplacingFile}}
         <c.content>
+          {{#if this.replacementFile}}
+            <AuAlert @skin="warning" @icon="alert-triangle">
+              {{t "replace-submission-document-warning"}}
+            </AuAlert>
+          {{/if}}
           <Auk::FileUploader
             @isSubmission={{true}}
             @multiple={{false}}
-            @onUpload={{set this "replacementSourceFile"}}
-            @onQueueUpdate={{this.handleReplacementSourceFileUploadQueue}}
+            @onUpload={{set this "replacementFile"}}
+            @onQueueUpdate={{this.handleReplacementFileUploadQueue}}
             @validateFile={{this.validateFile}}
             @dropzoneMessage={{if (not (user-may "upload-any-submission-document-extension")) "submission-document-accepted-types"}}
           />
         </c.content>
       {{/if}}
     </AuCard>
-    {{#if @piece.file.derived}}
-      <AuCard
-        @flex={{true}}
-        @size="small"
-        class="au-u-margin-top-small {{if this.isDeletingDerivedFile 'vlc-document--deleted-state'}}"
-        as |c|
-      >
-        <c.header
-          @badgeIcon={{document-icon @piece.file.derived.extension}}
-        >
-          <p class="vlc-subline au-u-medium au-u-muted">
-            {{uppercase @piece.file.derived.extension}}
-          </p>
-          <div class="au-u-flex au-u-flex--between au-u-flex--spaced-small">
-            <p>
-              {{@piece.name}}
-            </p>
-            <AuButtonGroup class="au-u-flex--no-wrap">
-              <AuButton
-                @skin="secondary"
-                {{on "click" this.toggleUploadReplacementDerivedFile}}
-              >
-                {{t "replace"}}
-              </AuButton>
-              <AuButton
-                @skin="secondary"
-                @alert={{true}}
-                @icon="trash"
-                @hideText={{true}}
-                {{on "click" (toggle "isDeletingDerivedFile" this)}}
-              >
-              </AuButton>
-            </AuButtonGroup>
-          </div>
-          {{#if @piece.file.derived.created}}
-            <AuHelpText @skin="secondary">
-              {{t "uploaded-at"}}
-              {{datetime-at @piece.file.derived.created}}
-            </AuHelpText>
-          {{/if}}
-        </c.header>
-        {{#if this.isReplacingDerivedFile}}
-          <c.content>
-            <Auk::FileUploader
-              @isSubmission={{true}}
-              @multiple={{false}}
-              @onUpload={{set this "replacementDerivedFile"}}
-              @onQueueUpdate={{this.handleReplacementDerivedFileUploadQueue}}
-              @validateFile={{this.validateFile}}
-              @dropzoneMessage={{if (not (user-may "upload-any-submission-document-extension")) "submission-document-accepted-types"}}
-            />
-          </c.content>
-        {{/if}}
-      </AuCard>
-    {{else}}
-      {{#unless this.uploadedDerivedFile}}
-        <AuCard
-          @flex={{true}}
-          @size="small"
-          class="au-u-margin-top-small"
-          as |c|
-        >
-          <c.header
-            @badgeIcon="document"
-          >
-            <div class="au-u-flex au-u-flex--spaced-small">
-              <AuHeading @skin="5" @level="3">{{t "upload-source-document"}}</AuHeading>
-            </div>
-          </c.header>
-          <c.content>
-            <Auk::FileUploader
-              @isSubmission={{true}}
-              @multiple={{false}}
-              @onUpload={{set this "uploadedSourceFile"}}
-              @onQueueUpdate={{this.handleSourceFileUploadQueue}}
-              @validateFile={{this.validateFile}}
-              @dropzoneMessage={{if (not (user-may "upload-any-submission-document-extension")) "submission-document-accepted-types"}}
-            />
-          </c.content>
-        </AuCard>
-      {{/unless}}
-      {{#unless (or this.uploadedDerivedFile this.uploadedSourceFile)}}
-        <div class="auk-u-mt-2 auk-u-text-align--center">
-          <p>{{t "or"}}</p>
-        </div>
-      {{/unless}}
-      {{#unless this.uploadedSourceFile}}
-        <AuCard
-          @flex={{true}}
-          @size="small"
-          class="au-u-margin-top-small"
-          as |c|
-        >
-          <c.header
-            @badgeIcon="document"
-          >
-            <div class="au-u-flex au-u-flex--spaced-small">
-              <AuHeading @skin="5" @level="3">{{t "upload-derived-document"}}</AuHeading>
-            </div>
-          </c.header>
-          <c.content>
-            <Auk::FileUploader
-              @isSubmission={{true}}
-              @multiple={{false}}
-              @onUpload={{set this "uploadedDerivedFile"}}
-              @onQueueUpdate={{this.handleDerivedFileUploadQueue}}
-              @validateFile={{this.validateFile}}
-              @dropzoneMessage={{if (not (user-may "upload-any-submission-document-extension")) "submission-document-accepted-types"}}
-            />
-          </c.content>
-        </AuCard>
-      {{/unless}}
-    {{/if}}
     <AuCard @size="small" class="au-u-margin-top-small" as |c|>
       <c.content>
         <div class="auk-form-group">
           <AuLabel for="type">{{t "document-type"}}</AuLabel>
           <Utils::DocumentTypeSelector
+            @disabled={{this.isDisabled}}
             @selectedDocumentType={{this.documentType}}
             @onChange={{this.selectDocumentType}}
           />

--- a/app/components/documents/draft-document-card/edit-modal.hbs
+++ b/app/components/documents/draft-document-card/edit-modal.hbs
@@ -9,7 +9,7 @@
 >
   <:body>
     <AuCard @size="small" class="au-u-margin-top-small" as |c|>
-      <c.header>
+      <c.content>
         <div class="auk-form-group">
           <AuLabel for="name">{{t "name-document"}}</AuLabel>
           <div class="au-u-flex au-u-flex--spaced-small">
@@ -18,15 +18,6 @@
               @width="block"
               {{on "input" (pick "target.value" (set this "name"))}}
             />
-            <AuButtonGroup class="au-u-flex--no-wrap">
-              <AuButton
-                @skin="secondary"
-                @disabled={{this.isDisabled}}
-                {{on "click" this.toggleUploadReplacementFile}}
-              >
-                {{t "replace"}}
-              </AuButton>
-            </AuButtonGroup>
           </div>
         </div>
         {{#if @piece.created}}
@@ -35,9 +26,12 @@
             {{datetime-at (or @piece.file.created @piece.created)}}
           </AuHelpText>
         {{/if}}
-      </c.header>
-      {{#if this.isReplacingFile}}
-        <c.content>
+      </c.content>
+    </AuCard>
+    <AuCard @size="small" class="au-u-margin-top-small" as |c|>
+      <c.content>
+        <div class="auk-form-group">
+          <AuLabel for="type">{{t "replace-file"}}</AuLabel>
           {{#if this.replacementFile}}
             <AuAlert @skin="warning" @icon="alert-triangle">
               {{t "replace-submission-document-warning"}}
@@ -51,8 +45,8 @@
             @validateFile={{this.validateFile}}
             @dropzoneMessage={{if (not (user-may "upload-any-submission-document-extension")) "submission-document-accepted-types"}}
           />
-        </c.content>
-      {{/if}}
+        </div>
+      </c.content>
     </AuCard>
     <AuCard @size="small" class="au-u-margin-top-small" as |c|>
       <c.content>

--- a/app/components/documents/draft-document-card/edit-modal.js
+++ b/app/components/documents/draft-document-card/edit-modal.js
@@ -11,28 +11,17 @@ export default class DocumentsDraftDocumentCardEditModalComponent extends Compon
    * @param {Function} onSave: the action to execute after saving changes
    * @param {Function} onCancel: the action to execute after cancelling the edit
    */
-  @service documentService;
   @service intl;
   @service toaster;
   @service fileConversionService;
   @service draftSubmissionService;
 
-  @tracked isUploadingSourceFile = false;
-  @tracked isReplacingSourceFile = false;
-  @tracked isReplacingDerivedFile = false;
-  @tracked isUploadingDerivedFile = false;
-  @tracked isDeletingDerivedFile = false;
-
-  @tracked isUploadingReplacementSourceFile = false;
-  @tracked isUploadingReplacementDerivedFile = false;
+  @tracked isReplacingFile = false;
+  @tracked isUploadingReplacementFile = false;
+  @tracked replacementFile;
 
   @tracked name;
   @tracked documentType;
-
-  @tracked uploadedSourceFile;
-  @tracked uploadedDerivedFile;
-  @tracked replacementSourceFile;
-  @tracked replacementDerivedFile;
 
   constructor() {
     super(...arguments);
@@ -46,51 +35,23 @@ export default class DocumentsDraftDocumentCardEditModalComponent extends Compon
   });
 
   get isDisabled() {
-    return (
-      this.saveEdit.isRunning
-        || this.isUploadingSourceFile
-        || this.isUploadingDerivedFile
-        || this.isUploadingReplacementDerivedFile
-        || this.isUploadingReplacementSourceFile
-    );
+    return this.saveEdit.isRunning || this.isUploadingReplacementFile;
   }
 
   validateFile = (file) => {
     return this.draftSubmissionService.validateUploadedFile(file);
+  };
+
+  @action
+  handleReplacementFileUploadQueue({ uploadIsRunning, uploadIsCompleted }) {
+    this.isUploadingReplacementFile = uploadIsRunning && !uploadIsCompleted;
   }
 
   @action
-  handleSourceFileUploadQueue({ uploadIsRunning, uploadIsCompleted}) {
-    this.isUploadingSourceFile = uploadIsRunning && !uploadIsCompleted;
-  }
-
-  @action
-  handleDerivedFileUploadQueue({ uploadIsRunning, uploadIsCompleted}) {
-    this.isUploadingDerivedFile = uploadIsRunning && !uploadIsCompleted;
-  }
-
-  @action
-  handleReplacementSourceFileUploadQueue({ uploadIsRunning, uploadIsCompleted}) {
-    this.isUploadingReplacementSourceFile = uploadIsRunning && !uploadIsCompleted;
-  }
-
-  @action
-  handleReplacementDerivedFileUploadQueue({ uploadIsRunning, uploadIsCompleted}) {
-    this.isUploadingReplacementDerivedFile = uploadIsRunning && !uploadIsCompleted;
-  }
-
-  @action
-  async toggleUploadReplacementSourceFile() {
-    await this.replacementSourceFile?.destroyRecord();
-    this.replacementSourceFile = null;
-    this.isReplacingSourceFile = !this.isReplacingSourceFile;
-  }
-
-  @action
-  async toggleUploadReplacementDerivedFile() {
-    await this.replacementDerivedFile?.destroyRecord();
-    this.replacementDerivedFile = null;
-    this.isReplacingDerivedFile = !this.isReplacingDerivedFile;
+  async toggleUploadReplacementFile() {
+    await this.replacementFile?.destroyRecord();
+    this.replacementFile = null;
+    this.isReplacingFile = !this.isReplacingFile;
   }
 
   @action
@@ -102,22 +63,9 @@ export default class DocumentsDraftDocumentCardEditModalComponent extends Compon
   async cancelEdit() {
     this.name = null;
 
-    await this.uploadedSourceFile?.destroyRecord();
-    this.isUploadingSourceFile = false;
-    this.uploadedSourceFile = null;
-
-    await this.replacementSourceFile?.destroyRecord();
-    this.isReplacingSourceFile = false;
-    this.replacementSourceFile = null;
-
-    await this.replacementDerivedFile?.destroyRecord();
-    this.isReplacingDerivedFile = false;
-    this.replacementDerivedFile = null;
-
-    await this.uploadedDerivedFile?.destroyRecord();
-    this.uploadedDerivedFile = null;
-
-    this.isDeletingDerivedFile = false;
+    await this.replacementFile?.destroyRecord();
+    this.isReplacingFile = false;
+    this.replacementFile = null;
 
     this.args.onCancel?.();
   }
@@ -125,64 +73,29 @@ export default class DocumentsDraftDocumentCardEditModalComponent extends Compon
   saveEdit = task(async () => {
     this.args.piece.name = this.name?.trim();
     this.args.documentContainer.type = this.documentType;
-    if (this.uploadedSourceFile) {
-      // use-case: we have a pdf and we want to add docx but keep our pdf
-      // derived file does not exist yet in this case
-      const oldFile = await this.args.piece.file;
-      this.uploadedSourceFile.derived = oldFile;
-      this.args.piece.file = this.uploadedSourceFile;
-      await Promise.all([oldFile.save(), this.uploadedSourceFile.save()]);
-    }
-    if (this.replacementSourceFile) {
+    if (this.replacementFile) {
+      // 1 use case: remove all current files (of this draft-piece) and use the new file
       const oldFile = await this.args.piece.file;
       const derivedFile = await oldFile.derived;
       if (derivedFile) {
         oldFile.derived = null;
-        this.replacementSourceFile.derived = derivedFile;
-        await Promise.all([oldFile.save(), this.replacementSourceFile.save()]);
+        await derivedFile.destroyRecord();
       }
-      this.args.piece.file = this.replacementSourceFile;
+      this.args.piece.file = this.replacementFile;
       await oldFile.destroyRecord();
       try {
         await this.fileConversionService.convertSourceFile(
-          this.replacementSourceFile
+          this.replacementFile,
         );
       } catch (error) {
         this.toaster.error(
           this.intl.t('error-convert-file', { message: error.message }),
-          this.intl.t('warning-title')
+          this.intl.t('warning-title'),
         );
       }
     }
-    if (this.replacementDerivedFile) {
-      const file = await this.args.piece.file;
-      const oldDerived = await file.derived;
-      file.derived = this.replacementDerivedFile;
-      await file.save();
-      await oldDerived.destroyRecord();
-    }
-    if (this.uploadedDerivedFile) {
-      const file = await this.args.piece.file;
-      file.derived = this.uploadedDerivedFile;
-      await file.save();
-    }
-    if (this.isDeletingDerivedFile) {
-      const file = await this.args.piece.file;
-      const derivedFile = await file.derived;
-      file.derived = null;
-      await file.save();
-      await derivedFile.destroyRecord();
-    }
     await this.args.piece.save();
     await this.args.documentContainer.save();
-
-    if (this.replacementSourceFile) {
-      if (this.args.piece.stamp) {
-        await this.documentService.stampDocuments([this.args.piece]);
-      }
-    } else {
-      await this.documentService.checkAndRestamp([this.args.piece]);
-    }
 
     this.name = null;
 
@@ -190,16 +103,7 @@ export default class DocumentsDraftDocumentCardEditModalComponent extends Compon
 
     this.args.onSave?.();
 
-    this.isUploadingSourceFile = false;
-    this.uploadedSourceFile = null;
-
-    this.isReplacingSourceFile = false;
-    this.replacementSourceFile = null;
-
-    this.isReplacingDerivedFile = false;
-    this.replacementDerivedFile = false;
-
-    this.uploadedDerivedFile = null;
-    this.isDeletingDerivedFile = false;
+    this.isReplacingFile = false;
+    this.replacementFile = null;
   });
 }

--- a/app/components/documents/draft-document-card/edit-modal.js
+++ b/app/components/documents/draft-document-card/edit-modal.js
@@ -16,7 +16,6 @@ export default class DocumentsDraftDocumentCardEditModalComponent extends Compon
   @service fileConversionService;
   @service draftSubmissionService;
 
-  @tracked isReplacingFile = false;
   @tracked isUploadingReplacementFile = false;
   @tracked replacementFile;
 
@@ -48,13 +47,6 @@ export default class DocumentsDraftDocumentCardEditModalComponent extends Compon
   }
 
   @action
-  async toggleUploadReplacementFile() {
-    await this.replacementFile?.destroyRecord();
-    this.replacementFile = null;
-    this.isReplacingFile = !this.isReplacingFile;
-  }
-
-  @action
   selectDocumentType(value) {
     this.documentType = value;
   }
@@ -64,7 +56,6 @@ export default class DocumentsDraftDocumentCardEditModalComponent extends Compon
     this.name = null;
 
     await this.replacementFile?.destroyRecord();
-    this.isReplacingFile = false;
     this.replacementFile = null;
 
     this.args.onCancel?.();
@@ -103,7 +94,6 @@ export default class DocumentsDraftDocumentCardEditModalComponent extends Compon
 
     this.args.onSave?.();
 
-    this.isReplacingFile = false;
     this.replacementFile = null;
   });
 }

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1530,5 +1530,6 @@
   "concepts": "Concepten",
   "agendaitem-positions-cannot-be-changed": "De volgorde van de agendapunten op deze agenda is intussen gewijzigd. Noteer je wijzigingen en hernieuw deze pagina om de laatste aanpassingen te zien.",
   "shortlist-publication-error-message": "De lijst op te starten publicaties kon niet opgevraagd worden",
-  "error-getting-related-subcase-agendas": "De lijst relevante agendas van deze procedurestap kan niet worden geladen"
+  "error-getting-related-subcase-agendas": "De lijst relevante agendas van deze procedurestap kan niet worden geladen",
+  "replace-submission-document-warning": "Let op, bij opslaan wordt het originele document in Kaleidos volledig vervangen door het nieuwe bestand. Deze actie kan niet ongedaan worden gemaakt."
 }

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1531,5 +1531,6 @@
   "agendaitem-positions-cannot-be-changed": "De volgorde van de agendapunten op deze agenda is intussen gewijzigd. Noteer je wijzigingen en hernieuw deze pagina om de laatste aanpassingen te zien.",
   "shortlist-publication-error-message": "De lijst op te starten publicaties kon niet opgevraagd worden",
   "error-getting-related-subcase-agendas": "De lijst relevante agendas van deze procedurestap kan niet worden geladen",
-  "replace-submission-document-warning": "Let op, bij opslaan wordt het originele document in Kaleidos volledig vervangen door het nieuwe bestand. Deze actie kan niet ongedaan worden gemaakt."
+  "replace-submission-document-warning": "Let op, bij opslaan wordt het originele document in Kaleidos volledig vervangen door het nieuwe bestand. Deze actie kan niet ongedaan worden gemaakt.",
+  "replace-file": "Bestand vervangen"
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5072

implemented replacing logic as follows:
- refactored to just have 1 upload modal
- both old file and derived file get destroyed only if we have a replacement
- try to convert the new file to pdf

Screencaptures
- opening modal
<img width="940" height="504" alt="image" src="https://github.com/user-attachments/assets/9ac1567e-13fc-4d39-a923-b38ff9588a2f" />

- "replace" clicked
<img width="933" height="683" alt="image" src="https://github.com/user-attachments/assets/830a581b-ee08-480e-8d00-7b683e483516" />

- file uploaded (limited type) showing alert
<img width="943" height="779" alt="image" src="https://github.com/user-attachments/assets/aed49fa1-2e28-4202-a5d6-798014c346e1" />

note:
- since this modal is used for draft-piece regardless of profile, admins/editors are also restricted
- no more option to manually add a PDF if automatic conversion fails (too large). this will have to be done after accepting submission (in the actual piece edit-modal)

But there is still the possibility to attempt a new conversion.
<img width="1857" height="266" alt="image" src="https://github.com/user-attachments/assets/78c55290-1ee2-46a9-a121-145fad3e0bc1" />

For this PR I kept a lot of the visual style of the existing model (using a "replace" button that opens a modal)
I also have a second suggestion for the view, where name editing is a separate card and the replacement upload modal is in it's own card.
I will branch of this PR and make that to compare.

- [ ] compare with https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/2359


