### PR TITLE
KAS-5125 add warnings when newsletter has confidential items

### DIFF
--- a/app/components/agenda/agenda-header/agenda-actions.hbs
+++ b/app/components/agenda/agenda-header/agenda-actions.hbs
@@ -279,6 +279,8 @@
 {{#if this.showConfirmPublishThemis}}
   <ThemisPublications::PublishConfirmationModal
     @scope={{this.themisPublicationScopes}}
+    @loading={{this.checkConfidentiality.isRunning}}
+    @showConfidentialWarning={{this.hasConfidentialNewsletters}}
     @onCancel={{this.cancelPublishThemis}}
     @onConfirm={{perform this.publishThemis}}
   />

--- a/app/components/agenda/agenda-header/agenda-actions.js
+++ b/app/components/agenda/agenda-header/agenda-actions.js
@@ -58,6 +58,7 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
   @tracked showVerifyDeleteDecisionsSignFlows = false;
   @tracked signFlowsToRemoveDoneCounter;
   @tracked signFlowsToRemoveTotalCounter;
+  @tracked hasConfidentialNewsletters;
 
   @tracked decisionPublicationActivity;
   @tracked documentPublicationActivity;
@@ -429,6 +430,22 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
     return;
   });
 
+  checkConfidentiality = task(async () => {
+    const confidentialNotaCount = (await this.countConfidentialNewsItems(this.args.currentAgenda, CONSTANTS.AGENDA_ITEM_TYPES.NOTA));
+    const confidentialAnnouncementCount = (await this.countConfidentialNewsItems(this.args.currentAgenda, CONSTANTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT));
+    this.hasConfidentialNewsletters = confidentialNotaCount != 0 || confidentialAnnouncementCount != 0;
+  });
+
+  countConfidentialNewsItems = async(agenda, agendaitemType) => {
+    return await this.store.count('news-item', {
+      'filter[agenda-item-treatment][agendaitems][agenda][:id:]': agenda.id,
+      'filter[agenda-item-treatment][agendaitems][type][:uri:]': agendaitemType,
+      'filter[in-newsletter]': true,
+      'filter[agenda-item-treatment][agendaitems][agenda-activity][subcase][confidential]': true,
+      'filter[:has:modified]': `date-added-for-cache-busting-${new Date().toISOString()}`,
+    });
+  }
+
   @action
   print() {
     window.print();
@@ -466,6 +483,7 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
 
   @action
   openConfirmPublishThemis() {
+    this.checkConfidentiality.perform();
     this.showConfirmPublishThemis = true;
   }
 

--- a/app/components/agenda/agenda-header/agenda-actions.js
+++ b/app/components/agenda/agenda-header/agenda-actions.js
@@ -431,20 +431,14 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
   });
 
   checkConfidentiality = task(async () => {
-    const confidentialNotaCount = (await this.countConfidentialNewsItems(this.args.currentAgenda, CONSTANTS.AGENDA_ITEM_TYPES.NOTA));
-    const confidentialAnnouncementCount = (await this.countConfidentialNewsItems(this.args.currentAgenda, CONSTANTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT));
-    this.hasConfidentialNewsletters = confidentialNotaCount != 0 || confidentialAnnouncementCount != 0;
-  });
-
-  countConfidentialNewsItems = async(agenda, agendaitemType) => {
-    return await this.store.count('news-item', {
-      'filter[agenda-item-treatment][agendaitems][agenda][:id:]': agenda.id,
-      'filter[agenda-item-treatment][agendaitems][type][:uri:]': agendaitemType,
+    const confidentialNewslettersCount = await this.store.count('news-item', {
+      'filter[agenda-item-treatment][agendaitems][agenda][:id:]': this.args.currentAgenda.id,
       'filter[in-newsletter]': true,
       'filter[agenda-item-treatment][agendaitems][agenda-activity][subcase][confidential]': true,
       'filter[:has:modified]': `date-added-for-cache-busting-${new Date().toISOString()}`,
     });
-  }
+    this.hasConfidentialNewsletters = confidentialNewslettersCount != 0;
+  });
 
   @action
   print() {

--- a/app/components/news-item/table-row.hbs
+++ b/app/components/news-item/table-row.hbs
@@ -8,6 +8,15 @@
     data-test-table-row-news-item-row-title-content
     class="auk-table__col--7"
   >
+    {{#if this.subcase.confidential}}
+      <AuPill
+        @size="small"
+        @skin="warning"
+        @icon="lock-closed"
+      >
+        {{t "limited-access"}}
+      </AuPill>
+    {{/if}}
     {{#if @newsItem}}
       <div class="auk-u-mb-2">
         <p class="auk-u-text-bold">

--- a/app/components/news-item/table-row.js
+++ b/app/components/news-item/table-row.js
@@ -14,18 +14,13 @@ export default class NewsItemTableRowComponent extends Component {
   @tracked isOpenEditView = false;
   @tracked notaOrVisieNota;
   @tracked decisionActivity;
+  @tracked subcase;
 
   constructor() {
     super(...arguments);
     this.loadNotaOrVisienota.perform();
     this.loadDecisionActivity.perform();
-  }
-
-  @task
-  *loadDecisionActivity() {
-    const treatment = yield this.args.agendaitem.treatment;
-    this.decisionActivity = yield treatment?.decisionActivity;
-    yield this.decisionActivity?.belongsTo('decisionResultCode').reload();
+    this.loadSubcase.perform();
   }
 
   get class() {
@@ -35,6 +30,18 @@ export default class NewsItemTableRowComponent extends Component {
     }
     return classes.join(' ');
   }
+
+  @task
+  *loadDecisionActivity() {
+    const treatment = yield this.args.agendaitem.treatment;
+    this.decisionActivity = yield treatment?.decisionActivity;
+    yield this.decisionActivity?.belongsTo('decisionResultCode').reload();
+  }
+
+  loadSubcase = task(async () => {
+    const agendaActivity = await this.args.agendaitem.agendaActivity;
+    this.subcase = await agendaActivity?.subcase;
+  })
 
   @task
   *saveNewsItem(newsItem, wasNewsItemNew) {

--- a/app/components/newsletter/newsletter-header-overview.hbs
+++ b/app/components/newsletter/newsletter-header-overview.hbs
@@ -190,18 +190,28 @@
   @disabled={{this.disableConfirm}}
 >
   <:body>
-  {{#if this.messageOnConfirm}}
-    <AuAlert
-      @title={{t "warning-title"}}
-      @skin="warning"
-      @icon="alert-triangle"
-      @size="small"
-    >
-      <p>{{this.messageOnConfirm}}</p>
-    </AuAlert>
-  {{else}}
-    {{t "send-newsitem-to-mail-verification"}}
-  {{/if}}
+    {{#if this.hasConfidentialNewsletters}}
+      <AuAlert
+        @title={{t "agendaitems-confidential-warning-title"}}
+        @skin="warning"
+        @icon="alert-triangle"
+        @size="small"
+      >
+        <p>{{t "agendaitems-confidential-warning-message"}}</p>
+      </AuAlert>
+    {{/if}}
+    {{#if this.messageOnConfirm}}
+      <AuAlert
+        @title={{t "warning-title"}}
+        @skin="warning"
+        @icon="alert-triangle"
+        @size="small"
+      >
+        <p>{{this.messageOnConfirm}}</p>
+      </AuAlert>
+    {{else}}
+      <p>{{t "send-newsitem-to-mail-verification"}}</p>
+    {{/if}}
   </:body>
 </ConfirmationModal>
 
@@ -215,18 +225,28 @@
   @disabled={{this.disableConfirm}}
 >
   <:body>
-  {{#if this.messageOnConfirm}}
-    <AuAlert
-      @title={{t "warning-title"}}
-      @skin="warning"
-      @icon="alert-triangle"
-      @size="small"
-    >
-      <p>{{this.messageOnConfirm}}</p>
-    </AuAlert>
-  {{else}}
-    {{t "send-newsitem-to-belga-verification"}}
-  {{/if}}
+    {{#if this.hasConfidentialNewsletters}}
+      <AuAlert
+        @title={{t "agendaitems-confidential-warning-title"}}
+        @skin="warning"
+        @icon="alert-triangle"
+        @size="small"
+      >
+        <p>{{t "agendaitems-confidential-warning-message"}}</p>
+      </AuAlert>
+    {{/if}}
+    {{#if this.messageOnConfirm}}
+      <AuAlert
+        @title={{t "warning-title"}}
+        @skin="warning"
+        @icon="alert-triangle"
+        @size="small"
+      >
+        <p>{{this.messageOnConfirm}}</p>
+      </AuAlert>
+    {{else}}
+      <p>{{t "send-newsitem-to-belga-verification"}}</p>
+    {{/if}}
   </:body>
 </ConfirmationModal>
 
@@ -234,6 +254,7 @@
   <ThemisPublications::PublishConfirmationModal
     @scope={{this.themisPublicationScopes}}
     @warningMessage={{this.messageOnConfirm}}
+    @showConfidentialWarning={{this.hasConfidentialNewsletters}}
     @onCancel={{this.cancelPublishThemis}}
     @onConfirm={{perform this.publishThemis}}
   />
@@ -249,6 +270,7 @@
     @title={{t "send-newsitem-to-all"}}
     @scope={{this.themisPublicationScopes}}
     @warningMessage={{this.messageOnConfirm}}
+    @showConfidentialWarning={{this.hasConfidentialNewsletters}}
     @onCancel={{this.cancelPublishAll}}
     @onConfirm={{perform this.publishToAll}}
   />

--- a/app/components/newsletter/newsletter-header-overview.js
+++ b/app/components/newsletter/newsletter-header-overview.js
@@ -30,6 +30,7 @@ export default class NewsletterHeaderOverviewComponent extends Component {
   @tracked notaWithThemeCount;
   @tracked announcementWithThemeCount;
   @tracked messageOnConfirm;
+  @tracked hasConfidentialNewsletters;
 
   constructor() {
     super(...arguments);
@@ -95,9 +96,30 @@ export default class NewsletterHeaderOverviewComponent extends Component {
     });
   }
 
+  checkConfidentiality = task(async () => {
+    const agenda = await this.store.queryOne('agenda', {
+      'filter[created-for][:id:]': this.args.meeting.id,
+      sort: '-created',
+    });
+    const confidentialNotaCount = (await this.countConfidentialNewsItems(agenda, CONSTANTS.AGENDA_ITEM_TYPES.NOTA));
+    const confidentialAnnouncementCount = (await this.countConfidentialNewsItems(agenda, CONSTANTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT));
+    this.hasConfidentialNewsletters = confidentialNotaCount != 0 || confidentialAnnouncementCount != 0;
+  });
+
+  countConfidentialNewsItems = async(agenda, agendaitemType) => {
+    return await this.store.count('news-item', {
+      'filter[agenda-item-treatment][agendaitems][agenda][:id:]': agenda.id,
+      'filter[agenda-item-treatment][agendaitems][type][:uri:]': agendaitemType,
+      'filter[in-newsletter]': true,
+      'filter[agenda-item-treatment][agendaitems][agenda-activity][subcase][confidential]': true,
+      'filter[:has:modified]': `date-added-for-cache-busting-${new Date().toISOString()}`,
+    });
+  }
+
   get disableConfirm() {
     return this.calculateTotals.isRunning ||
     (this.notaWithThemeCount == 0 && this.announcementWithThemeCount == 0) ||
+    this.checkConfidentiality.isRunning ||
     this.publishToAll.isRunning ||
     this.publishToBelga.isRunning ||
     this.publishToMail.isRunning;
@@ -329,6 +351,7 @@ export default class NewsletterHeaderOverviewComponent extends Component {
   @action
   openConfirmPublishAll() {
     this.calculateTotals.perform();
+    this.checkConfidentiality.perform();
     this.showConfirmPublishAll = true;
   }
 
@@ -340,6 +363,7 @@ export default class NewsletterHeaderOverviewComponent extends Component {
   @action
   openConfirmPublishMail() {
     this.calculateTotals.perform();
+    this.checkConfidentiality.perform();
     this.showConfirmPublishMail = true;
   }
 
@@ -351,6 +375,7 @@ export default class NewsletterHeaderOverviewComponent extends Component {
   @action
   openConfirmPublishBelga() {
     this.calculateTotals.perform();
+    this.checkConfidentiality.perform();
     this.showConfirmPublishBelga = true;
   }
 
@@ -362,6 +387,7 @@ export default class NewsletterHeaderOverviewComponent extends Component {
   @action
   openConfirmPublishThemis() {
     this.calculateTotals.perform();
+    this.checkConfidentiality.perform();
     this.showConfirmPublishThemis = true;
   }
 

--- a/app/components/newsletter/newsletter-header-overview.js
+++ b/app/components/newsletter/newsletter-header-overview.js
@@ -101,20 +101,14 @@ export default class NewsletterHeaderOverviewComponent extends Component {
       'filter[created-for][:id:]': this.args.meeting.id,
       sort: '-created',
     });
-    const confidentialNotaCount = (await this.countConfidentialNewsItems(agenda, CONSTANTS.AGENDA_ITEM_TYPES.NOTA));
-    const confidentialAnnouncementCount = (await this.countConfidentialNewsItems(agenda, CONSTANTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT));
-    this.hasConfidentialNewsletters = confidentialNotaCount != 0 || confidentialAnnouncementCount != 0;
-  });
-
-  countConfidentialNewsItems = async(agenda, agendaitemType) => {
-    return await this.store.count('news-item', {
+    const confidentialNewslettersCount = await this.store.count('news-item', {
       'filter[agenda-item-treatment][agendaitems][agenda][:id:]': agenda.id,
-      'filter[agenda-item-treatment][agendaitems][type][:uri:]': agendaitemType,
       'filter[in-newsletter]': true,
       'filter[agenda-item-treatment][agendaitems][agenda-activity][subcase][confidential]': true,
       'filter[:has:modified]': `date-added-for-cache-busting-${new Date().toISOString()}`,
     });
-  }
+    this.hasConfidentialNewsletters = confidentialNewslettersCount != 0;
+  });
 
   get disableConfirm() {
     return this.calculateTotals.isRunning ||

--- a/app/components/themis-publications/publish-confirmation-modal.hbs
+++ b/app/components/themis-publications/publish-confirmation-modal.hbs
@@ -5,6 +5,16 @@
     @closeDisabled={{this.confirmPublish.isRunning}}
   />
   <Auk::Modal::Body>
+    {{#if @showConfidentialWarning}}
+      <AuAlert
+        @title={{t "agendaitems-confidential-warning-title"}}
+        @skin="warning"
+        @icon="alert-triangle"
+        @size="small"
+      >
+        <p>{{t "agendaitems-confidential-warning-message"}}</p>
+      </AuAlert>
+    {{/if}}
     {{#if @warningMessage}}
       <AuAlert
         @title={{t "warning-title"}}
@@ -23,12 +33,12 @@
   >
     <AuButton
       @skin="primary"
-      @alert={{@warningMessage}}
-      @loading={{this.confirmPublish.isRunning}}
+      @alert={{or @warningMessage @showConfidentialWarning}}
+      @loading={{or this.confirmPublish.isRunning @loading}}
       @loadingMessage={{t "loading"}}
       {{on "click" (perform this.confirmPublish)}}
     >
-      {{t (if @warningMessage "publish-anyway" "publish-to-public")}}
+      {{t (if (or @warningMessage @showConfidentialWarning)  "publish-anyway" "publish-to-public")}}
     </AuButton>
   </Auk::Modal::Footer>
 </Auk::Modal>

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1558,5 +1558,7 @@
   "no-visible-news-items": "Geen kort bestek beschikbaar",
   "newsletter-nothing-to-send": "Er zijn geen agendapunten of mededelingen gevonden 'in kort bestek' met een thema",
   "newsletter-only-announcements-to-send": "U staat op het punt om enkel mededelingen te publiceren",
-  "publish-anyway": "Toch publiceren"
+  "publish-anyway": "Toch publiceren",
+  "agendaitems-confidential-warning-title": "Agendapunten met beperkte toegang",
+  "agendaitems-confidential-warning-message": "Er zijn agendapunten met beperkte toegang opgenomen in het kort bestek, Deze zullen mee gepubliceerd worden als u bevestigt."
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5125

FYI, this branch will fail on its own, it needs the backend branch of feature/KAS-5060-send-announcements-only-mail


- agenda-actions: added calculation and alert message on (re)publishing modal (note: this does not appear on the documents planning modal, where you would initially confirm the release of the documents, which I think is ok. Newsletter will already be released at that stage)
- table-row (newsletter zebra view): added confidential pill
- newsletter-header-overview: added an alert on all confirm actions (separate from the 'no newsletters have valid theme' alert) when any newsletter that is `in-newsletter` but also the subcase is `confidential`
- Had to add cache-busting since the count didn't change after updating `confidential` or `in-newsletter`