### PR TITLE
Feature/KAS-5061 newsitems being edited by

### DIFF
--- a/app/components/news-item/edit-panel.hbs
+++ b/app/components/news-item/edit-panel.hbs
@@ -166,7 +166,7 @@
               <AuButton
                 data-test-news-item-edit-item-cancel
                 @skin="naked"
-                {{on "click" @onCancel}}
+                {{on "click" this.cancel}}
               >
                 {{t "cancel"}}
               </AuButton>
@@ -195,7 +195,7 @@
   @title={{t "no-themes-selected"}}
   @message={{t "no-themes-selected-message"}}
   @onConfirm={{perform this.confirmSave}}
-  @onCancel={{this.cancelSave}}
+  @onCancel={{this.cancel}}
   @confirmMessage={{t "save"}}
   @loading={{this.confirmSave.isRunning}}
 />

--- a/app/components/news-item/edit-panel.hbs
+++ b/app/components/news-item/edit-panel.hbs
@@ -53,6 +53,20 @@
     {{#unless this.ensureNewsItem.isRunning}}
       <Auk::Panel::Body>
         <div class="au-c-form">
+          {{#if this.showBeingEditedByWarning}}
+            <AuAlert
+              @skin="warning"
+              @icon="alert-triangle"
+              @size="small"
+            >
+              {{t
+                "newsitems-being-edited-by"
+                date=(date-phrase this.newsItem.modified)
+                time=(time this.newsItem.modified)
+                name=this.newsItem.isBeingEditedBy.fullName
+              }}
+            </AuAlert>
+          {{/if}}
           <AuFormRow>
             <AuLabel>{{t "title"}}</AuLabel>
             <p

--- a/app/components/news-item/edit-panel.js
+++ b/app/components/news-item/edit-panel.js
@@ -39,6 +39,7 @@ export default class NewsItemEditPanelComponent extends Component {
 
   get showBeingEditedByWarning() {
     return (
+      this.currentSession.may('manage-news-items') &&
       this.ensureNewsItem.isIdle &&
       this.newsItem.isBeingEditedBy?.id &&
       this.newsItem.isBeingEditedBy?.id != this.currentSession.user.id

--- a/app/components/news-item/edit-panel.js
+++ b/app/components/news-item/edit-panel.js
@@ -9,6 +9,7 @@ export default class NewsItemEditPanelComponent extends Component {
   @service newsletterService;
   @service agendaitemNota;
   @service preventUnload;
+  @service currentSession;
 
   editorController;
   @tracked newsItem;
@@ -36,6 +37,14 @@ export default class NewsItemEditPanelComponent extends Component {
     return this.isFullscreen ? 'fullscreen' : this.args.size;
   }
 
+  get showBeingEditedByWarning() {
+    return (
+      this.ensureNewsItem.isIdle &&
+      this.newsItem.isBeingEditedBy?.id &&
+      this.newsItem.isBeingEditedBy?.id != this.currentSession.user.id
+    );
+  }
+
   @task
   *ensureNewsItem() {
     this.newsItem = this.args.newsItem;
@@ -44,14 +53,14 @@ export default class NewsItemEditPanelComponent extends Component {
       this.newsItem = yield this.newsletterService.createNewsItemForAgendaitem(this.args.agendaitem);
       if (this.newsItem) {
         // If the service call returned a newsItem, it is new and we save immediately to avoid concurrency issues
-        yield this.newsItem.startEditing(this.newsItemIsNew);
+        yield this.newsItem.startEditingByUser(this.currentSession.user, this.newsItemIsNew);
         this.preventUnload.enable();
       } else {
         // If the service call returned nothing, it means someone else created a newsitem and we have to refresh
-        return this.args.onCancel(this.newsItemIsNew);
+        return this.args.onCancel(null, this.newsItemIsNew);
       }
     } else {
-      yield this.newsItem.startEditing();
+      yield this.newsItem.startEditingByUser(this.currentSession.user);
       this.preventUnload.enable();
     }
 
@@ -129,7 +138,7 @@ export default class NewsItemEditPanelComponent extends Component {
   @action
   async cancel() {
     this.preventUnload.disable();
-    await this.args.onCancel();
+    await this.args.onCancel(this.newsItem, this.newsItemIsNew);
     this.isOpenMissingThemesModal = false;
   }
 

--- a/app/components/news-item/edit-panel.js
+++ b/app/components/news-item/edit-panel.js
@@ -8,6 +8,7 @@ import { action } from '@ember/object';
 export default class NewsItemEditPanelComponent extends Component {
   @service newsletterService;
   @service agendaitemNota;
+  @service preventUnload;
 
   editorController;
   @tracked newsItem;
@@ -43,11 +44,15 @@ export default class NewsItemEditPanelComponent extends Component {
       this.newsItem = yield this.newsletterService.createNewsItemForAgendaitem(this.args.agendaitem);
       if (this.newsItem) {
         // If the service call returned a newsItem, it is new and we save immediately to avoid concurrency issues
-        yield this.newsItem.save();
+        yield this.newsItem.startEditing(this.newsItemIsNew);
+        this.preventUnload.enable();
       } else {
         // If the service call returned nothing, it means someone else created a newsitem and we have to refresh
         return this.args.onCancel(this.newsItemIsNew);
       }
+    } else {
+      yield this.newsItem.startEditing();
+      this.preventUnload.enable();
     }
 
     this.title = this.newsItem.title;
@@ -116,12 +121,15 @@ export default class NewsItemEditPanelComponent extends Component {
     } catch {
       // pass
     }
+    this.preventUnload.disable();
     yield this.args.onSave(this.newsItem, this.newsItemIsNew);
     this.isOpenMissingThemesModal = false;
   }
 
   @action
-  cancelSave() {
+  async cancel() {
+    this.preventUnload.disable();
+    await this.args.onCancel();
     this.isOpenMissingThemesModal = false;
   }
 

--- a/app/components/news-item/print.js
+++ b/app/components/news-item/print.js
@@ -6,6 +6,7 @@ import { task } from 'ember-concurrency';
 
 export default class NewsItemPrintComponent extends Component {
   @service newsletterService;
+  @service currentSession;
 
   @tracked proposalText;
   @tracked themes;
@@ -25,18 +26,20 @@ export default class NewsItemPrintComponent extends Component {
   }
 
   @action
-  openEdit() {
+  async openEdit() {
+    await this.args.newsItem?.preEditOrSaveCheck();
     this.isEditing = true;
   }
 
   @action
-  closeEdit() {
+  async closeEdit() {
+    await this.args.newsItem?.stopEditingOnCancel(this.currentSession.user);
     this.isEditing = false;
   }
 
   @action
   async save() {
-    await this.args.onSave();
-    this.closeEdit();
+    await this.args.onSave(this.args.newsItem);
+    this.isEditing = false;
   }
 }

--- a/app/components/news-item/table-row.js
+++ b/app/components/news-item/table-row.js
@@ -9,6 +9,7 @@ export default class NewsItemTableRowComponent extends Component {
   @service toaster;
   @service intl;
   @service agendaitemNota;
+  @service currentSession;
 
   @tracked isOpenEditView = false;
   @tracked notaOrVisieNota;
@@ -37,8 +38,9 @@ export default class NewsItemTableRowComponent extends Component {
 
   @task
   *saveNewsItem(newsItem, wasNewsItemNew) {
-    yield this.args.onSave(newsItem, wasNewsItemNew);
-    this.closeEditView();
+    yield newsItem.stopEditingOnSave();
+    yield this.args.onSave(wasNewsItemNew);
+    this.isOpenEditView = false;
   }
 
   @task
@@ -51,7 +53,8 @@ export default class NewsItemTableRowComponent extends Component {
   @task
   *toggleInNewsletterFlag(checked) {
     this.args.newsItem.inNewsletter = checked;
-    yield this.saveNewsItem.perform(this.args.newsItem);
+    yield this.args.newsItem.save(); // not setting/unsetting isbeingEditedBy
+    yield this.args.onSave();
   }
 
   @action
@@ -68,7 +71,8 @@ export default class NewsItemTableRowComponent extends Component {
   }
 
   @action
-  closeEditView(wasNewsItemNew) {
+  async closeEditView(newsItem, wasNewsItemNew) {
+    await newsItem?.stopEditingOnCancel(this.currentSession.user);
     this.args.onCancel(wasNewsItemNew);
     this.isOpenEditView = false;
   }

--- a/app/controllers/agenda/agendaitems/agendaitem/news-item.js
+++ b/app/controllers/agenda/agendaitems/agendaitem/news-item.js
@@ -26,6 +26,7 @@ export default class NewsItemAgendaitemAgendaitemsAgendaController extends Contr
 
   get showBeingEditedByWarning() {
     return (
+      this.currentSession.may('manage-news-items') &&
       !this.isEditing &&
       this.model &&
       this.model.isBeingEditedBy?.id &&

--- a/app/controllers/agenda/agendaitems/agendaitem/news-item.js
+++ b/app/controllers/agenda/agendaitems/agendaitem/news-item.js
@@ -24,6 +24,15 @@ export default class NewsItemAgendaitemAgendaitemsAgendaController extends Contr
     return !this.hideNotaModificationWarning && this.notaHasChanged;
   }
 
+  get showBeingEditedByWarning() {
+    return (
+      !this.isEditing &&
+      this.model &&
+      this.model.isBeingEditedBy?.id &&
+      this.model.isBeingEditedBy.id != this.currentSession.user.id
+    );
+  }
+
   @action
   async openFullscreenEdit() {
     await this.model?.preEditOrSaveCheck();
@@ -44,9 +53,9 @@ export default class NewsItemAgendaitemAgendaitemsAgendaController extends Contr
       // there is no model here on first creation.
       const agendaitemTreatment = await this.agendaitem.treatment;
       const newsItem = await agendaitemTreatment.belongsTo('newsItem').reload();
-      await newsItem?.stopEditingOnCancel();
+      await newsItem?.stopEditingOnCancel(this.currentSession.user);
     } else {
-      await this.model.stopEditingOnCancel();
+      await this.model.stopEditingOnCancel(this.currentSession.user);
     }
     this.isEditing = false;
     this.preventUnload.disable();

--- a/app/controllers/agenda/agendaitems/agendaitem/news-item.js
+++ b/app/controllers/agenda/agendaitems/agendaitem/news-item.js
@@ -6,6 +6,8 @@ import { inject as service } from '@ember/service';
 
 export default class NewsItemAgendaitemAgendaitemsAgendaController extends Controller {
   @service router;
+  @service currentSession;
+  @service preventUnload;
 
   @tracked agendaitem;
   @tracked notaModifiedTime;
@@ -37,17 +39,35 @@ export default class NewsItemAgendaitemAgendaitemsAgendaController extends Contr
   }
 
   @action
-  closeEdit(wasNewsItemNew) {
+  async stopEditing() {
+    if (!this.model) {
+      // there is no model here on first creation.
+      const agendaitemTreatment = await this.agendaitem.treatment;
+      const newsItem = await agendaitemTreatment.belongsTo('newsItem').reload();
+      await newsItem?.stopEditingOnCancel();
+    } else {
+      await this.model.stopEditingOnCancel();
+    }
     this.isEditing = false;
+    this.preventUnload.disable();
+    this.router.refresh('agenda.agendaitems.agendaitem.news-item');
+  }
+
+  @task
+  *closeEdit(wasNewsItemNew) {
     if (wasNewsItemNew) {
+      this.isEditing = false;
       this.router.refresh('agenda.agendaitems.agendaitem.news-item');
+    } else {
+      yield this.stopEditing();
     }
   }
 
   @task
   *saveNewsItem(newsItem, wasNewsItemNew) {
-    yield newsItem.save();
+    yield newsItem.stopEditingOnSave();
     this.isEditing = false;
+    this.preventUnload.disable();
     if (wasNewsItemNew) {
       this.router.refresh('agenda.agendaitems.agendaitem.news-item');
     }

--- a/app/controllers/newsletter/index.js
+++ b/app/controllers/newsletter/index.js
@@ -1,6 +1,5 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
-import { task } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 
@@ -13,9 +12,8 @@ export default class NewsletterController extends Controller {
 
   @tracked sort = 'number';
 
-  @task
-  *saveNewsItem(newsItem, wasNewsItemNew) {
-    yield newsItem.save();
+  @action
+  async saveNewsItem(wasNewsItemNew) {
     if (wasNewsItemNew) {
       this.router.refresh('newsletter.index');
     }
@@ -23,7 +21,7 @@ export default class NewsletterController extends Controller {
   }
 
   @action
-  cancelEdit(wasNewsItemNew) {
+  async cancelEdit(wasNewsItemNew) {
     if (wasNewsItemNew) {
       this.router.refresh('newsletter.index');
     }

--- a/app/controllers/newsletter/print.js
+++ b/app/controllers/newsletter/print.js
@@ -15,6 +15,6 @@ export default class PrintNewsletterController extends Controller {
 
   @task
   *saveNewsItem(newsItem) {
-    yield newsItem.save();
+    yield newsItem.stopEditingOnSave();
   }
 }

--- a/app/models/news-item.js
+++ b/app/models/news-item.js
@@ -1,9 +1,7 @@
 import { attr, belongsTo, hasMany } from '@ember-data/model';
 import ModelWithModifier from 'frontend-kaleidos/models/model-with-modifier';
-import { inject as service } from '@ember/service';
 
 export default class NewsItem extends ModelWithModifier {
-  @service currentSession;
   @attr title;
   @attr subtitle;
   @attr htmlContent;
@@ -23,13 +21,13 @@ export default class NewsItem extends ModelWithModifier {
 
   @hasMany('theme', { inverse: null, async: true}) themes;
 
-  async startEditing(newsItemIsNew) {
+  async startEditingByUser(currentUser, newsItemIsNew) {
     await this.belongsTo('isBeingEditedBy').reload();
     if (!newsItemIsNew) {
       await this.preEditOrSaveCheck();
     }
-    if (this.currentSession.user.id && !this.isBeingEditedBy?.id) {
-      this.isBeingEditedBy = this.currentSession.user;
+    if (currentUser?.id && !this.isBeingEditedBy?.id) {
+      this.isBeingEditedBy = currentUser;
       return super.save(...arguments);
     }
   }
@@ -41,9 +39,9 @@ export default class NewsItem extends ModelWithModifier {
     return super.save(...arguments);
   }
 
-  async stopEditingOnCancel() {
+  async stopEditingOnCancel(currentUser) {
     await this.belongsTo('isBeingEditedBy').reload();
-    if (this.currentSession.user.id != this.isBeingEditedBy?.id) {
+    if (currentUser.id != this.isBeingEditedBy?.id) {
       return; // no save, canceled
     }
     await this.preEditOrSaveCheck();

--- a/app/models/news-item.js
+++ b/app/models/news-item.js
@@ -1,7 +1,9 @@
 import { attr, belongsTo, hasMany } from '@ember-data/model';
 import ModelWithModifier from 'frontend-kaleidos/models/model-with-modifier';
+import { inject as service } from '@ember/service';
 
 export default class NewsItem extends ModelWithModifier {
+  @service currentSession;
   @attr title;
   @attr subtitle;
   @attr htmlContent;
@@ -17,6 +19,35 @@ export default class NewsItem extends ModelWithModifier {
 
   @belongsTo('agenda-item-treatment', { inverse: 'newsItem', async: true })
   agendaItemTreatment;
+  @belongsTo('user', { inverse: null, async: true }) isBeingEditedBy;
 
   @hasMany('theme', { inverse: null, async: true}) themes;
+
+  async startEditing(newsItemIsNew) {
+    await this.belongsTo('isBeingEditedBy').reload();
+    if (!newsItemIsNew) {
+      await this.preEditOrSaveCheck();
+    }
+    if (this.currentSession.user.id && !this.isBeingEditedBy?.id) {
+      this.isBeingEditedBy = this.currentSession.user;
+      return super.save(...arguments);
+    }
+  }
+
+  async stopEditingOnSave() {
+    await this.belongsTo('isBeingEditedBy').reload();
+    await this.preEditOrSaveCheck();
+    this.isBeingEditedBy = undefined;
+    return super.save(...arguments);
+  }
+
+  async stopEditingOnCancel() {
+    await this.belongsTo('isBeingEditedBy').reload();
+    if (this.currentSession.user.id != this.isBeingEditedBy?.id) {
+      return; // no save, canceled
+    }
+    await this.preEditOrSaveCheck();
+    this.isBeingEditedBy = undefined;
+    return super.save(...arguments);
+  }
 }

--- a/app/routes/agenda/agendaitems/agendaitem/news-item.js
+++ b/app/routes/agenda/agendaitems/agendaitem/news-item.js
@@ -29,7 +29,7 @@ export default class NewsitemAgendaitemAgendaitemsAgendaRoute extends Route {
     });
   }
 
-  async afterModel() {
+  async afterModel(model) {
     const nota = await this.store.findRecordByUri(
       'concept',
       CONSTANTS.DOCUMENT_TYPES.NOTA,
@@ -38,6 +38,7 @@ export default class NewsitemAgendaitemAgendaitemsAgendaRoute extends Route {
       'concept',
       CONSTANTS.DOCUMENT_TYPES.VISIENOTA,
     );
+    await model?.belongsTo('isBeingEditedBy').reload();
     // Get most recent version of document with type 'Nota' or 'VisieNota',
     // but only if there are multiple versions of the document
     const latestNotaVersion = await this.store.queryOne('piece', {

--- a/app/templates/agenda/agendaitems/agendaitem/news-item.hbs
+++ b/app/templates/agenda/agendaitems/agendaitem/news-item.hbs
@@ -9,7 +9,7 @@
       {{#if this.isEditing}}
         <AuButton
           @skin="link"
-          {{on "click" this.closeEdit}}
+          {{on "click" this.stopEditing}}
         >
           {{t "cancel"}}
         </AuButton>
@@ -56,12 +56,22 @@
     @buttonText={{t "close"}}
     @onConfirm={{this.dismissNotaModifiedWarning}} />
 {{/if}}
+{{!-- there is no model yet to show on initial create --}}
+{{#if this.model.isBeingEditedBy}}
+  <AuAlert
+    @skin="warning"
+    @icon="alert-triangle"
+    @size="small"
+  >
+    {{t "newsitems-being-edited-by" name=this.model.isBeingEditedBy.fullName}}
+  </AuAlert>
+{{/if}}
 {{#if this.isEditing}}
   <NewsItem::EditPanel
     @newsItem={{this.model}}
     @agendaitem={{this.agendaitem}}
     @isFullscreen={{this.isFullscreen}}
-    @onCancel={{this.closeEdit}}
+    @onCancel={{perform this.closeEdit}}
     @onSave={{perform this.saveNewsItem}}
   />
 {{else}}

--- a/app/templates/agenda/agendaitems/agendaitem/news-item.hbs
+++ b/app/templates/agenda/agendaitems/agendaitem/news-item.hbs
@@ -56,16 +56,6 @@
     @buttonText={{t "close"}}
     @onConfirm={{this.dismissNotaModifiedWarning}} />
 {{/if}}
-{{!-- there is no model yet to show on initial create --}}
-{{#if this.model.isBeingEditedBy}}
-  <AuAlert
-    @skin="warning"
-    @icon="alert-triangle"
-    @size="small"
-  >
-    {{t "newsitems-being-edited-by" name=this.model.isBeingEditedBy.fullName}}
-  </AuAlert>
-{{/if}}
 {{#if this.isEditing}}
   <NewsItem::EditPanel
     @newsItem={{this.model}}
@@ -75,6 +65,20 @@
     @onSave={{perform this.saveNewsItem}}
   />
 {{else}}
+  {{#if this.showBeingEditedByWarning}}
+    <AuAlert
+      @skin="warning"
+      @icon="alert-triangle"
+      @size="small"
+    >
+      {{t
+        "newsitems-being-edited-by"
+        date=(date-phrase this.model.modified)
+        time=(time this.model.modified)
+        name=this.model.isBeingEditedBy.fullName
+      }}
+    </AuAlert>
+  {{/if}}
   {{#if this.model}}
     <NewsItem::ViewPanel
       @newsItem={{this.model}}

--- a/app/templates/newsletter/index.hbs
+++ b/app/templates/newsletter/index.hbs
@@ -42,7 +42,7 @@
           <NewsItem::TableRow
             @agendaitem={{item.agendaitem}}
             @newsItem={{item.newsItem}}
-            @onSave={{perform this.saveNewsItem}}
+            @onSave={{this.saveNewsItem}}
             @onCancel={{this.cancelEdit}}
           />
         {{/each}}

--- a/cypress/e2e/unit/rdfa-editor.cy.js
+++ b/cypress/e2e/unit/rdfa-editor.cy.js
@@ -48,8 +48,10 @@ context('rdfa editor tests', () => {
   // RDFA tests can be flaky locally when having dev tools open or when running in background (not in focus)
   it('should test the rdfa editor keypresses', () => {
     cy.visitAgendaWithLink('/vergadering/5EBA94D7751CF70008000001/kort-bestek');
+    cy.intercept('PATCH', '/news-items/*').as('patchNewsItems1');
     cy.get(newsletter.buttonToolbar.edit).eq(0)
       .click();
+    cy.wait('@patchNewsItems1');
 
     cy.get(dependency.rdfaEditor.inner).type('{ctrl+u}Underline')
       .type('{ctrl+u} ');
@@ -84,11 +86,15 @@ context('rdfa editor tests', () => {
       .type('{del}')
       .type('{del}');
     cy.get(dependency.rdfaEditor.inner).should('not.contain', 'old');
+    cy.intercept('PATCH', '/news-items/*').as('patchNewsItems2');
     cy.get(newsletter.editItem.cancel).click();
+    cy.wait('@patchNewsItems2');
 
     // check enter
+    cy.intercept('PATCH', '/news-items/*').as('patchNewsItems3');
     cy.get(newsletter.buttonToolbar.edit).eq(0)
       .click();
+    cy.wait('@patchNewsItems3');
     cy.get(dependency.rdfaEditor.inner).find('br')
       .should('have.length', 1); // 1 br exists by default
     cy.get(dependency.rdfaEditor.inner).type('{enter}');
@@ -105,7 +111,9 @@ context('rdfa editor tests', () => {
       .type('test  test');
     cy.get(dependency.rdfaEditor.inner).should('contain', ' ');
     cy.get(dependency.rdfaEditor.inner).should('not.contain', '\u00a0');
+    cy.intercept('PATCH', '/news-items/*').as('patchNewsItems4');
     cy.get(newsletter.editItem.cancel).click();
+    cy.wait('@patchNewsItems4');
   });
 
   it('should test the rdfa editor buttonpresses', () => {
@@ -268,13 +276,16 @@ context('rdfa editor tests', () => {
       // in zebra view
       cy.visitAgendaWithLink('/vergadering/5EBA94D7751CF70008000001/kort-bestek');
       cy.get(newsletter.newsletterHeaderOverview.newsletterActions.optionsDropdown).should('be.visible');
+      cy.intercept('PATCH', '/news-items/*').as('patchNewsItems1');
       cy.get(newsletter.buttonToolbar.edit).eq(0)
-        .click();
+        .click();  // a patch happens here
+      cy.wait('@patchNewsItems1');
       cy.get(auk.expand).scrollIntoView()
         .click();
       cy.get(newsletter.newsletterHeaderOverview.newsletterActions.optionsDropdown).scrollIntoView()
         .shouldNotBeActionable(done);
       // no further testing possible
+      // we can't cancel here since the shouldNotBeActionable ends the testing, but isBeingEditedBy is still set
     });
 
     it('should test the zebra view fullscreen mode covers m-header', (done) => {
@@ -282,7 +293,7 @@ context('rdfa editor tests', () => {
       cy.visitAgendaWithLink('/vergadering/5EBA94D7751CF70008000001/kort-bestek');+
       cy.get(utils.mHeader.search).should('be.visible');
       cy.get(newsletter.buttonToolbar.edit).eq(0)
-        .click();
+        .click(); // no patch happens here since isBeingEditedBy is still set from previous test
       cy.get(newsletter.editItem.save).scrollIntoView()
         .should('be.visible');
       cy.get(newsletter.editItem.cancel).should('be.visible');
@@ -290,6 +301,7 @@ context('rdfa editor tests', () => {
         .click();
       cy.get(utils.mHeader.search).shouldNotBeActionable(done);
       // no further testing possible
+      // we can't cancel here since the shouldNotBeActionable ends the testing, but isBeingEditedBy is still set
     });
 
 
@@ -298,7 +310,7 @@ context('rdfa editor tests', () => {
       cy.visitAgendaWithLink('/vergadering/5EBA94D7751CF70008000001/kort-bestek');
       cy.get(newsletter.editItem.saveFullscreen).should('not.exist');
       cy.get(newsletter.buttonToolbar.edit).eq(0)
-        .click();
+        .click(); // no patch happens here since isBeingEditedBy is still set from previous test
       cy.get(auk.expand).scrollIntoView()
         .click();
       cy.get(newsletter.editItem.saveFullscreen).should('be.visible');
@@ -307,7 +319,10 @@ context('rdfa editor tests', () => {
       cy.get(newsletter.editItem.saveFullscreen).should('not.exist');
       cy.get(newsletter.editItem.save).scrollIntoView()
         .should('be.visible');
-      cy.get(newsletter.editItem.cancel).should('be.visible');
+      cy.intercept('PATCH', '/news-items/*').as('patchNewsItems');
+      cy.get(newsletter.editItem.cancel).should('be.visible')
+        .click();
+      cy.wait('@patchNewsItems'); // unset the isBeingEditedBy
     });
   });
 });

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1545,5 +1545,6 @@
   "action-cannot-be-undone": "Deze actie kan niet ongedaan gemaakt worden.",
   "dont-close-the-page": "Gelieve de pagina niet te sluiten.",
   "delete-subcase-and-restore-submission": "Procedurestap verwijderen en indiening behouden",
-  "delete-subcase-and-restore-submission-confirmation": "Bent u zeker dat u de procedurestap wilt verwijderen? De indiening status zal worden teruggezet naar \"in behandeling\"."
+  "delete-subcase-and-restore-submission-confirmation": "Bent u zeker dat u de procedurestap wilt verwijderen? De indiening status zal worden teruggezet naar \"in behandeling\".",
+  "newsitems-being-edited-by": "Dit kort bestek wordt momenteel bewerkt door {name}"
 }

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1546,5 +1546,5 @@
   "dont-close-the-page": "Gelieve de pagina niet te sluiten.",
   "delete-subcase-and-restore-submission": "Procedurestap verwijderen en indiening behouden",
   "delete-subcase-and-restore-submission-confirmation": "Bent u zeker dat u de procedurestap wilt verwijderen? De indiening status zal worden teruggezet naar \"in behandeling\".",
-  "newsitems-being-edited-by": "Dit kort bestek wordt momenteel bewerkt door {name}"
+  "newsitems-being-edited-by": "Dit kort bestek wordt bewerkt door {name} sinds {date} om {time}."
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5061


- [x] https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/537

TODO test a bit more.
changed 1 "actions up" to process the save/cancel deeper in the tree since I needed to save normally or save + remove the user.
In print view, the `preventUnload` doesn't work when switching between "klad" en "definitief" since we are staying in the same route but change the params instead
in zebra view, opening more than 1 edit panel and closing 1 means the other opened panels now have `preventUnload` disabled. Not sure how to counter that

Yggdrasil, We WILL be propagating this relation if not ignored/removed. (only when the relation exists after releasing decisions)
Perhaps hide the alert behind a permission instead of changing yggdrasil?  --- DONE
