### PR TITLE
KAS-4425 add and implement automation to ensure signedPiece(Copy) has correct accessLevel

### DIFF
--- a/app/components/documents/batch-details/batch-documents-details-modal.js
+++ b/app/components/documents/batch-details/batch-documents-details-modal.js
@@ -208,6 +208,7 @@ export default class BatchDocumentsDetailsModal extends Component {
           ) {
             // - "draft-pieces" have "pieces" as previous. we update those in a later step.
             // - some profiles are allowed to edit "draft-piece" but not "piece" so this could error
+            await this.pieceAccessLevelService.updateSignedPieceAccessLevels(piece);
             await this.pieceAccessLevelService.updatePreviousAccessLevels(piece);
           }
           changedPieces.push(piece);

--- a/app/components/documents/document-card.js
+++ b/app/components/documents/document-card.js
@@ -476,6 +476,7 @@ export default class DocumentsDocumentCardComponent extends Component {
   async saveAccessLevel() {
     await this.piece.belongsTo('file').reload(); // concurrent edits of file are possible like when signatures are stripped
     await this.piece.save();
+    await this.pieceAccessLevelService.updateSignedPieceAccessLevels(this.piece);
     await this.pieceAccessLevelService.updatePreviousAccessLevels(this.piece);
     if (this.hasConfidentialityChanged && this.args.onChangeConfidentiality) {
       await this.args?.onChangeConfidentiality();
@@ -493,6 +494,7 @@ export default class DocumentsDocumentCardComponent extends Component {
   @action
   async saveAccessLevelOfPiece(piece) {
     await piece.save();
+    await this.pieceAccessLevelService.updateSignedPieceAccessLevels(piece);
     await this.pieceAccessLevelService.updatePreviousAccessLevels(piece);
   }
 

--- a/app/components/documents/document-details-panel.js
+++ b/app/components/documents/document-details-panel.js
@@ -210,6 +210,7 @@ export default class DocumentsDocumentDetailsPanel extends Component {
     this.args.piece.accessLevel = this.accessLevel;
     this.args.piece.name = this.args.piece.name?.trim();
     yield this.args.piece.save();
+    yield this.pieceAccessLevelService.updateSignedPieceAccessLevels(this.args.piece);
     yield this.pieceAccessLevelService.updatePreviousAccessLevels(
       this.args.piece
     );

--- a/app/components/documents/draft-document-card.js
+++ b/app/components/documents/draft-document-card.js
@@ -336,6 +336,10 @@ export default class DocumentsDraftDocumentCardComponent extends Component {
   @action
   async saveAccessLevel() {
     await this.piece.save();
+    if (this.piece.constructor.modelName === 'piece' && this.currentSession.may('manage-document-access-levels')) {
+      await this.pieceAccessLevelService.updateSignedPieceAccessLevels(this.piece);
+      await this.pieceAccessLevelService.updatePreviousAccessLevels(this.piece);
+    }
     await this.loadPieceRelatedData.perform();
     this.args.onSaveAccessLevel?.();
   }

--- a/app/services/piece-access-level-service.js
+++ b/app/services/piece-access-level-service.js
@@ -73,6 +73,7 @@ export default class PieceAccessLevelService extends Service {
     if (previousAccessLevel.uri !== accessLevelToSet.uri) {
       previousPiece.accessLevel = accessLevelToSet;
       await previousPiece.save();
+      await this.updateSignedPieceAccessLevels(previousPiece);
     }
     return true;
   }
@@ -109,6 +110,7 @@ export default class PieceAccessLevelService extends Service {
       );
       piece.accessLevel = internRegering;
       await piece.save();
+      await this.updateSignedPieceAccessLevels(piece);
       await this.updatePreviousAccessLevels(piece);
     }
   }
@@ -129,6 +131,7 @@ export default class PieceAccessLevelService extends Service {
       const confidential = await this.store.findRecordByUri('concept', CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK);
       piece.accessLevel = confidential;
       await piece.save();
+      await this.updateSignedPieceAccessLevels(piece);
       await this.updatePreviousAccessLevels(piece);
     }
   }
@@ -164,6 +167,70 @@ export default class PieceAccessLevelService extends Service {
     await Promise.all(pieces.slice().map(async (piece) => {
       await this.strengthenAccessLevelToConfidential(piece);
     }));
+  }
+
+  /**
+   * Ensures that the signedPieceCopy of a piece always has the correct accessLevel
+   * Either the same accessLevel or at be at least "intern overheid"
+   * !this is one of the rare occurences where weakening accessLevel is OK, since it reflects the main piece
+   */
+  async _updateSignedPieceCopyOfPiece(piece) {
+    const accessLevel = await piece.accessLevel;
+    const signedPieceCopy = await piece.belongsTo('signedPieceCopy').reload();
+    if (!signedPieceCopy) {
+      return;
+    }
+    let accessLevelToSet;
+    const signedPieceCopyAccessLevel = await signedPieceCopy.accessLevel;
+    if (accessLevel.uri == CONSTANTS.ACCESS_LEVELS.PUBLIEK) {
+      const internOverheid = await this.store.findRecordByUri('concept', CONSTANTS.ACCESS_LEVELS.INTERN_OVERHEID);
+      accessLevelToSet = internOverheid;
+    } else {
+      accessLevelToSet = accessLevel;
+    }
+    if (signedPieceCopyAccessLevel.uri !== accessLevelToSet.uri) {
+      signedPieceCopy.accessLevel = accessLevelToSet;
+      await signedPieceCopy.save();
+    }
+  }
+
+  /**
+   * Ensures that the signedPieceCopy of a piece always has the correct accessLevel
+   * Either the same accessLevel or be at least "intern regering"
+   * !this is one of the rare occurences where weakening accessLevel is OK, since it reflects the main piece
+   */
+  async _updateSignedPieceOfPiece(piece) {
+    const accessLevel = await piece.accessLevel;
+    const signedPiece = await piece.belongsTo('signedPiece').reload();
+    if (!signedPiece) {
+      return;
+    }
+    let accessLevelToSet;
+    const signedPieceAccessLevel = await signedPiece.accessLevel;
+    if (
+      [
+        CONSTANTS.ACCESS_LEVELS.PUBLIEK,
+        CONSTANTS.ACCESS_LEVELS.INTERN_OVERHEID,
+      ].includes(accessLevel.uri)
+    ) {
+      const internRegering = await this.store.findRecordByUri('concept', CONSTANTS.ACCESS_LEVELS.INTERN_REGERING);
+      accessLevelToSet = internRegering;
+    } else {
+      accessLevelToSet = accessLevel;
+    }
+    if (signedPieceAccessLevel.uri !== accessLevelToSet.uri) {
+      signedPiece.accessLevel = accessLevelToSet;
+      await signedPiece.save();
+    }
+  }
+
+  /**
+   * Update signedPiece and signedPieceCopy based on updates on main piece
+   * strengthening or weakening accordingly
+   */ 
+  async updateSignedPieceAccessLevels(piece) {
+    await this._updateSignedPieceOfPiece(piece);
+    await this._updateSignedPieceCopyOfPiece(piece);
   }
 
   /*


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4425

Not a lot of code, tried to keep it simple and clear.
Was wondering if it would have been better to do this with deltas, but that would require sending a lot of deltas where we only have to do the work a few times a day since accessLevels are not updated that frequently
I also expect some concurrency issues where we have to implement `piece.belongsTo('accessLevel').reload();` for `SignedPieces` and `SignedPieceCopy`.

Anyway, there are many pieces now where the signedPiece or the signedPieceCopy do not have the correct accessLevel.
Are we going to update those with migrations?
Ticket doesn't mention them, but we could list them with queries


Places where we save pieces but this logic is not needed:
- When we add a new version of a piece (new piece, no signed piece at that time but previous piece will be checked since it's in that piece of code)
- publication pieces (no accessLevel)
- draft-pieces (no signedPieces yet)
- places where we edit piece/file but not the accessLevel (like edit-modal)