### PR TITLE
KAS-4715 add retracted access level

### DIFF
--- a/app/components/access-level-pill.js
+++ b/app/components/access-level-pill.js
@@ -36,6 +36,9 @@ export default class AccessLevelPillComponent extends Component {
         case CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK:
           icon = 'lock-closed';
           break;
+        case CONSTANTS.ACCESS_LEVELS.INGETROKKEN:
+          icon = 'lock-closed'; // TODO KAS-4715 what icon?
+          break;
         case CONSTANTS.ACCESS_LEVELS.INTERN_REGERING:
           icon = 'circle';
           break;
@@ -59,6 +62,9 @@ export default class AccessLevelPillComponent extends Component {
           skin = 'warning';
           break;
         case CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK:
+          skin = 'warning';
+          break;
+        case CONSTANTS.ACCESS_LEVELS.INGETROKKEN:
           skin = 'warning';
           break;
         case CONSTANTS.ACCESS_LEVELS.INTERN_REGERING:

--- a/app/components/access-level-pill.js
+++ b/app/components/access-level-pill.js
@@ -37,7 +37,7 @@ export default class AccessLevelPillComponent extends Component {
           icon = 'lock-closed';
           break;
         case CONSTANTS.ACCESS_LEVELS.INGETROKKEN:
-          icon = 'lock-closed'; // TODO KAS-4715 what icon?
+          icon = 'lock-closed';
           break;
         case CONSTANTS.ACCESS_LEVELS.INTERN_REGERING:
           icon = 'circle';

--- a/app/components/agenda/agendaitem/agendaitem-controls.js
+++ b/app/components/agenda/agendaitem/agendaitem-controls.js
@@ -238,7 +238,7 @@ export default class AgendaitemControls extends Component {
   @task
   *retractAgendaitem() {
     yield this.setDecisionResultCode.perform(CONSTANTS.DECISION_RESULT_CODE_URIS.INGETROKKEN);
-    yield this.updateDecisionPiecePart.perform(this.intl.t('retracted-item-decision'));
+    yield this.updateDecisionPiecePart.perform(this.intl.t('retracted-item-decision'), true);
     yield this.newsletterService.updateNewsItemVisibility(this.args.agendaitem);
   }
 
@@ -277,7 +277,7 @@ export default class AgendaitemControls extends Component {
   }
 
   @task
-  *updateDecisionPiecePart(message) {
+  *updateDecisionPiecePart(message, regenerateConcerns) {
     const report = yield this.store.queryOne('report', {
       filter: {
         'decision-activity': { ':id:': this.decisionActivity.id },
@@ -305,7 +305,8 @@ export default class AgendaitemControls extends Component {
         );
         yield newBeslissingPiecePart.save();
         yield this.decisionReportGeneration.generateReplacementReport.perform(
-          report
+          report,
+          regenerateConcerns
         );
       }
     }

--- a/app/components/agenda/agendaitem/agendaitem-controls.js
+++ b/app/components/agenda/agendaitem/agendaitem-controls.js
@@ -331,24 +331,24 @@ export default class AgendaitemControls extends Component {
     );
     this.decisionActivity.decisionResultCode = decisionResultCodeConcept;
     yield this.decisionActivity.save();
-    if (
-      [
-        CONSTANTS.DECISION_RESULT_CODE_URIS.UITGESTELD,
-        CONSTANTS.DECISION_RESULT_CODE_URIS.INGETROKKEN,
-      ].includes(decisionResultCodeUri)
-    ) {
+    if (decisionResultCodeUri === CONSTANTS.DECISION_RESULT_CODE_URIS.UITGESTELD) {
       const pieces = yield this.args.agendaitem.pieces;
       for (const piece of pieces.slice()) {
         yield this.pieceAccessLevelService.strengthenAccessLevelToInternRegering(
-          piece
+          piece,
         );
-        if (
-          decisionResultCodeUri ===
-          CONSTANTS.DECISION_RESULT_CODE_URIS.INGETROKKEN
-        ) {
+      }
+      return;
+    }
+    if (decisionResultCodeUri === CONSTANTS.DECISION_RESULT_CODE_URIS.INGETROKKEN) {
+      const pieces = yield this.args.agendaitem.pieces;
+        for (const piece of pieces.slice()) {
+          yield this.pieceAccessLevelService.strengthenAccessLevelToRetracted(
+            piece,
+          );
           yield this.signatureService.removeSignFlowForPiece(piece);
         }
-      }
+      return;
     }
   }
 }

--- a/app/components/agenda/agendaitem/decision/digital.js
+++ b/app/components/agenda/agendaitem/decision/digital.js
@@ -231,16 +231,19 @@ export default class AgendaAgendaitemDecisionDigitalComponent extends Component 
   updateAgendaitemPiecesAccessLevels = task(async () => {
     const decisionResultCode = await this.args.decisionActivity
       .decisionResultCode;
-    if (
-      [
-        CONSTANTS.DECISION_RESULT_CODE_URIS.UITGESTELD,
-        CONSTANTS.DECISION_RESULT_CODE_URIS.INGETROKKEN,
-      ].includes(decisionResultCode?.uri)
-    ) {
+    if (decisionResultCode?.uri === CONSTANTS.DECISION_RESULT_CODE_URIS.UITGESTELD) {
       const pieces = await this.args.agendaitem.pieces;
       for (const piece of pieces.slice()) {
         await this.pieceAccessLevelService.strengthenAccessLevelToInternRegering(
-          piece
+          piece,
+        );
+      }
+    }
+    if (decisionResultCode?.uri === CONSTANTS.DECISION_RESULT_CODE_URIS.INGETROKKEN) {
+      const pieces = await this.args.agendaitem.pieces;
+      for (const piece of pieces.slice()) {
+        await this.pieceAccessLevelService.strengthenAccessLevelToRetracted(
+          piece,
         );
       }
     }

--- a/app/components/agenda/agendaitem/decision/digital.js
+++ b/app/components/agenda/agendaitem/decision/digital.js
@@ -200,6 +200,7 @@ export default class AgendaAgendaitemDecisionDigitalComponent extends Component 
       return;
     }
     let newBeslissingHtmlContent = this.beslissingPiecePart.htmlContent;
+    let regenerateConcerns = false;
     const decisionResultCode = await this.args.decisionActivity.decisionResultCode;
     switch (decisionResultCode?.uri) {
       case CONSTANTS.DECISION_RESULT_CODE_URIS.UITGESTELD:
@@ -207,6 +208,7 @@ export default class AgendaAgendaitemDecisionDigitalComponent extends Component 
         break;
       case CONSTANTS.DECISION_RESULT_CODE_URIS.INGETROKKEN:
         newBeslissingHtmlContent = this.intl.t('retracted-item-decision');
+        regenerateConcerns = true;
         break;
       default:
         break;
@@ -222,10 +224,14 @@ export default class AgendaAgendaitemDecisionDigitalComponent extends Component 
       });
       await newBeslissingPiecePart.save();
       await this.decisionReportGeneration.generateReplacementReport.perform(
-        this.report
+        this.report,
+        regenerateConcerns
       );
     }
     await this.loadBeslissingPiecePart.perform();
+    if (regenerateConcerns) {
+      await this.loadBetreftPiecePart.perform();
+    }
   });
 
   updateAgendaitemPiecesAccessLevels = task(async () => {

--- a/app/components/agenda/agendaitem/decision/legacy.js
+++ b/app/components/agenda/agendaitem/decision/legacy.js
@@ -59,16 +59,19 @@ export default class AgendaAgendaitemDecisionLegacyComponent extends Component {
   updateAgendaitemPiecesAccessLevels = task(async () => {
     const decisionResultCode = await this.args.decisionActivity
       .decisionResultCode;
-    if (
-      [
-        CONSTANTS.DECISION_RESULT_CODE_URIS.UITGESTELD,
-        CONSTANTS.DECISION_RESULT_CODE_URIS.INGETROKKEN,
-      ].includes(decisionResultCode?.uri)
-    ) {
+    if (decisionResultCode?.uri === CONSTANTS.DECISION_RESULT_CODE_URIS.UITGESTELD) {
       const pieces = await this.args.agendaitem.pieces;
       for (const piece of pieces.slice()) {
         await this.pieceAccessLevelService.strengthenAccessLevelToInternRegering(
-          piece
+          piece,
+        );
+      }
+    }
+    if (decisionResultCode?.uri === CONSTANTS.DECISION_RESULT_CODE_URIS.INGETROKKEN) {
+      const pieces = await this.args.agendaitem.pieces;
+      for (const piece of pieces.slice()) {
+        await this.pieceAccessLevelService.strengthenAccessLevelToRetracted(
+          piece,
         );
       }
     }

--- a/app/components/agenda/printable-agenda/list-section/item-group/item/document.js
+++ b/app/components/agenda/printable-agenda/list-section/item-group/item/document.js
@@ -15,6 +15,10 @@ export default class AgendaPrintableAgendaListSectionItemGroupItemDocumentListDo
 
   get showAccessLevel() {
     const accessLevelUri = this.args.accessLevel.get('uri');
-    return (accessLevelUri === CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK) || (accessLevelUri === CONSTANTS.ACCESS_LEVELS.INTERN_SECRETARIE);
+    return (
+      accessLevelUri === CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK ||
+      accessLevelUri === CONSTANTS.ACCESS_LEVELS.INTERN_SECRETARIE ||
+      accessLevelUri === CONSTANTS.ACCESS_LEVELS.INGETROKKEN
+    );
   }
 }

--- a/app/components/documents/document-badge-list.js
+++ b/app/components/documents/document-badge-list.js
@@ -9,7 +9,8 @@ export default class DcoumentsDocumentBadgeListComponent extends Component {
   shouldShowAccessLevel(accessLevel) {
     return [
       CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK,
-      CONSTANTS.ACCESS_LEVELS.INTERN_SECRETARIE
+      CONSTANTS.ACCESS_LEVELS.INTERN_SECRETARIE,
+      CONSTANTS.ACCESS_LEVELS.INGETROKKEN,
     ].includes(accessLevel?.uri);
   }
 }

--- a/app/config/constants.js
+++ b/app/config/constants.js
@@ -17,6 +17,7 @@ export default {
   ACCESS_LEVELS: {
     INTERN_SECRETARIE: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/66804c35-4652-4ff4-b927-16982a3b6de8',
     VERTROUWELIJK: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/9692ba4f-f59b-422b-9402-fcbd30a46d17',
+    INGETROKKEN: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/9b354d36-250b-43d7-887c-db28fe2fc6fb',
     INTERN_REGERING: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/13ae94b0-6188-49df-8ecd-4c4a17511d6d',
     INTERN_OVERHEID: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/634f438e-0d62-4ae4-923a-b63460f6bc46',
     PUBLIEK: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/c3de9c70-391e-4031-a85e-4b03433d6266',
@@ -24,6 +25,7 @@ export default {
   ACCESS_LEVEL_IDS: {
     INTERN_SECRETARIE: '66804c35-4652-4ff4-b927-16982a3b6de8',
     VERTROUWELIJK: '9692ba4f-f59b-422b-9402-fcbd30a46d17',
+    INGETROKKEN: '9b354d36-250b-43d7-887c-db28fe2fc6fb',
     INTERN_REGERING: '13ae94b0-6188-49df-8ecd-4c4a17511d6d',
     INTERN_OVERHEID: '634f438e-0d62-4ae4-923a-b63460f6bc46',
     PUBLIEK: 'c3de9c70-391e-4031-a85e-4b03433d6266',

--- a/app/config/constants.js
+++ b/app/config/constants.js
@@ -17,7 +17,7 @@ export default {
   ACCESS_LEVELS: {
     INTERN_SECRETARIE: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/66804c35-4652-4ff4-b927-16982a3b6de8',
     VERTROUWELIJK: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/9692ba4f-f59b-422b-9402-fcbd30a46d17',
-    INGETROKKEN: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/9b354d36-250b-43d7-887c-db28fe2fc6fb',
+    INGETROKKEN: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/969a712a-b3d3-406f-ab08-5f665427185a',
     INTERN_REGERING: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/13ae94b0-6188-49df-8ecd-4c4a17511d6d',
     INTERN_OVERHEID: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/634f438e-0d62-4ae4-923a-b63460f6bc46',
     PUBLIEK: 'http://themis.vlaanderen.be/id/concept/toegangsniveau/c3de9c70-391e-4031-a85e-4b03433d6266',
@@ -25,7 +25,7 @@ export default {
   ACCESS_LEVEL_IDS: {
     INTERN_SECRETARIE: '66804c35-4652-4ff4-b927-16982a3b6de8',
     VERTROUWELIJK: '9692ba4f-f59b-422b-9402-fcbd30a46d17',
-    INGETROKKEN: '9b354d36-250b-43d7-887c-db28fe2fc6fb',
+    INGETROKKEN: '969a712a-b3d3-406f-ab08-5f665427185a',
     INTERN_REGERING: '13ae94b0-6188-49df-8ecd-4c4a17511d6d',
     INTERN_OVERHEID: '634f438e-0d62-4ae4-923a-b63460f6bc46',
     PUBLIEK: 'c3de9c70-391e-4031-a85e-4b03433d6266',

--- a/app/controllers/signatures/ongoing-decisions.js
+++ b/app/controllers/signatures/ongoing-decisions.js
@@ -58,6 +58,7 @@ export default class SignaturesOngoingDecisionsController extends Controller {
     return [
       CONSTANTS.ACCESS_LEVELS.INTERN_SECRETARIE,
       CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK,
+      CONSTANTS.ACCESS_LEVELS.INGETROKKEN,
     ].includes(accessLevel.get('uri'));
   }
 

--- a/app/controllers/signatures/ongoing-ratifications.js
+++ b/app/controllers/signatures/ongoing-ratifications.js
@@ -58,6 +58,7 @@ export default class SignaturesOngoingRatificationsController extends Controller
     return [
       CONSTANTS.ACCESS_LEVELS.INTERN_SECRETARIE,
       CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK,
+      CONSTANTS.ACCESS_LEVELS.INGETROKKEN,
     ].includes(accessLevel.get('uri'));
   }
 

--- a/app/controllers/signatures/ongoing.js
+++ b/app/controllers/signatures/ongoing.js
@@ -56,6 +56,7 @@ export default class SignaturesOngoingController extends Controller {
     return [
       CONSTANTS.ACCESS_LEVELS.INTERN_SECRETARIE,
       CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK,
+      CONSTANTS.ACCESS_LEVELS.INGETROKKEN,
     ].includes(accessLevel.get('uri'));
   }
 

--- a/app/routes/search/documents.js
+++ b/app/routes/search/documents.js
@@ -92,6 +92,7 @@ export default class SearchDocumentsRoute extends Route {
       filter[':terms:accessLevel'] = [
         CONSTANTS.ACCESS_LEVELS.INTERN_SECRETARIE,
         CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK,
+        CONSTANTS.ACCESS_LEVELS.INGETROKKEN,
       ];
     }
 

--- a/app/services/decision-report-generation.js
+++ b/app/services/decision-report-generation.js
@@ -227,7 +227,7 @@ export default class DecisionReportGeneration extends Service {
     return { alterableReports, unalterableReports };
   }
 
-  generateReplacementReport = task(async (report) => {
+  generateReplacementReport = task(async (report, regenerateConcerns) => {
     if (!(await this.canReplaceReport(report))) {
       this.toaster.error(
         this.intl.t('report-cannot-be-altered', {
@@ -237,7 +237,7 @@ export default class DecisionReportGeneration extends Service {
       return;
     }
     try {
-      await this._generateSinglePdf.perform(report, 'generate-decision-report');
+      await this._generateSinglePdf.perform(report, 'generate-decision-report', regenerateConcerns);
       await this.reloadFile(report);
       this.toaster.success(
         this.intl.t(
@@ -304,12 +304,21 @@ export default class DecisionReportGeneration extends Service {
     return !hasPreparationActivity;
   }
 
-  _generateSinglePdf = task(async (report, urlBase) => {
-    const response = await fetch(`/${urlBase}/${report.id}`);
+  _generateSinglePdf = task(async (report, urlBase, shouldRegenerateConcerns = false) => {
+    const response = await fetch(`/${urlBase}/${report.id}`, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/vnd.api+json',
+        'Content-Type': 'application/vnd.api+json',
+      },
+      body: JSON.stringify({
+        shouldRegenerateConcerns,
+      }),
+    });
     return await getJsonPayloadOrThrow(response);
   });
 
-  _generateMultiplePdfs = task(async (reports, urlBase, shouldRegenerateConcerns=false) => {
+  _generateMultiplePdfs = task(async (reports, urlBase, shouldRegenerateConcerns = false) => {
     const response = await fetch(`/${urlBase}/generate-reports`, {
       method: 'POST',
       headers: {

--- a/app/services/piece-access-level-service.js
+++ b/app/services/piece-access-level-service.js
@@ -40,6 +40,7 @@ export default class PieceAccessLevelService extends Service {
   async updatePreviousAccessLevel(piece) {
     const internSecretarie = await this.store.findRecordByUri('concept', CONSTANTS.ACCESS_LEVELS.INTERN_SECRETARIE);
     const vertrouwelijk = await this.store.findRecordByUri('concept', CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK);
+    const ingetrokken = await this.store.findRecordByUri('concept', CONSTANTS.ACCESS_LEVELS.INGETROKKEN);
     const internRegering = await this.store.findRecordByUri('concept', CONSTANTS.ACCESS_LEVELS.INTERN_REGERING);
 
     const accessLevel = await piece.accessLevel;
@@ -59,6 +60,16 @@ export default class PieceAccessLevelService extends Service {
       return false;
     }
 
+    if (
+      previousAccessLevel.uri === CONSTANTS.ACCESS_LEVELS.INGETROKKEN &&
+      ![
+        CONSTANTS.ACCESS_LEVELS.INTERN_SECRETARIE,
+        CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK,
+      ].includes(accessLevel.uri)
+    ) {
+      return false;
+    }
+
     let accessLevelToSet;
     switch (accessLevel.uri) {
       case CONSTANTS.ACCESS_LEVELS.INTERN_SECRETARIE:
@@ -66,6 +77,9 @@ export default class PieceAccessLevelService extends Service {
         break;
       case CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK:
         accessLevelToSet = vertrouwelijk;
+        break;
+      case CONSTANTS.ACCESS_LEVELS.INGETROKKEN:
+        accessLevelToSet = ingetrokken;
         break;
       default:
         accessLevelToSet = internRegering;
@@ -101,6 +115,7 @@ export default class PieceAccessLevelService extends Service {
       ![
         CONSTANTS.ACCESS_LEVELS.INTERN_SECRETARIE,
         CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK,
+        CONSTANTS.ACCESS_LEVELS.INGETROKKEN,
         CONSTANTS.ACCESS_LEVELS.INTERN_REGERING,
       ].includes(accessLevel.uri)
     ) {
@@ -130,6 +145,31 @@ export default class PieceAccessLevelService extends Service {
     ) {
       const confidential = await this.store.findRecordByUri('concept', CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK);
       piece.accessLevel = confidential;
+      await piece.save();
+      await this.updateSignedPieceAccessLevels(piece);
+      await this.updatePreviousAccessLevels(piece);
+    }
+  }
+
+  /**
+   * Strengthen the access level of the piece to ingetrokken (unless the
+   * access level was already this level or higher) and then update all the previous access
+   * levels.
+   */
+  async strengthenAccessLevelToRetracted(piece) {
+    const accessLevel = await piece.accessLevel;
+    if (
+      ![
+        CONSTANTS.ACCESS_LEVELS.INTERN_SECRETARIE,
+        CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK,
+        CONSTANTS.ACCESS_LEVELS.INGETROKKEN,
+      ].includes(accessLevel.uri)
+    ) {
+      const ingetrokken = await this.store.findRecordByUri(
+        'concept',
+        CONSTANTS.ACCESS_LEVELS.INGETROKKEN,
+      );
+      piece.accessLevel = ingetrokken;
       await piece.save();
       await this.updateSignedPieceAccessLevels(piece);
       await this.updatePreviousAccessLevels(piece);
@@ -253,8 +293,11 @@ export default class PieceAccessLevelService extends Service {
       if (accessLevel.uri === CONSTANTS.ACCESS_LEVELS.INTERN_SECRETARIE) {
         // no propagation required, so never in draft
         return false;
-      } else if (accessLevel.uri === CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK) {
-        // draft iff:
+      } else if (
+        accessLevel.uri === CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK ||
+        accessLevel.uri === CONSTANTS.ACCESS_LEVELS.INGETROKKEN
+      ) {
+        // draft if:
         // - design-agenda without previous version
         // - new document on an agendaitem of a design agenda with a previous version
         const isDesignAgenda = (await agenda.status).isDesignAgenda;
@@ -308,7 +351,8 @@ export default class PieceAccessLevelService extends Service {
     );
     if (
       mayViewConfidentialPiece &&
-      accessLevel?.uri === CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK
+      (accessLevel?.uri === CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK ||
+        accessLevel?.uri === CONSTANTS.ACCESS_LEVELS.INGETROKKEN)
     ) {
       const submissionActivity = await this.store.queryOne('submission-activity', {
         filter: {
@@ -360,18 +404,23 @@ export default class PieceAccessLevelService extends Service {
       }
     } else {
       // careful with submissions access/permissions, all confidential files are in the submissions graph
+      // retracted documents treated similar to confidential
       const mayViewAllConfidentialPieces = this.currentSession.may(
         'view-all-confidential-documents'
       );
       // TODO will there ever be intern secretarie document in the submissions??
-      if (!mayViewAllConfidentialPieces && accessLevel?.uri === CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK) {
-        // specifically cabinet medewerker needs this for submission graph docs, other profiles don't have confidential in their graph
+      if (
+        !mayViewAllConfidentialPieces &&
+        (accessLevel?.uri === CONSTANTS.ACCESS_LEVELS.VERTROUWELIJK ||
+          accessLevel?.uri === CONSTANTS.ACCESS_LEVELS.INGETROKKEN)
+      ) {
+        // specifically cabinet medewerker needs this for submission graph docs, other profiles don't have confidential (or retracted) in their graph
         return false;
       }
       // default to standard behaviour (if non confidential doc is in your graph it can be accessed normally)
       return true;
     }
-    // dossierbeheerder looking at a confidential doc that is not theirs
+    // dossierbeheerder looking at a confidential/retracted doc that is not theirs
     return false;
   }
 }

--- a/app/utils/decision-minutes-formatting.js
+++ b/app/utils/decision-minutes-formatting.js
@@ -33,8 +33,12 @@ function formatDocuments(pieceRecords, isApproval) {
       continue;
     }
   }
-  const formatter = new Intl.ListFormat('nl-be');
-  return `(${formatter.format(simplifiedNames)})`;
+  if (simplifiedNames.length) {
+    const formatter = new Intl.ListFormat('nl-be');
+    return `(${formatter.format(simplifiedNames)})`;
+  }
+  // no documents or all rectracted
+  return '';
 }
 
 async function generateBetreft(
@@ -45,21 +49,26 @@ async function generateBetreft(
   subcaseName = null,
   agendaitemType,
 ) {
-  const documentsWithoutBijlageTerInzageOrSecretarie = await Promise.all(documents.map(async (document) => {
+  const documentsForBetreft = await Promise.all(documents.map(async (document) => {
     const accessLevel = await document.accessLevel;
     const documentContainer = await document.documentContainer;
     // it is possible to concurrently change the type, need to reload just in case
     const type = await documentContainer.belongsTo('type').reload();
+    // this document type should not be shown in the documents list
     if (type?.uri === CONSTANTS.DOCUMENT_TYPES.BIJLAGE_TER_INZAGE) {
       return null;
     }
-    if (accessLevel?.uri === CONSTANTS.ACCESS_LEVELS.INTERN_SECRETARIE) {
+    // these accessLevels should not be shown in the documents list
+    if (
+      accessLevel?.uri === CONSTANTS.ACCESS_LEVELS.INTERN_SECRETARIE ||
+      accessLevel?.uri === CONSTANTS.ACCESS_LEVELS.INGETROKKEN
+    ) {
       return null;
     }
     return document;
   }))
   const isNota = agendaitemType?.uri === CONSTANTS.AGENDA_ITEM_TYPES.NOTA;
-  const filteredDocuments = documentsWithoutBijlageTerInzageOrSecretarie.filter((document) => document !== null);
+  const filteredDocuments = documentsForBetreft.filter((document) => document !== null);
   let betreft = '';
   betreft += `${shortTitle}`;
   betreft += title ? `<br/>${title}` : '';

--- a/cypress/e2e/unit/cancel-editing-document.cy.js
+++ b/cypress/e2e/unit/cancel-editing-document.cy.js
@@ -402,7 +402,7 @@ context('Tests for cancelling CRUD operations on document and pieces', () => {
     cy.get(document.documentDetailsRow.row).eq(1)
       .find(document.documentDetailsRow.accessLevel)
       .click();
-    cy.get(dependency.emberPowerSelect.option).eq(4)
+    cy.get(dependency.emberPowerSelect.option).contains(accesLevelOption3)
       .click();
     cy.intercept('PATCH', '/pieces/**').as('patchPieces');
     cy.intercept('PATCH', '/document-containers/**').as('patchdocumentContainers');
@@ -420,7 +420,7 @@ context('Tests for cancelling CRUD operations on document and pieces', () => {
     cy.get(document.documentDetailsRow.row).eq(0)
       .find(document.documentDetailsRow.type)
       .click();
-    cy.get(dependency.emberPowerSelect.option).eq(2)
+    cy.get(dependency.emberPowerSelect.option).contains(typeOption)
       .click();
     cy.intercept('PATCH', '/pieces/**').as('patchPieces2');
     cy.intercept('PATCH', '/document-containers/**').as('patchdocumentContainers2');
@@ -439,13 +439,13 @@ context('Tests for cancelling CRUD operations on document and pieces', () => {
     cy.get(document.documentDetailsRow.row).eq(1)
       .find(document.documentDetailsRow.type)
       .click();
-    cy.get(dependency.emberPowerSelect.option).eq(1)
+    cy.get(dependency.emberPowerSelect.option).contains(typeOption2)
       .click();
     cy.wait(500); // minor wait between ember power selects to ensure the previous one closed
     cy.get(document.documentDetailsRow.row).eq(0)
       .find(document.documentDetailsRow.type)
       .click();
-    cy.get(dependency.emberPowerSelect.option).eq(1)
+    cy.get(dependency.emberPowerSelect.option).contains(typeOption2)
       .click();
     cy.intercept('PATCH', '/pieces/**').as('patchPieces3');
     cy.intercept('PATCH', '/document-containers/**').as('patchdocumentContainers3');


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4715

WIP


- [x] https://github.com/kanselarij-vlaanderen/decision-report-generation-service/pull/28
- [x] https://github.com/kanselarij-vlaanderen/document-naming-service/pull/13
- [x] https://github.com/kanselarij-vlaanderen/file-bundling-job-creation-service/pull/22
- [x] https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/552


Been looking and thinking what else is different.

Yggdrasil doesn't need changes.
Minister graph gets everything but "interne secretarie", regering graph gets only "regering, overheid, public" documents.

