### PR TITLE
KAS-1989 add option to download only new documents from agenda

### DIFF
--- a/app/components/agenda/agenda-header/agenda-actions.hbs
+++ b/app/components/agenda/agenda-header/agenda-actions.hbs
@@ -335,6 +335,25 @@
           </AuRadioGroup>
         </Fieldset.content>
       </AuFieldset>
+      <AuFieldset as |Fieldset|>
+        <Fieldset.legend>{{t "download-documents-agenda-selection"}}</Fieldset.legend>
+        <Fieldset.content>
+          <AuRadioGroup
+            @alignment="inline"
+            @selected={{this.selectedCurrentAgendaOnlyOptions}}
+            @onChange={{this.onChangeCurrentAgendaOnlyOption}}
+            as |Group|
+          >
+            {{#each this.currentAgendaOnlyOptions as |option|}}
+            <Group.Radio
+              @value={{option.value}}
+              >
+              {{option.label}}
+            </Group.Radio>
+            {{/each}}
+          </AuRadioGroup>
+        </Fieldset.content>
+      </AuFieldset>
     </div>
   </:body>
 </ConfirmationModal>

--- a/app/components/agenda/agenda-header/agenda-actions.hbs
+++ b/app/components/agenda/agenda-header/agenda-actions.hbs
@@ -340,11 +340,11 @@
         <Fieldset.content>
           <AuRadioGroup
             @alignment="inline"
-            @selected={{this.selectedCurrentAgendaOnlyOptions}}
-            @onChange={{this.onChangeCurrentAgendaOnlyOption}}
+            @selected={{this.selectedNewDocumentsOnlyOptions}}
+            @onChange={{this.onChangeNewDocumentsOnlyOption}}
             as |Group|
           >
-            {{#each this.currentAgendaOnlyOptions as |option|}}
+            {{#each this.newDocumentsOnlyOptions as |option|}}
             <Group.Radio
               @value={{option.value}}
               >

--- a/app/components/agenda/agenda-header/agenda-actions.js
+++ b/app/components/agenda/agenda-header/agenda-actions.js
@@ -44,7 +44,7 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
     },
   ];
 
-  currentAgendaOnlyOptions = [
+  newDocumentsOnlyOptions = [
     {
       label: this.intl.t('download-documents-agenda-selection-all'),
       value: false,
@@ -77,7 +77,7 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
   @tracked latestThemisPublicationActivity;
 
   @tracked downloadOption = this.downloadOptions[0].value;
-  @tracked currentAgendaOnlyOption = this.currentAgendaOnlyOptions[0].value;
+  @tracked newDocumentsOnlyOption = this.newDocumentsOnlyOptions[0].value;
 
   constructor() {
     super(...arguments);
@@ -88,8 +88,8 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
     return this.downloadOption;
   }
 
-  get selectedCurrentAgendaOnlyOptions() {
-    return this.currentAgendaOnlyOption;
+  get selectedNewDocumentsOnlyOptions() {
+    return this.newDocumentsOnlyOption;
   }
 
   get showPrintButton() {
@@ -323,7 +323,7 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
       timeOut: 60 * 10 * 1000,
     };
     const pdfOnly = this.downloadOption === 'pdf' ? true : false;
-    const currentAgendaOnly = this.currentAgendaOnlyOption;
+    const newDocumentsOnly = this.newDocumentsOnlyOption;
     const namePromise = constructArchiveName(this.args.currentAgenda);
     debug('Checking if archive exists ...');
     const jobPromise = fetchArchivingJobForAgenda(
@@ -332,7 +332,7 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
       decisions,
       this.store,
       pdfOnly,
-      currentAgendaOnly
+      newDocumentsOnly
     );
     const [name, job] = await all([namePromise, jobPromise]);
     if (!job) {
@@ -572,8 +572,8 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
   }
 
   @action
-  onChangeCurrentAgendaOnlyOption(selectedDownloadOption) {
-    this.currentAgendaOnlyOption = selectedDownloadOption;
+  onChangeNewDocumentsOnlyOption(selectedDownloadOption) {
+    this.newDocumentsOnlyOption = selectedDownloadOption;
   }
 
   openConfirmEmptyInternalReviews = () => {

--- a/app/components/agenda/agenda-header/agenda-actions.js
+++ b/app/components/agenda/agenda-header/agenda-actions.js
@@ -44,6 +44,17 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
     },
   ];
 
+  currentAgendaOnlyOptions = [
+    {
+      label: this.intl.t('download-documents-agenda-selection-all'),
+      value: false,
+    },
+    {
+      label: this.intl.t('download-documents-agenda-selection-current-only'),
+      value: true,
+    },
+  ];
+
   @tracked isAddingAgendaitems = false;
   @tracked isEditingMeeting = false;
   @tracked showConfirmApprovingAllAgendaitems = false;
@@ -66,6 +77,7 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
   @tracked latestThemisPublicationActivity;
 
   @tracked downloadOption = this.downloadOptions[0].value;
+  @tracked currentAgendaOnlyOption = this.currentAgendaOnlyOptions[0].value;
 
   constructor() {
     super(...arguments);
@@ -74,6 +86,10 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
 
   get selectedDownloadOption() {
     return this.downloadOption;
+  }
+
+  get selectedCurrentAgendaOnlyOptions() {
+    return this.currentAgendaOnlyOption;
   }
 
   get showPrintButton() {
@@ -307,6 +323,7 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
       timeOut: 60 * 10 * 1000,
     };
     const pdfOnly = this.downloadOption === 'pdf' ? true : false;
+    const currentAgendaOnly = this.currentAgendaOnlyOption;
     const namePromise = constructArchiveName(this.args.currentAgenda);
     debug('Checking if archive exists ...');
     const jobPromise = fetchArchivingJobForAgenda(
@@ -314,7 +331,8 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
       this.selectedMandatees,
       decisions,
       this.store,
-      pdfOnly
+      pdfOnly,
+      currentAgendaOnly
     );
     const [name, job] = await all([namePromise, jobPromise]);
     if (!job) {
@@ -551,6 +569,11 @@ export default class AgendaAgendaHeaderAgendaActions extends Component {
   @action
   onChangeDownloadOption(selectedDownloadOption) {
     this.downloadOption = selectedDownloadOption;
+  }
+
+  @action
+  onChangeCurrentAgendaOnlyOption(selectedDownloadOption) {
+    this.currentAgendaOnlyOption = selectedDownloadOption;
   }
 
   openConfirmEmptyInternalReviews = () => {

--- a/app/utils/zip-agenda-files.js
+++ b/app/utils/zip-agenda-files.js
@@ -22,8 +22,8 @@ async function constructArchiveName(agenda) {
   return `VR_zitting_${formattedDate}_${agendaName}_alle_punten.zip`;
 }
 
-async function fetchArchivingJob(agenda, mandateeIds, decisions= false, pdfOnly, currentAgendaOnly) {
-  let url = `/agendas/${agenda.id}/agendaitems/pieces/files/archive?decisions=${decisions}&pdfOnly=${pdfOnly}&currentAgendaOnly=${currentAgendaOnly}`;
+async function fetchArchivingJob(agenda, mandateeIds, decisions= false, pdfOnly, newDocumentsOnly) {
+  let url = `/agendas/${agenda.id}/agendaitems/pieces/files/archive?decisions=${decisions}&pdfOnly=${pdfOnly}&newDocumentsOnly=${newDocumentsOnly}`;
   if (mandateeIds.length) {
     url += '&' + (new URLSearchParams({ mandateeIds }).toString());
   }
@@ -40,9 +40,9 @@ async function fetchArchivingJob(agenda, mandateeIds, decisions= false, pdfOnly,
   return await getJsonPayloadOrThrow(fetchedJob);
 }
 
-async function fetchArchivingJobForAgenda(agenda, mandateeIds, decisions, store, pdfOnly, currentAgendaOnly) {
+async function fetchArchivingJobForAgenda(agenda, mandateeIds, decisions, store, pdfOnly, newDocumentsOnly) {
   // pdfOnly is not applicable to decisions since KAS-5059
-  const job = await fetchArchivingJob(agenda, mandateeIds, decisions, pdfOnly ,currentAgendaOnly);
+  const job = await fetchArchivingJob(agenda, mandateeIds, decisions, pdfOnly ,newDocumentsOnly);
   if (job) {
     return registerJobToStore(job, store);
   }

--- a/app/utils/zip-agenda-files.js
+++ b/app/utils/zip-agenda-files.js
@@ -22,8 +22,8 @@ async function constructArchiveName(agenda) {
   return `VR_zitting_${formattedDate}_${agendaName}_alle_punten.zip`;
 }
 
-async function fetchArchivingJob(agenda, mandateeIds, decisions= false, pdfOnly) {
-  let url = `/agendas/${agenda.id}/agendaitems/pieces/files/archive?decisions=${decisions}&pdfOnly=${pdfOnly}`;
+async function fetchArchivingJob(agenda, mandateeIds, decisions= false, pdfOnly, currentAgendaOnly) {
+  let url = `/agendas/${agenda.id}/agendaitems/pieces/files/archive?decisions=${decisions}&pdfOnly=${pdfOnly}&currentAgendaOnly=${currentAgendaOnly}`;
   if (mandateeIds.length) {
     url += '&' + (new URLSearchParams({ mandateeIds }).toString());
   }
@@ -40,9 +40,9 @@ async function fetchArchivingJob(agenda, mandateeIds, decisions= false, pdfOnly)
   return await getJsonPayloadOrThrow(fetchedJob);
 }
 
-async function fetchArchivingJobForAgenda(agenda, mandateeIds, decisions, store, pdfOnly) {
+async function fetchArchivingJobForAgenda(agenda, mandateeIds, decisions, store, pdfOnly, currentAgendaOnly) {
   // pdfOnly is not applicable to decisions since KAS-5059
-  const job = await fetchArchivingJob(agenda, mandateeIds, decisions, pdfOnly);
+  const job = await fetchArchivingJob(agenda, mandateeIds, decisions, pdfOnly ,currentAgendaOnly);
   if (job) {
     return registerJobToStore(job, store);
   }

--- a/cypress/e2e/unit/agenda.cy.js
+++ b/cypress/e2e/unit/agenda.cy.js
@@ -44,7 +44,7 @@ function downloadDocs(postAgenda = true) {
   cy.wait(2000); // wait for deltas or file replacement from document-stamping service
 
   cy.get(appuniversum.loader).should('not.exist');
-  cy.intercept('POST', 'agendas/*/agendaitems/pieces/files/archive?decisions=false&pdfOnly=true').as(`postAgendas${randomInt}`);
+  cy.intercept('POST', 'agendas/*/agendaitems/pieces/files/archive?decisions=false&pdfOnly=true&newDocumentsOnly=false').as(`postAgendas${randomInt}`);
   cy.intercept('GET', '/file-bundling-jobs/**').as(`fileBundlingJobs${randomInt}`);
   cy.get(auk.confirmationModal.footer.confirm).click();
   cy.get(utils.downloadFileToast.link).eq(0)

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1564,5 +1564,8 @@
   "newsletter-only-announcements-to-send": "U staat op het punt om enkel mededelingen te publiceren",
   "publish-anyway": "Toch publiceren",
   "agendaitems-confidential-warning-title": "Agendapunten met beperkte toegang",
-  "agendaitems-confidential-warning-message": "Er zijn agendapunten met beperkte toegang opgenomen in het kort bestek, Deze zullen mee gepubliceerd worden als u bevestigt."
+  "agendaitems-confidential-warning-message": "Er zijn agendapunten met beperkte toegang opgenomen in het kort bestek, Deze zullen mee gepubliceerd worden als u bevestigt.",
+  "download-documents-agenda-selection": "Selectie documenten",
+  "download-documents-agenda-selection-all": "Alle documenten op deze agendaversie",
+  "download-documents-agenda-selection-current-only": "Enkel nieuwe documenten op deze agendaversie"
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-1989

- add option to download only "new" documents by passing a new param to backend.

- [x] https://github.com/kanselarij-vlaanderen/file-bundling-job-creation-service/pull/21
- [ ] https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/548 (Don't merge, for jenkins only)

- note, this is showing on agendas where only agenda A exists. In that case both option would be the same.
Not sure if this is ok.
I guess we could only show the option if the current agenda is A and there is only 1 agenda in total.


example of the updated modal
<img width="1920" height="803" alt="image" src="https://github.com/user-attachments/assets/cf9fccca-fd46-4f43-8716-55a1840825c9" />
