### PR TITLE
KAS-5079 add logic to keep and reapply newsitem and decision on sending back/resubmitting

### DIFF
--- a/app/components/agenda/agendaitem/agendaitem-controls.hbs
+++ b/app/components/agenda/agendaitem/agendaitem-controls.hbs
@@ -128,7 +128,13 @@
       @skin="warning"
       @icon="alert-triangle"
     >
-      <p>{{t "send-back-to-submitter-message"}}</p>
+      <p>
+        {{#if (is-nota @agendaitem.type)}}
+          {{t "send-back-to-submitter-keep-newsitem-message"}}
+        {{else}}
+          {{t "send-back-to-submitter-message"}}
+        {{/if}}
+      </p>
     </AuAlert>
     <div class="au-c-form">
       <AuFormRow>

--- a/app/components/agenda/agendaitem/agendaitem-controls.hbs
+++ b/app/components/agenda/agendaitem/agendaitem-controls.hbs
@@ -124,18 +124,20 @@
   @loading={{this.isSendingBackToSubmitter}}
 >
   <:body>
-    <AuAlert
-      @skin="warning"
-      @icon="alert-triangle"
-    >
-      <p>
-        {{#if (is-nota @agendaitem.type)}}
-          {{t "send-back-to-submitter-keep-newsitem-message"}}
-        {{else}}
-          {{t "send-back-to-submitter-message"}}
-        {{/if}}
-      </p>
-    </AuAlert>
+    {{#if (not this.isSendingBackToSubmitter)}}
+      <AuAlert
+        @skin="warning"
+        @icon="alert-triangle"
+      >
+        <p>
+          {{#if (is-nota @agendaitem.type)}}
+            {{t "send-back-to-submitter-keep-newsitem-message"}}
+          {{else}}
+            {{t "send-back-to-submitter-message"}}
+          {{/if}}
+        </p>
+      </AuAlert>
+    {{/if}}
     <div class="au-c-form">
       <AuFormRow>
         <AuLabel for="comment-title-send-back">{{t "comment-title"}}</AuLabel>

--- a/app/components/agenda/agendaitem/agendaitem-controls.js
+++ b/app/components/agenda/agendaitem/agendaitem-controls.js
@@ -207,8 +207,6 @@ export default class AgendaitemControls extends Component {
     this.showLoader = true;
     const agendaItemType = await agendaitem.type;
     const previousNumber = agendaitem.number > 1 ? agendaitem.number - 1 : agendaitem.number;
-    // TODO save newsitem and decision report on submission, don't delete the newsitem and repor
-    // Do I want to do this with a query instead of on the model?. maybe not having it in the frontend is better to avoid concurrency/graph issues
     if (this.isDeletable) {
       const keepDecisionAndNewsitem = agendaItemType.uri === CONSTANTS.AGENDA_ITEM_TYPES.NOTA;
       if (keepDecisionAndNewsitem) {

--- a/app/components/agenda/agendaitem/agendaitem-controls.js
+++ b/app/components/agenda/agendaitem/agendaitem-controls.js
@@ -207,8 +207,14 @@ export default class AgendaitemControls extends Component {
     this.showLoader = true;
     const agendaItemType = await agendaitem.type;
     const previousNumber = agendaitem.number > 1 ? agendaitem.number - 1 : agendaitem.number;
+    // TODO save newsitem and decision report on submission, don't delete the newsitem and repor
+    // Do I want to do this with a query instead of on the model?. maybe not having it in the frontend is better to avoid concurrency/graph issues
     if (this.isDeletable) {
-      await this.agendaService.deleteAgendaitem(agendaitem);
+      const keepDecisionAndNewsitem = agendaItemType.uri === CONSTANTS.AGENDA_ITEM_TYPES.NOTA;
+      if (keepDecisionAndNewsitem) {
+        await this.agendaService.keepDraftDecisionAndNewsItem(agendaitem, submission);
+      }
+      await this.agendaService.deleteAgendaitem(agendaitem, keepDecisionAndNewsitem);
     } else {
       // should be unreachable if there is a submission
       await this.agendaService.deleteAgendaitemFromMeeting(agendaitem);

--- a/app/components/submission/header.js
+++ b/app/components/submission/header.js
@@ -482,7 +482,8 @@ export default class SubmissionHeaderComponent extends Component {
             meeting,
             subcase,
             formallyStatusUri,
-            privateComment
+            privateComment,
+            this.args.submission
           );
         } catch (error) {
           this.toaster.error(

--- a/app/services/agenda-service.js
+++ b/app/services/agenda-service.js
@@ -6,6 +6,7 @@ import { isEnabledCabinetSubmissions } from 'frontend-kaleidos/utils/feature-fla
 import CONSTANTS from 'frontend-kaleidos/config/constants';
 import generateReportName from 'frontend-kaleidos/utils/generate-report-name';
 import { getJsonPayloadOrThrow } from 'frontend-kaleidos/utils/json-util';
+import { deleteDocumentContainer } from 'frontend-kaleidos/utils/document-delete-helpers';
 
 export default class AgendaService extends Service {
   @service store;
@@ -146,7 +147,8 @@ export default class AgendaService extends Service {
     meeting,
     subcase,
     formallyStatusUri = CONSTANTS.FORMALLY_OK_STATUSES.NOT_YET_FORMALLY_OK,
-    privateComment = null
+    privateComment = null,
+    submission = null
   ) {  
     const internalReview = await subcase.internalReview;
     if (!internalReview?.id) {
@@ -159,6 +161,7 @@ export default class AgendaService extends Service {
       body: JSON.stringify({
         subcase: subcase.uri,
         formallyOkStatus: formallyStatusUri,
+        submission: submission?.uri,
       })
     });
     const json = await getJsonPayloadOrThrow(response);
@@ -198,6 +201,40 @@ export default class AgendaService extends Service {
           }));
           await this.decisionReportGeneration.generateReplacementReports.perform(reportsToRegenerate);
         }
+      }
+    }
+    if (json.data.didRestoreFromSubmission) {
+      // There may be a decision now with stale name or content.
+      const report = await this.store.queryOne('report', {
+        'filter[:has-no:next-piece]': true,
+        'filter[:has:piece-parts]': true,
+        'filter[decision-activity][treatment][agendaitems][:id:]': agendaitem.id,
+      });
+      if (report) {
+        const documentContainer = await report.documentContainer;
+        const pieces = await documentContainer.pieces;
+        const newName = await generateReportName(agendaitem, meeting, pieces.length);
+        if (report.name !== newName) {
+          report.name = newName;
+          await report.belongsTo('file').reload();
+          await report.save();
+        }
+        // TODO we will do this twice if the logic above on didReorder is executed
+        await this.decisionReportGeneration.generateReplacementReport.perform(report);
+        // TODO generate concerns needed? like if more files were added (no VR number yet)
+
+        // since we have a "restored" report, we also need a decision result. approved is the only logical one (nota and not postponed/retracted yet)
+        // TODO do this in the backend maybe??
+        const decisionActivity = await this.store.queryOne('decision-activity', {
+          'filter[treatment][agendaitems][:id:]': agendaitem.id,
+        });
+        const decisionResultCode = await this.store.findRecordByUri(
+          'concept',
+          CONSTANTS.DECISION_RESULT_CODE_URIS.GOEDGEKEURD
+        );
+        decisionActivity.decisionResultCode = decisionResultCode;
+        await decisionActivity.save();
+        // toast to prompt the user to check/verify?
       }
     }
     return agendaitem;
@@ -270,6 +307,24 @@ export default class AgendaService extends Service {
     }
   }
 
+  /**
+   * @argument agendaitem
+   * @argument submission
+   */
+  async keepDraftDecisionAndNewsItem(agendaitem, submission) {
+    const url = `/submissions/${submission.id}/keep-draft-decision-and-news-item`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Accept': 'application/vnd.api+json', 'Content-Type': 'application/vnd.api+json' },
+      body: JSON.stringify({
+        agendaitem: agendaitem.uri,
+      })
+    });
+    if (!response.ok) {
+      await getJsonPayloadOrThrow(response);
+    }
+  }
+
   /* No API */
 
   async setAgendaitemsGroupname(agendaitems) {
@@ -306,7 +361,7 @@ export default class AgendaService extends Service {
     );
   }
 
-  async deleteAgendaitem(agendaitem) {
+  async deleteAgendaitem(agendaitem, keepDecisionAndNewsItem = false) {
     const agendaitemToDelete = await this.store.findRecord(
       'agendaitem',
       agendaitem.get('id'),
@@ -325,13 +380,17 @@ export default class AgendaService extends Service {
       if (treatment) {
         const decisionActivity = await treatment.decisionActivity;
         const newsItem = await treatment.newsItem;
-        if (newsItem) {
+        if (newsItem && !keepDecisionAndNewsItem) {
           await newsItem.destroyRecord();
         }
         if (decisionActivity) {
+          const report = await decisionActivity.belongsTo('report').reload();
           await decisionActivity.destroyRecord();
+          if (report && !keepDecisionAndNewsItem) {
+            const documentContainer = await report.documentContainer;
+            await deleteDocumentContainer(documentContainer);
+          }
         }
-        // TODO DELETE REPORT !
         await treatment.destroyRecord();
       }
       await Promise.all(

--- a/app/services/agenda-service.js
+++ b/app/services/agenda-service.js
@@ -219,12 +219,10 @@ export default class AgendaService extends Service {
           await report.belongsTo('file').reload();
           await report.save();
         }
-        // TODO we will do this twice if the logic above on didReorder is executed
         await this.decisionReportGeneration.generateReplacementReport.perform(report);
-        // TODO generate concerns needed? like if more files were added (no VR number yet)
 
-        // since we have a "restored" report, we also need a decision result. approved is the only logical one (nota and not postponed/retracted yet)
-        // TODO do this in the backend maybe??
+        // since we have a "restored" report, we also need a decision result.
+        // approved is the only logical one (nota and not postponed/retracted yet)
         const decisionActivity = await this.store.queryOne('decision-activity', {
           'filter[treatment][agendaitems][:id:]': agendaitem.id,
         });
@@ -234,7 +232,6 @@ export default class AgendaService extends Service {
         );
         decisionActivity.decisionResultCode = decisionResultCode;
         await decisionActivity.save();
-        // toast to prompt the user to check/verify?
       }
     }
     return agendaitem;

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1438,6 +1438,7 @@
   "accept-update-and-put-on-agenda": "Aanvaard update en agendeer",
   "send-back-to-submitter": "Stuur terug naar indiener",
   "send-back-to-submitter-message": "Bij terugsturen zal dit agendapunt volledig verwijderd worden. Hierbij gaan ook de beslissing en het kort bestek verloren!",
+  "send-back-to-submitter-keep-newsitem-message": "Bij terugsturen zal dit agendapunt volledig verwijderd worden. De beslissingsfiche en het kort bestek zullen worden bijgehouden en hersteld bij het heragenderen van de indiening",
   "delete-submission": "Verwijder indiening",
   "this-submission-is-being-treated-by-user": "Deze indiening is in behandeling genomen door {user}",
   "resubmit-submission": "Dien opnieuw in",


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5079

- [x] https://github.com/kanselarij-vlaanderen/agenda-submission-service/pull/21
- [x] https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/542


on "delete agendaitem and send back":
- api call to `agenda-submission`: newsitems and decision report get linked to submission
on submit for meeting:
- api call to `agenda-submission / submit` with new body param 'submissionUri' 
- in the `agenda-submission`: after all the data gets persisted we check if there is any `newsItem` or `decisionReport` on submission. If there is we link them to the new treatment/decisionActivity while unlinking them from submission"
In the response to the frontend we add a new boolean "didRestoreFromSubmission".
- in the frontend we regenerate the report and set a decisionResult code (approved is the only logical one.)


!note: only for type `nota`.
Announcements almost never have a decision result + newsitems are already auto generated.
I also guess the amount of announcements that get sent back to submitter is very tiny if any at all.

Some of the naming was a bit difficult. making it clear what it does while keeping it short.
The setting of the decision result is something I may still move to the backend.