### PR TITLE
KAS-4997 fix publication pill filtering was too strict

### DIFF
--- a/app/components/agenda/agenda-header/publication-pills.js
+++ b/app/components/agenda/agenda-header/publication-pills.js
@@ -100,9 +100,13 @@ export default class AgendaAgendaHeaderPublicationPillsComponent extends Compone
       'filter[scope]': 'documents',
       include: 'status',
     });
+    // 2 scenarios:
+    // - we have 1 without a start-date between release of decisions and planned release of documents
+    // - we have 1 or more released/retracted with start-dates (any new one has startDate of now)
+    // - in both cases sorting on date should be fine.
     this.latestThemisDocumentPublicationActivity =  allThemisDocumentPublicationActivities
       .slice()
-      .filter((a) => a.startDate)
+      // .filter((a) => a.startDate) // we also need to show "planned only" activities, which have no startDate
       .sort((a1, a2) => a1.startDate - a2.startDate)
       .at(-1);
 

--- a/cypress/e2e/unit/release-status-pills.cy.js
+++ b/cypress/e2e/unit/release-status-pills.cy.js
@@ -66,8 +66,7 @@ context('Testing internal and themis document release pills', () => {
     cy.wait('@patchThemisActivity');
     cy.get(agenda.publicationPills.container).within(() => {
       cy.get(appuniversum.pill).contains(`Publicatie documenten gepland op ${newReleaseDate.format('DD-MM-YYYY')}`);
-      // cy.get(appuniversum.pill).eq(1)
-      //   .contains(`Publicatie documenten gepland op ${newReleaseDate.format('DD-MM-YYYY')}`);
+      cy.get(appuniversum.pill).contains(`Vrijgave van documenten gepland op ${newReleaseDate.format('DD-MM-YYYY')}`);
     });
   });
 });


### PR DESCRIPTION
test in release-status-pills.cy  is failing because of a recent fix for a different issue
This should correct it.