### PR TITLE
KAS-5102 Add prevent unload on accepting submission

### DIFF
--- a/app/components/submission/header.hbs
+++ b/app/components/submission/header.hbs
@@ -217,7 +217,11 @@
     <Auk::Modal::Body>
       {{#let (await @submission.pieces) as |pieces|}}
         {{#if pieces.length}}
-          <Auk::Loader @message={{concat (t "save-in-progress") " " (t "documents-creating-progress-message" count=this.piecesMovedCounter total=pieces.length)}} />
+          {{#if (eq this.piecesMovedCounter pieces.length)}}
+            <Auk::Loader @message={{concat (t "save-in-progress") " " (t "dont-close-the-page")}} />
+          {{else}}
+            <Auk::Loader @message={{concat (t "save-in-progress") " " (t "documents-creating-progress-message" count=this.piecesMovedCounter total=pieces.length)}} />
+          {{/if}}
         {{else}}
           <Auk::Loader @message={{t "save-in-progress"}} />
         {{/if}}

--- a/app/components/submission/header.js
+++ b/app/components/submission/header.js
@@ -23,6 +23,7 @@ export default class SubmissionHeaderComponent extends Component {
   @service draftSubmissionService;
   @service pieceAccessLevelService;
   @service signatureService;
+  @service preventUnload;
 
   @tracked isOpenResubmitModal;
   @tracked isOpenCreateSubcaseModal;
@@ -272,8 +273,6 @@ export default class SubmissionHeaderComponent extends Component {
     const selectedMeeting = meeting?.id ? meeting : this.selectedMeeting;
     const comment = meeting?.id ? remarks : this.comment;
 
-    // TODO  remove old status change??
-
     await this._updateSubmission(
       CONSTANTS.SUBMISSION_STATUSES.INGEDIEND,
       comment,
@@ -369,6 +368,7 @@ export default class SubmissionHeaderComponent extends Component {
           this.intl.t('warning-title')
         );
       }
+      this.preventUnload.enable();
       this.toggleCreateSubcaseModal();
       const now = new Date();
       const trimmedShortTitle = trimText(this.args.submission.shortTitle);
@@ -496,6 +496,7 @@ export default class SubmissionHeaderComponent extends Component {
 
       this.args.submission.subcase = subcase;
       await this._updateSubmission(CONSTANTS.SUBMISSION_STATUSES.BEHANDELD);
+      this.preventUnload.disable();
       this.router.transitionTo(
         'cases.case.subcases.subcase',
         decisionmakingFlow.id,

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1542,5 +1542,6 @@
   "strip-signature-loading-message": "Bestand omzetten naar een ongetekend bestand.",
   "strip-signature-success-message": "Bestand omgezet naar een ongetekend bestand.",
   "strip-signature-error-message": "Het opgeladen getekend pdf bestand kan niet worden omgezet naar een ongetekend bestand.",
-  "action-cannot-be-undone": "Deze actie kan niet ongedaan gemaakt worden."
+  "action-cannot-be-undone": "Deze actie kan niet ongedaan gemaakt worden.",
+  "dont-close-the-page": "Gelieve de pagina niet te sluiten."
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5102

- added prevent unloader. ( on backend error it will not be removed, but any error breaks the entire flow anyway)
- added a message to indicate that the page should not be closed after moving/copying the draft pieces (it should indicate to the user that we are doing stuff)


I tried changing the message on page close but it doesn't seem possible.
So only the default text is shown on page closing.