### PR TITLE
KAS-5147 handle succesful stamping job with message

### DIFF
--- a/app/services/document-service.js
+++ b/app/services/document-service.js
@@ -78,6 +78,12 @@ export default class DocumentService extends Service {
       `/document-stamping/agendas/${agendaId}/agendaitems/documents/stamp`,
       {
         method: 'POST',
+        // headers: {
+        //   'Content-Type': 'application/vnd.api+json',
+        // },
+        // body: JSON.stringify({
+        //   shouldRestamp : false,
+        // }),
       }
     );
     let data;
@@ -183,7 +189,7 @@ export default class DocumentService extends Service {
       setTimeout(() => {
         this.toaster.close(toasterToClose);
       }, 2000);
-      if (job.status === job.SUCCESS) {
+      if (job.status === job.SUCCESS && !job.message) {
         this.toaster.close(toasterToClose);
         this.toaster.success(
           this.intl.t(


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5147


- since it will be possible for jobs to succeed (everything stamped) but with invalid VR numbers, the error handling needed to change a bit.
- It is also possible to restamp everything on the agenda, but should only be a manual fetch so commented the code in the service to reflect that.

- [x] https://github.com/kanselarij-vlaanderen/document-stamping-service/pull/12