### PR TITLE
KAS-5062 add filter to hide intermediate versions and ignore retracted/postponed

### DIFF
--- a/app/routes/newsletter/nota-updates.js
+++ b/app/routes/newsletter/nota-updates.js
@@ -48,6 +48,7 @@ export default class NewsletterNotaUpdatesRoute extends Route {
       'filter[agendaitems][type][:uri:]': CONSTANTS.AGENDA_ITEM_TYPES.NOTA,
       'filter[document-container][type][:id:]': [nota.id, visienota.id].join(','),
       'filter[:has:previous-piece]': 'yes', // "Enkel bissen, ter'en, etc" ...
+      'filter[:has-no:next-piece]': 'yes', // enkel laatste versie
       'filter[:has:created]': `date-added-for-cache-busting-${new Date().toISOString()}`,
       include: 'agendaitems',
       'fields[agendaitems]': 'id,number,short-title',
@@ -70,6 +71,20 @@ export default class NewsletterNotaUpdatesRoute extends Route {
           }
         }
       }
+      // don't process postponed/retracted agendaitems
+      const decisionActivity = await this.store.queryOne('decision-activity', {
+        'filter[treatment][agendaitems][:id:]': agendaitemOnLatestAgenda.id,
+      });
+      const decisionResultCode = await decisionActivity.decisionResultCode;
+      if (
+        [
+          CONSTANTS.DECISION_RESULT_CODE_URIS.UITGESTELD,
+          CONSTANTS.DECISION_RESULT_CODE_URIS.INGETROKKEN,
+        ].includes(decisionResultCode?.uri)
+      ) {
+        continue;
+      }
+
       const agendaitemNumber = agendaitemOnLatestAgenda.get('number');
       const agendaitemId = agendaitemOnLatestAgenda.get('id');
       const agendaitemShortTitle = agendaitemOnLatestAgenda.get('shortTitle');

--- a/cypress/e2e/unit/news-item.cy.js
+++ b/cypress/e2e/unit/news-item.cy.js
@@ -116,10 +116,25 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
     cy.openAgendaitemKortBestekTab(subcaseTitle1);
     cy.get(utils.changesAlert.container).should('not.exist');
     cy.visit('/vergadering/5EBA84900A655F0008000004/kort-bestek/nota-updates');
+    // decision is postponed now, nothing to see
+    cy.get(route.notaUpdates.dataTable).find('tbody')
+      .children('tr')
+      .should('have.length', 1)
+      .contains('Geen resultaten gevonden');
+    // change status to approved, newsitem will show in updates
+    cy.visitAgendaWithLink('/vergadering/5EBA84900A655F0008000004/agenda/5EBA84910A655F0008000005/agendapunten/5EBA84AE0A655F0008000008/kort-bestek');
+    cy.openAgendaitemKortBestekTab(subcaseTitle1);
+    cy.changeDecisionResult('Goedgekeurd');
+
+    cy.visit('/vergadering/5EBA84900A655F0008000004/kort-bestek/nota-updates');
     cy.get(route.notaUpdates.dataTable).find('tbody')
       .children('tr')
       .should('have.length', 1)
       .contains(subcaseTitle1);
+    // this was postponed before, so setting it back to not mess with other tests
+    cy.visitAgendaWithLink('/vergadering/5EBA84900A655F0008000004/agenda/5EBA84910A655F0008000005/agendapunten/5EBA84AE0A655F0008000008/kort-bestek');
+    cy.openAgendaitemKortBestekTab(subcaseTitle1);
+    cy.changeDecisionResult('Uitgesteld');
   });
 
   it('should test default newsletter values on nota', () => {


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5062

- add filter on "has-no" next piece. only the most recent version is shown in the list (tried locally where I saw 2 before fix, 1 after fix)
- add post query filtering of notas where agenditem is "retracted" or "postponed".
only notas are shown when the decision is "approved", "acknowledged" or undefined. (but agendaitem type has to be a nota)

Might want to test this on ACC on its own on large agendas (`decisionActivity` is not optional here since we shouldn't have a nota on an agendaitem without it except for maybe legacy, but this screen is not designed for legacy anyway...)