### PR TITLE
KAS-4921 Add modal for adding signed piece (replace main pdf) + sidetracking

### DIFF
--- a/app/components/auk/color-badge.js
+++ b/app/components/auk/color-badge.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 
 /**
  *
- * @argument skin {String}: Possible values are: (empty, default), "succes", "warning", "error"
+ * @argument skin {String}: Possible values are: (empty, default), "success", "warning", "error"
  */
 export default class ColorBadge extends Component {
   get skin() {

--- a/app/components/documents/document-card.hbs
+++ b/app/components/documents/document-card.hbs
@@ -266,6 +266,15 @@
                     {{t "stop-sign-flow"}}
                   </AuButton>
                 {{/if}}
+                {{#if this.mayAddSignedPiece}}
+                  <AuButton
+                    @skin="link"
+                    {{on "click" (toggle "isAddingSignedPiece" this)}}
+                    role="menuitem"
+                  >
+                    {{t "upload-signed-file"}}
+                  </AuButton>
+                {{/if}}
                 {{#if this.mayDelete}}
                   <AuHr />
                   <AuButton
@@ -376,3 +385,11 @@
   @confirmIcon="trash"
   @alert={{true}}
 />
+
+{{#if this.isAddingSignedPiece}}
+  <Documents::DocumentCard::AddSignedPieceModal
+    @piece={{this.piece}}
+    @onCancel={{this.cancelAddSignedPiece}}
+    @onSave={{queue (toggle "isAddingSignedPiece" this) (perform this.loadPieceRelatedData)}}
+  />
+{{/if}}

--- a/app/components/documents/document-card.js
+++ b/app/components/documents/document-card.js
@@ -123,7 +123,7 @@ export default class DocumentsDocumentCardComponent extends Component {
   get mayAddSignedPiece() {
     return (
       !this.signMarkingActivity &&
-      !this.piece.signedPiece?.get('id') && // TODO this could be removed, it also works if signedPieces exist
+      // !this.piece.signedPiece?.get('id') && // Only allow upload if no signed piece exists yet
       this.currentSession.may('add-signed-piece')
     );
   }

--- a/app/components/documents/document-card.js
+++ b/app/components/documents/document-card.js
@@ -45,6 +45,7 @@ export default class DocumentsDocumentCardComponent extends Component {
   @tracked isOpenUploadModal = false;
   @tracked isOpenVerifyDeleteModal = false;
   @tracked isEditingPiece = false;
+  @tracked isAddingSignedPiece = false;
 
   @tracked piece;
   @tracked documentContainer;
@@ -112,6 +113,18 @@ export default class DocumentsDocumentCardComponent extends Component {
         (!this.args.agendaitem && this.args.decisionActivity) ||
         (!this.args.agendaitem && !this.args.decisionActivity && this.args.meeting)
       )
+    );
+  }
+
+  /**
+   * see if the user may add a signed piece (by replacing the current pdf by a signed one)
+   * Afterwards we will trigger the strip/flatten features on that new pdf
+   */
+  get mayAddSignedPiece() {
+    return (
+      !this.signMarkingActivity &&
+      !this.piece.signedPiece?.get('id') && // TODO this could be removed, it also works if signedPieces exist
+      this.currentSession.may('add-signed-piece')
     );
   }
 
@@ -510,5 +523,10 @@ export default class DocumentsDocumentCardComponent extends Component {
   async cancelEditPiece() {
     await this.loadPieceRelatedData.perform();
     this.isEditingPiece = false;
+  }
+
+  cancelAddSignedPiece = async() => {
+    await this.loadPieceRelatedData.perform();
+    this.isAddingSignedPiece = false;
   }
 }

--- a/app/components/documents/document-card/add-signed-piece-modal.hbs
+++ b/app/components/documents/document-card/add-signed-piece-modal.hbs
@@ -1,0 +1,45 @@
+<ConfirmationModal
+  @modalOpen={{true}}
+  @title={{t "upload-signed-file"}}
+  @onConfirm={{perform this.saveEdit}}
+  @onCancel={{this.cancelEdit}}
+  @confirmMessage={{t "save"}}
+  @loading={{this.saveEdit.isRunning}}
+  @disabled={{this.isDisabled}}
+>
+  <:body>
+    <AuCard @size="small" class="au-u-margin-top-small" as |c|>
+      <c.content>
+        <div class="auk-form-group">
+          <AuLabel for="name">{{t "name-document"}}</AuLabel>
+          <div class="au-u-flex au-u-flex--spaced-small">
+            <span>
+              {{@piece.name}}
+            </span>
+          </div>
+        </div>
+      </c.content>
+    </AuCard>
+    <AuCard @size="small" class="au-u-margin-top-small" as |c|>
+      <c.content>
+        <div class="auk-form-group">
+          <AuLabel for="type">{{t "upload-signed-file"}}</AuLabel>
+          {{!-- {{#if this.replacementFile}} --}}
+            <AuAlert @skin="warning" @icon="alert-triangle">
+              <p>{{t "replace-signed-document-warning"}}</p>
+              <p>{{t "replace-signed-document-warning-extra"}}</p>
+              <p>{{t "action-cannot-be-undone"}}</p>
+            </AuAlert>
+          {{!-- {{/if}} --}}
+          <Auk::FileUploader
+            @multiple={{false}}
+            @onUpload={{set this "replacementFile"}}
+            @onQueueUpdate={{this.handleReplacementFileUploadQueue}}
+            @validateFile={{this.validateFile}}
+            @dropzoneMessage="document-accepted-only-pdf"
+          />
+        </div>
+      </c.content>
+    </AuCard>
+  </:body>
+</ConfirmationModal>

--- a/app/components/documents/document-card/add-signed-piece-modal.js
+++ b/app/components/documents/document-card/add-signed-piece-modal.js
@@ -1,0 +1,108 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+import { task } from 'ember-concurrency';
+import CopyErrorToClipboardToast from 'frontend-kaleidos/components/utils/toaster/copy-error-to-clipboard-toast';
+
+export default class DocumentsDocumentCardAddSignedPieceModalComponent extends Component {
+  /**
+   * @param {Piece} piece: the piece we will be editing
+   * @param {Function} onSave: the action to execute after saving changes
+   * @param {Function} onCancel: the action to execute after cancelling the edit
+   */
+  @service intl;
+  @service toaster;
+  @service documentService;
+
+  @tracked isUploadingReplacementFile = false;
+  @tracked replacementFile;
+
+  constructor() {
+    super(...arguments);
+  }
+
+  get isDisabled() {
+    return (
+      !this.replacementFile ||
+      this.saveEdit.isRunning ||
+      this.isUploadingReplacementFile
+    );
+  }
+
+  saveEdit = task(async () => {
+    // save button will be disabled anyway if there is no file
+    if (!this.replacementFile) {
+      // TODO throw error? should be unreachable unless disabled param is removed
+      return this.args.onCancel?.();
+    }
+    // 1 use case: remove the current PDF file (if any, derived or source) and use the new PDF file, call pdf strip feature
+    const oldFile = await this.args.piece.file;
+    const derivedFile = await oldFile?.derived;
+    if (derivedFile) {
+      oldFile.derived = null;
+      await derivedFile.destroyRecord();
+      oldFile.derived = this.replacementFile;
+      await oldFile.save();
+    } else {
+      // either we replace a PDF or add a derived
+      if (oldFile?.extension.toLowerCase() === 'pdf') {
+        await oldFile.destroyRecord();
+        this.args.piece.file = this.replacementFile;
+      } else {
+        // this could mean a missing oldFile and will fail in that case
+        oldFile.derived = this.replacementFile;
+        await oldFile.save();
+      }
+    }
+    await this.args.piece.save();
+    try {
+      await this.documentService.triggerSignatureRemoval(this.args.piece);
+      // TODO KAS-4921 what if the uploaded file does not contain a signature? we removed the stamped pdf, but get an error here so the new pdf isn't stamped
+      // TODO KAS-4921 in testing, I allowed this action when signedPieces exist (it works just fine) but when errors happen here the signedpiece and copy are not removed
+      if (this.args.piece.stamp) {
+        await this.documentService.stampDocuments([this.args.piece]);
+      }
+    } catch (error) {
+      const signedPieceUploadErrorOptions = {
+        title: this.intl.t('warning-title'),
+        errorContent: error.message,
+        showDatetime: true,
+        options: {
+          timeOut: 60 * 10 * 1000,
+        },
+      };
+      this.toaster.show(
+        CopyErrorToClipboardToast,
+        signedPieceUploadErrorOptions,
+      );
+    }
+
+    this.args.onSave?.();
+    this.replacementFile = null;
+  });
+
+  validateFile = (file) => {
+    const extension = file.name.split('.').pop();
+    const isPDF = extension.toLowerCase() === 'pdf';
+    if (!isPDF) {
+      this.toaster.error(
+        this.intl.t('document-incorrect-file-type', { name: file.name }),
+        this.intl.t('document-accepted-only-pdf'),
+      );
+      return false;
+    }
+  };
+
+  handleReplacementFileUploadQueue = ({
+    uploadIsRunning,
+    uploadIsCompleted,
+  }) => {
+    this.isUploadingReplacementFile = uploadIsRunning && !uploadIsCompleted;
+  };
+
+  cancelEdit = async () => {
+    await this.replacementFile?.destroyRecord();
+    this.replacementFile = null;
+    this.args.onCancel?.();
+  };
+}

--- a/app/components/documents/document-card/edit-modal.js
+++ b/app/components/documents/document-card/edit-modal.js
@@ -162,7 +162,7 @@ export default class DocumentsDocumentCardEditModalComponent extends Component {
       // reload after the possible oldFile.save happened
       const fileToDestroy = await this.args.piece.file;
       this.args.piece.file = this.replacementSourceFile;
-      await fileToDestroy.destroyRecord();
+      await fileToDestroy?.destroyRecord();
       try {
         await this.fileConversionService.convertSourceFile(
           this.replacementSourceFile

--- a/app/config/permissions.js
+++ b/app/config/permissions.js
@@ -85,6 +85,7 @@ const {
 // - upload-any-submission-document-extension: no enforced restrictions on mime-type/extension of document uploaded (submission mostly)
 // - remove-piece-from-parliament
 // - manage-agendaitems-with-parliament-flow
+// - add-signed-piece: replacing a main piece or derived piece with a signed pdf and run strip/flatten
 
 const groups = [
   {
@@ -150,6 +151,7 @@ const groups = [
         'remove-piece-from-parliament',
         'manage-agendaitems-with-parliament-flow',
         'edit-draft-document-access-levels',
+        'add-signed-piece',
       ]
     }
   },

--- a/app/services/document-service.js
+++ b/app/services/document-service.js
@@ -53,7 +53,7 @@ export default class DocumentService extends Service {
           const stampingToaster = this.toaster.loading(data.message, null, {
             timeOut: 60000,
           });
-          await this.handleStampingErrors(stampingJob, stampingToaster);
+          await this.handleStampingErrors(stampingJob, stampingToaster, pieceIds.length > 1);
         } else {
           this.toaster.warning(data.message, null, {
             timeOut: 5000,
@@ -178,14 +178,19 @@ export default class DocumentService extends Service {
     }
   }
 
-  async handleStampingErrors(job, toasterToClose) {
+  async handleStampingErrors(job, toasterToClose, multiplePieces = true) {
     await this.jobMonitor.register(job, async (job) => {
       setTimeout(() => {
         this.toaster.close(toasterToClose);
       }, 2000);
       if (job.status === job.SUCCESS) {
+        this.toaster.close(toasterToClose);
         this.toaster.success(
-          this.intl.t('succes-stamping-documents'),
+          this.intl.t(
+            multiplePieces
+              ? 'success-stamping-documents'
+              : 'success-stamping-single-document',
+          ),
         );
       } else {
         this.toaster.show(CopyErrorToClipboardToast, {
@@ -219,5 +224,36 @@ export default class DocumentService extends Service {
       }
     }
     return false;
+  }
+
+  // PDF-signature-remover service
+
+  async triggerSignatureRemoval(piece) {
+    const loadingToast = this.toaster.loading(
+      this.intl.t('strip-signature-loading-message'),
+      null,
+      {
+        timeOut: 10 * 60 * 1000,
+      },
+    );
+    const response = await fetch(
+      `/pdf-signature-remover/pieces/${piece.id}/strip`,
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/vnd.api+json',
+        },
+      },
+    );
+    try {
+      this.toaster.close(loadingToast);
+      await getJsonPayloadOrThrow(response);
+      this.toaster.success(this.intl.t('strip-signature-success-message'));
+    } catch (error) {
+      const message = error?.message ? `: ${error?.message}` : '';
+      throw new Error(
+        this.intl.t('strip-signature-error-message') + `${message}`,
+      );
+    }
   }
 }

--- a/app/utils/json-util.js
+++ b/app/utils/json-util.js
@@ -29,6 +29,9 @@ async function getJsonPayloadOrThrow(maybeJsonResponse) {
   if (!responseHasJson(maybeJsonResponse)) {
     // service most likely down or encountered database issues
     // TODO throw custom named error? this means timeout or database issues?? a non JSON response
+    if (maybeJsonResponse.status === 204) {
+      return; // no content, no errors
+    }
     throw new Error(
       `Backend returned an unexpected response (status: ${maybeJsonResponse.statusText}) from fetching url: ${maybeJsonResponse.url}`
     );

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1467,7 +1467,8 @@
   "error-while-sending-document-naming-mapping": "Er ging iets fout tijdens het toepassen van de VR nummers. Er is geen mapping beschikbaar",
   "error-while-searching-document-naming-job": "Er is geen lopende VR nummering job gevonden.",
   "error-while-stamping-document": "Er ging iets fout tijdens het stempelen van de documenten.",
-  "succes-stamping-documents": "De documenten zijn gestempeld.",
+  "success-stamping-documents": "De documenten zijn gestempeld.",
+  "success-stamping-single-document": "Het document is gestempeld.",
   "cabinet-submissions": "Kabinetten Indienen",
   "ikw": "IKW",
   "kc-group": "KC-groep",
@@ -1532,5 +1533,14 @@
   "shortlist-publication-error-message": "De lijst op te starten publicaties kon niet opgevraagd worden",
   "error-getting-related-subcase-agendas": "De lijst relevante agendas van deze procedurestap kan niet worden geladen",
   "replace-submission-document-warning": "Let op, bij opslaan wordt het originele document in Kaleidos volledig vervangen door het nieuwe bestand. Deze actie kan niet ongedaan worden gemaakt.",
-  "replace-file": "Bestand vervangen"
+  "replace-file": "Bestand vervangen",
+  "upload-signed-file": "Getekend bestand uploaden",
+  "replace-signed-document-warning": "Let op, bij opslaan wordt het originele pdf document in Kaleidos volledig vervangen door het nieuwe getekende bestand en automatisch omgezet tot een ongetekend pdf bestand + pdf bestand (met certificaat) + pdf bestand (ondertekend).",
+  "replace-signed-document-warning-extra": "Indien er reeds getekend bestanden \"(met certificaat)\" en/of \"(ondertekend)\" gekoppeld zijn, zullen die ook worden verwijderd.",
+  "document-accepted-only-pdf": "Enkel het bestandsformaat pdf is toegestaan.",
+  "document-incorrect-file-type": "Het document \"{name}\" heeft een ongeldig formaat en kan niet worden opgeladen.",
+  "strip-signature-loading-message": "Bestand omzetten naar een ongetekend bestand.",
+  "strip-signature-success-message": "Bestand omgezet naar een ongetekend bestand.",
+  "strip-signature-error-message": "Het opgeladen getekend pdf bestand kan niet worden omgezet naar een ongetekend bestand.",
+  "action-cannot-be-undone": "Deze actie kan niet ongedaan gemaakt worden."
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4921

- added new modal, based on the one from draft-piece file replacements
- added action as dropdown option to document-card only (do we want it in document-viewer? then extract main logic to service)
- added translations
- added endpoint call to pdf-signature-remover (is documentService the right service? or signatureService? I choose the former)
- added permission

sidetracking:
- fixed "succes" typos
- fixed document stamping toasts being weird (loading toast still showing while success toast is showing)
- fixed document stamping showing plural text on single document stamping
- fixed replace source file wasn't possible if source file was missing (error instead of accepting the new file, in the edit-modal)
- json-util couldn't handle 204 (no-content) responses


- [ ] https://github.com/kanselarij-vlaanderen/pdf-signature-remover/pull/9
