### PR TITLE
Feature/kas 2958 new newsletter themes

### DIFF
--- a/app/components/newsletter/newsletter-header-overview.hbs
+++ b/app/components/newsletter/newsletter-header-overview.hbs
@@ -281,7 +281,7 @@
   />
 {{/if}}
 
-{{#if (or this.loadNewsletterHTML.isRunning this.newsletterHTML)}}
+{{!-- {{#if (or this.loadNewsletterHTML.isRunning this.newsletterHTML)}}
   <Auk::Modal @size="full-screen-padded">
     <Auk::Modal::Header @title={{t "show-newsletter"}} @onClose={{this.clearNewsletterHTML}} />
     <Auk::Modal::Body>
@@ -294,4 +294,4 @@
       {{/if}}
     </Auk::Modal::Body>
   </Auk::Modal>
-{{/if}}
+{{/if}} --}}

--- a/app/components/newsletter/newsletter-header-overview.hbs
+++ b/app/components/newsletter/newsletter-header-overview.hbs
@@ -14,7 +14,7 @@
               {{date @meeting.plannedStart}}
             </h4>
           </div>
-          {{#unless this.areTasksRunning}}
+          {{#unless this.arePublishTasksRunning}}
             <Newsletter::PublicationPills @meeting={{@meeting}} />
           {{/unless}}
         </div>
@@ -193,29 +193,34 @@
   @confirmMessage={{t "send-newsitem-to-mail"}}
   @loading={{this.publishToMail.isRunning}}
   @disabled={{this.disableConfirm}}
+  @alert={{or this.messageOnConfirm this.hasConfidentialNewsletters}}
 >
   <:body>
-    {{#if this.hasConfidentialNewsletters}}
-      <AuAlert
-        @title={{t "agendaitems-confidential-warning-title"}}
-        @skin="warning"
-        @icon="alert-triangle"
-        @size="small"
-      >
-        <p>{{t "agendaitems-confidential-warning-message"}}</p>
-      </AuAlert>
-    {{/if}}
-    {{#if this.messageOnConfirm}}
-      <AuAlert
-        @title={{t "warning-title"}}
-        @skin="warning"
-        @icon="alert-triangle"
-        @size="small"
-      >
-        <p>{{this.messageOnConfirm}}</p>
-      </AuAlert>
+    {{#if this.areCalculateTasksRunning}}
+      <Auk::Loader @message={{t "loading" }} />
     {{else}}
-      <p>{{t "send-newsitem-to-mail-verification"}}</p>
+      {{#if this.hasConfidentialNewsletters}}
+        <AuAlert
+          @title={{t "agendaitems-confidential-warning-title"}}
+          @skin="warning"
+          @icon="alert-triangle"
+          @size="small"
+        >
+          <p>{{t "agendaitems-confidential-warning-message"}}</p>
+        </AuAlert>
+      {{/if}}
+      {{#if this.messageOnConfirm}}
+        <AuAlert
+          @title={{t "warning-title"}}
+          @skin="warning"
+          @icon="alert-triangle"
+          @size="small"
+        >
+          <p>{{this.messageOnConfirm}}</p>
+        </AuAlert>
+      {{else}}
+        <p>{{t "send-newsitem-to-mail-verification"}}</p>
+      {{/if}}
     {{/if}}
   </:body>
 </ConfirmationModal>
@@ -228,29 +233,34 @@
   @confirmMessage={{t "send-newsitem-to-belga"}}
   @loading={{this.publishToBelga.isRunning}}
   @disabled={{this.disableConfirm}}
+  @alert={{or this.messageOnConfirm this.hasConfidentialNewsletters}}
 >
   <:body>
-    {{#if this.hasConfidentialNewsletters}}
-      <AuAlert
-        @title={{t "agendaitems-confidential-warning-title"}}
-        @skin="warning"
-        @icon="alert-triangle"
-        @size="small"
-      >
-        <p>{{t "agendaitems-confidential-warning-message"}}</p>
-      </AuAlert>
-    {{/if}}
-    {{#if this.messageOnConfirm}}
-      <AuAlert
-        @title={{t "warning-title"}}
-        @skin="warning"
-        @icon="alert-triangle"
-        @size="small"
-      >
-        <p>{{this.messageOnConfirm}}</p>
-      </AuAlert>
+    {{#if this.areCalculateTasksRunning}}
+      <Auk::Loader @message={{t "loading" }} />
     {{else}}
-      <p>{{t "send-newsitem-to-belga-verification"}}</p>
+      {{#if this.hasConfidentialNewsletters}}
+        <AuAlert
+          @title={{t "agendaitems-confidential-warning-title"}}
+          @skin="warning"
+          @icon="alert-triangle"
+          @size="small"
+        >
+          <p>{{t "agendaitems-confidential-warning-message"}}</p>
+        </AuAlert>
+      {{/if}}
+      {{#if this.messageOnConfirm}}
+        <AuAlert
+          @title={{t "warning-title"}}
+          @skin="warning"
+          @icon="alert-triangle"
+          @size="small"
+        >
+          <p>{{this.messageOnConfirm}}</p>
+        </AuAlert>
+      {{else}}
+        <p>{{t "send-newsitem-to-belga-verification"}}</p>
+      {{/if}}
     {{/if}}
   </:body>
 </ConfirmationModal>
@@ -259,6 +269,7 @@
   <ThemisPublications::PublishConfirmationModal
     @scope={{this.themisPublicationScopes}}
     @warningMessage={{this.messageOnConfirm}}
+    @loading={{this.areCalculateTasksRunning}}
     @showConfidentialWarning={{this.hasConfidentialNewsletters}}
     @onCancel={{this.cancelPublishThemis}}
     @onConfirm={{perform this.publishThemis}}
@@ -275,6 +286,7 @@
     @title={{t "send-newsitem-to-all"}}
     @scope={{this.themisPublicationScopes}}
     @warningMessage={{this.messageOnConfirm}}
+    @loading={{this.areCalculateTasksRunning}}
     @showConfidentialWarning={{this.hasConfidentialNewsletters}}
     @onCancel={{this.cancelPublishAll}}
     @onConfirm={{perform this.publishToAll}}

--- a/app/components/newsletter/newsletter-header-overview.js
+++ b/app/components/newsletter/newsletter-header-overview.js
@@ -19,7 +19,7 @@ export default class NewsletterHeaderOverviewComponent extends Component {
   @service currentSession;
 
   @tracked mailCampaign;
-  @tracked newsletterHTML = null;
+  // @tracked newsletterHTML = null;
   @tracked latestPublicationActivity;
 
   @tracked showConfirmPublishAll = false;

--- a/app/components/newsletter/newsletter-header-overview.js
+++ b/app/components/newsletter/newsletter-header-overview.js
@@ -69,13 +69,14 @@ export default class NewsletterHeaderOverviewComponent extends Component {
   }
 
   calculateTotals = task(async () => {
+    this.messageOnConfirm = '';
     const agenda = await this.store.queryOne('agenda', {
       'filter[created-for][:id:]': this.args.meeting.id,
       sort: '-created', // serialnumber
     });
-    this.notaWithThemeCount = (await this.countNewsItemsWithValidTheme(agenda, CONSTANTS.AGENDA_ITEM_TYPES.NOTA));
-    this.announcementWithThemeCount = (await this.countNewsItemsWithValidTheme(agenda, CONSTANTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT));
-    this.messageOnConfirm = '';
+    this.notaWithThemeCount = await this.countNewsItemsWithValidTheme(agenda, CONSTANTS.AGENDA_ITEM_TYPES.NOTA);
+    this.announcementWithThemeCount = await this.countNewsItemsWithValidTheme(agenda, CONSTANTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT);
+    
     if (this.notaWithThemeCount === 0) {
       if (this.announcementWithThemeCount === 0) {
         this.messageOnConfirm = this.intl.t('newsletter-nothing-to-send');
@@ -97,6 +98,7 @@ export default class NewsletterHeaderOverviewComponent extends Component {
   }
 
   checkConfidentiality = task(async () => {
+    this.hasConfidentialNewsletters = false;
     const agenda = await this.store.queryOne('agenda', {
       'filter[created-for][:id:]': this.args.meeting.id,
       sort: '-created',
@@ -111,12 +113,9 @@ export default class NewsletterHeaderOverviewComponent extends Component {
   });
 
   get disableConfirm() {
-    return this.calculateTotals.isRunning ||
+    return this.areCalculateTasksRunning ||
     (this.notaWithThemeCount == 0 && this.announcementWithThemeCount == 0) ||
-    this.checkConfidentiality.isRunning ||
-    this.publishToAll.isRunning ||
-    this.publishToBelga.isRunning ||
-    this.publishToMail.isRunning;
+    this.arePublishTasksRunning;
   }
 
   get shouldShowPrintButton() {
@@ -128,12 +127,17 @@ export default class NewsletterHeaderOverviewComponent extends Component {
       this.latestPublicationActivity.scope.includes(CONSTANTS.THEMIS_PUBLICATION_SCOPES.NEWSITEMS);
   }
 
-  get areTasksRunning() {
+  get arePublishTasksRunning() {
     return this.publishToMail.isRunning ||
-    this.publishToBelga.isRunning ||
-    this.publishThemis.isRunning ||
-    this.publishToAll.isRunning ||
-    this.unpublishThemis.isRunning
+      this.publishToBelga.isRunning ||
+      this.publishThemis.isRunning ||
+      this.publishToAll.isRunning ||
+      this.unpublishThemis.isRunning
+  }
+
+  get areCalculateTasksRunning() {
+    return this.calculateTotals.isRunning ||
+      this.checkConfidentiality.isRunning
   }
 
   @action

--- a/app/components/themis-publications/publish-confirmation-modal.hbs
+++ b/app/components/themis-publications/publish-confirmation-modal.hbs
@@ -5,27 +5,31 @@
     @closeDisabled={{this.confirmPublish.isRunning}}
   />
   <Auk::Modal::Body>
-    {{#if @showConfidentialWarning}}
-      <AuAlert
-        @title={{t "agendaitems-confidential-warning-title"}}
-        @skin="warning"
-        @icon="alert-triangle"
-        @size="small"
-      >
-        <p>{{t "agendaitems-confidential-warning-message"}}</p>
-      </AuAlert>
+    {{#if @loading}}
+      <Auk::Loader @message={{t "loading" }} />
+    {{else}}
+      {{#if @showConfidentialWarning}}
+        <AuAlert
+          @title={{t "agendaitems-confidential-warning-title"}}
+          @skin="warning"
+          @icon="alert-triangle"
+          @size="small"
+        >
+          <p>{{t "agendaitems-confidential-warning-message"}}</p>
+        </AuAlert>
+      {{/if}}
+      {{#if @warningMessage}}
+        <AuAlert
+          @title={{t "warning-title"}}
+          @skin="warning"
+          @icon="alert-triangle"
+          @size="small"
+        >
+          <p>{{@warningMessage}}</p>
+        </AuAlert>
+      {{/if}}
+      <p>{{this.confirmationMessage}}</p>
     {{/if}}
-    {{#if @warningMessage}}
-      <AuAlert
-        @title={{t "warning-title"}}
-        @skin="warning"
-        @icon="alert-triangle"
-        @size="small"
-      >
-        <p>{{@warningMessage}}</p>
-      </AuAlert>
-    {{/if}}
-    <p>{{this.confirmationMessage}}</p>
   </Auk::Modal::Body>
   <Auk::Modal::Footer
     @onCancel={{@onCancel}}

--- a/app/components/utils/themes-selector.js
+++ b/app/components/utils/themes-selector.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { task } from 'ember-concurrency';
+import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { addObject, removeObject } from 'frontend-kaleidos/utils/array-helpers';
@@ -9,6 +10,8 @@ import { addObject, removeObject } from 'frontend-kaleidos/utils/array-helpers';
  */
 export default class ThemesSelector extends Component {
   @service store;
+
+  @tracked themes;
 
   constructor() {
     super(...arguments);

--- a/app/config/constants.js
+++ b/app/config/constants.js
@@ -221,7 +221,6 @@ export default {
     FIRST_ACTION: 'Eerste actie',
     COPY_SUBCASE_CLICK: 'Kopieer voorgaande procedurestap',
   },
-  // is this the right way?
   PRIVATE_COMMENT_TEMPLATE: {
     NOTA:
 `IF:
@@ -235,5 +234,9 @@ Def. check: `,
 `Co-agendering:
 
 Def. check: `
-  }
+  },
+  NEWSLETTER_THEMES: {
+    // there are more themes, we only need announcement to set automatically
+    ANNOUNCEMENT: "http://kanselarij.vo.data.gift/id/concept/thema-codes/59f3131e-cf44-4ee2-8258-70e3ac6303b1",
+  },
 };

--- a/app/services/newsletter-service.js
+++ b/app/services/newsletter-service.js
@@ -132,6 +132,7 @@ export default class NewsletterService extends Service {
     });
     const agendaItemType = await agendaitem.type;
     if (agendaItemType.uri === CONSTANTS.AGENDA_ITEM_TYPES.ANNOUNCEMENT) {
+      const announcementTheme = await this.store.findRecordByUri('theme', CONSTANTS.NEWSLETTER_THEMES.ANNOUNCEMENT);
       const content = agendaitem.title;
       const contentWithBreaks = content?.replace(/\n/g, '<br />');
       news.title = agendaitem.shortTitle || content;
@@ -140,9 +141,10 @@ export default class NewsletterService extends Service {
       // We should check if the decision activity has "postponed" or "retracted" or subcase is confidential
       // but right now, we always create newsitems for announcements in the `agenda-submission` service
       // when creating the initial agendaitem
-      // there is no way for a user to remove an announcement newsItem so this should be next to unreachable code
-      // the only possible way is on legacy, where announcements do not have a newsItem (or even a subcase)
+      // there is no way for a user to remove an announcement newsItem besides changing the agendaitemType
       news.inNewsletter = true;
+      // all announcements have this theme
+      news.themes = [announcementTheme];
     } else {
       news.title = agendaitem.shortTitle;
       news.subtitle = agendaitem.title;

--- a/cypress/e2e/unit/mail-campaign.cy.js
+++ b/cypress/e2e/unit/mail-campaign.cy.js
@@ -75,7 +75,7 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
   });
 
 
-  it.only('should test the pre mailchimp checks', () => {
+  it('should test the pre mailchimp checks', () => {
     const randomInt = Math.floor(Math.random() * Math.floor(10000));
 
     const agendaDate = Cypress.dayjs().add(5, 'weeks')
@@ -84,6 +84,7 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
     const type2 = 'Nota';
     const shortSubcaseTitle1 = 'Cypress test: nieuwsbrief mededeling';
     const theme = 'Brussel'; // 'Justitie en Handhaving' is the one theme we can't accept, no mailchimp id
+    const announcementTheme = 'Mededeling'; // default theme on all NEW announcement newsitems
     const shortSubcaseTitle2 = 'Cypress test: nieuwsbrief nota';
     const shortSubcaseTitle3 = 'Cypress test: tweede nieuwsbrief nota';
     const alertMessage = 'De nieuwsbrief kan niet verzonden worden';
@@ -113,19 +114,7 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
     cy.addAgendaitemToAgenda(shortSubcaseTitle2);
     cy.addAgendaitemToAgenda(shortSubcaseTitle3);
 
-    // test without kort bestek and no theme in mededeling
-    cy.get(agenda.agendaActions.optionsDropdown)
-      .children(appuniversum.button)
-      .click();
-    cy.get(agenda.agendaActions.navigateToNewsletter).forceClick();
-    cy.get(newsletter.tableRow.titleContent); // await page load
-    checkPublishMail(alertMessage);
-
-    // add theme to mededeling
-    cy.openAgendaForDate(agendaDate);
-    addOrRemoveThemeFromMededeling(shortSubcaseTitle1, theme);
-
-    // test without kort bestek and with theme in mededeling
+    // test without kort bestek and with theme in mededeling (new announcement newsitems have a theme to start)
     cy.get(agenda.agendaActions.optionsDropdown)
       .children(appuniversum.button)
       .click();
@@ -148,11 +137,19 @@ context('newsletter tests, both in agenda detail view and newsletter route', () 
         }
       });
 
-    // remove theme from mededeling
+    // remove theme from mededeling, test without any valid nota or announcements
     cy.openAgendaForDate(agendaDate);
-    addOrRemoveThemeFromMededeling(shortSubcaseTitle1, theme, true);
+    addOrRemoveThemeFromMededeling(shortSubcaseTitle1, announcementTheme, true);
+
+    cy.get(agenda.agendaActions.optionsDropdown)
+      .children(appuniversum.button)
+      .click();
+    cy.get(agenda.agendaActions.navigateToNewsletter).forceClick();
+    cy.get(newsletter.tableRow.titleContent); // await page load
+    checkPublishMail(alertMessage);
 
     // add kort bestek
+    cy.openAgendaForDate(agendaDate);
     cy.openAgendaitemKortBestekTab(shortSubcaseTitle2);
     cy.intercept('GET', '/themes**').as('getAgendaitemThemes1');
     cy.intercept('POST', '/news-items').as('newsItemsPost');


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-2958

- [x] https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/547
- [x] https://github.com/kanselarij-vlaanderen/agenda-submission-service/pull/22
- [x] https://github.com/kanselarij-vlaanderen/newsletter-service/pull/58

Part 1: add themes on Kaleidos - done
Part 2: add themes (interests) on mailchimp API - TODO (ACC (DONE) and PROD have different servers, different lists to update)
Part 3: contact webplatform, where are they getting that list? assuming they are using mailchimp API (should be automatic if true)
Part 4: Inform users that they should update their subscribiption to themes? TBD
if Part 4: maybe improve the form to do so? Currently a bit basic (can update/design it on mailchimp website)


- Updated created news items for announcements to have default theme "mededeling"
Either via `agenda-submission` service or in frontend when changing `agendaitemType`
- commented some unused code (we could remove it, the values were no longer loaded)
- added `@tracked` to `themes-selector`. 
- updated tests (order changed, we start with announcement with a theme now)

Also check themis PR :
- [ ] https://github.com/kanselarij-vlaanderen/app-themis/pull/29


note: the loading time and popping up of the alerts when doing newsletter actions might be considered "annoying" (I did, but left it as-is) but in real use cases, that button won't be pressed until everything is ok so no popup will be shown.
Could change it to show a loader before opening the relevant modal.