### PR TITLE
Feature/kas 5072 cabinet replace documents v2

### DIFF
--- a/app/components/documents/draft-document-card/edit-modal.hbs
+++ b/app/components/documents/draft-document-card/edit-modal.hbs
@@ -9,7 +9,7 @@
 >
   <:body>
     <AuCard @size="small" class="au-u-margin-top-small" as |c|>
-      <c.header>
+      <c.content>
         <div class="auk-form-group">
           <AuLabel for="name">{{t "name-document"}}</AuLabel>
           <div class="au-u-flex au-u-flex--spaced-small">
@@ -18,15 +18,6 @@
               @width="block"
               {{on "input" (pick "target.value" (set this "name"))}}
             />
-            <AuButtonGroup class="au-u-flex--no-wrap">
-              <AuButton
-                @skin="secondary"
-                @disabled={{this.isDisabled}}
-                {{on "click" this.toggleUploadReplacementFile}}
-              >
-                {{t "replace"}}
-              </AuButton>
-            </AuButtonGroup>
           </div>
         </div>
         {{#if @piece.created}}
@@ -35,9 +26,12 @@
             {{datetime-at (or @piece.file.created @piece.created)}}
           </AuHelpText>
         {{/if}}
-      </c.header>
-      {{#if this.isReplacingFile}}
-        <c.content>
+      </c.content>
+    </AuCard>
+    <AuCard @size="small" class="au-u-margin-top-small" as |c|>
+      <c.content>
+        <div class="auk-form-group">
+          <AuLabel for="type">{{t "replace-file"}}</AuLabel>
           {{#if this.replacementFile}}
             <AuAlert @skin="warning" @icon="alert-triangle">
               {{t "replace-submission-document-warning"}}
@@ -51,8 +45,8 @@
             @validateFile={{this.validateFile}}
             @dropzoneMessage={{if (not (user-may "upload-any-submission-document-extension")) "submission-document-accepted-types"}}
           />
-        </c.content>
-      {{/if}}
+        </div>
+      </c.content>
     </AuCard>
     <AuCard @size="small" class="au-u-margin-top-small" as |c|>
       <c.content>

--- a/app/components/documents/draft-document-card/edit-modal.js
+++ b/app/components/documents/draft-document-card/edit-modal.js
@@ -16,7 +16,6 @@ export default class DocumentsDraftDocumentCardEditModalComponent extends Compon
   @service fileConversionService;
   @service draftSubmissionService;
 
-  @tracked isReplacingFile = false;
   @tracked isUploadingReplacementFile = false;
   @tracked replacementFile;
 
@@ -48,13 +47,6 @@ export default class DocumentsDraftDocumentCardEditModalComponent extends Compon
   }
 
   @action
-  async toggleUploadReplacementFile() {
-    await this.replacementFile?.destroyRecord();
-    this.replacementFile = null;
-    this.isReplacingFile = !this.isReplacingFile;
-  }
-
-  @action
   selectDocumentType(value) {
     this.documentType = value;
   }
@@ -64,7 +56,6 @@ export default class DocumentsDraftDocumentCardEditModalComponent extends Compon
     this.name = null;
 
     await this.replacementFile?.destroyRecord();
-    this.isReplacingFile = false;
     this.replacementFile = null;
 
     this.args.onCancel?.();
@@ -103,7 +94,6 @@ export default class DocumentsDraftDocumentCardEditModalComponent extends Compon
 
     this.args.onSave?.();
 
-    this.isReplacingFile = false;
     this.replacementFile = null;
   });
 }

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1531,5 +1531,6 @@
   "agendaitem-positions-cannot-be-changed": "De volgorde van de agendapunten op deze agenda is intussen gewijzigd. Noteer je wijzigingen en hernieuw deze pagina om de laatste aanpassingen te zien.",
   "shortlist-publication-error-message": "De lijst op te starten publicaties kon niet opgevraagd worden",
   "error-getting-related-subcase-agendas": "De lijst relevante agendas van deze procedurestap kan niet worden geladen",
-  "replace-submission-document-warning": "Let op, bij opslaan wordt het originele document in Kaleidos volledig vervangen door het nieuwe bestand. Deze actie kan niet ongedaan worden gemaakt."
+  "replace-submission-document-warning": "Let op, bij opslaan wordt het originele document in Kaleidos volledig vervangen door het nieuwe bestand. Deze actie kan niet ongedaan worden gemaakt.",
+  "replace-file": "Bestand vervangen"
 }


### PR DESCRIPTION
CFR version 1:
https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/2358

https://kanselarij.atlassian.net/browse/KAS-5072
Starting from version 1:
- removed the toggle so the upload modal is always showing
- alert is still only shown if a file was actually uploaded (only when the previous file is about to be deleted)

Opening modal
<img width="847" height="678" alt="image" src="https://github.com/user-attachments/assets/57d781b0-7685-46fa-86fa-44e37973fb38" />

Uploading a file
<img width="835" height="753" alt="image" src="https://github.com/user-attachments/assets/a606a5b2-1f33-48eb-b208-9cf8d4d20308" />


