### PR TITLE
add deprecated themes list to theme selector for legacy edits

### DIFF
--- a/app/components/utils/themes-selector.hbs
+++ b/app/components/utils/themes-selector.hbs
@@ -1,6 +1,32 @@
 {{#if this.findAll.isRunning}}
   <Auk::Loader @message={{t "themes-loading-text"}} />
 {{else}}
+  {{#if this.deprecatedThemes}}
+    <AuAlert
+      @skin="warning"
+      @icon="alert-triangle"
+      @size="small"
+    >
+      <AuLabel>{{t "deprecated-themes"}}</AuLabel>
+      <div class="auk-o-grid">
+        {{#each this.deprecatedThemes as |theme|}}
+          <div class="auk-o-grid-col-4">
+            <div class="auk-u-mb">
+              {{#let (includes theme @selectedThemes) as |checked|}}
+                <AuCheckbox
+                  @checked={{checked}}
+                  @onChange={{fn this.toggleTheme theme}}
+                  @disabled={{not checked}}
+                >
+                  {{theme.label}}
+                </AuCheckbox>
+              {{/let}}
+            </div>
+          </div>
+        {{/each}}
+      </div>
+    </AuAlert>
+  {{/if}}
   <div class="auk-o-grid">
     {{#each this.themes as |theme|}}
       <div class="auk-o-grid-col-4">

--- a/app/components/utils/themes-selector.js
+++ b/app/components/utils/themes-selector.js
@@ -12,6 +12,7 @@ export default class ThemesSelector extends Component {
   @service store;
 
   @tracked themes;
+  @tracked deprecatedThemes;
 
   constructor() {
     super(...arguments);
@@ -24,6 +25,12 @@ export default class ThemesSelector extends Component {
       filter: { deprecated: false },
       sort: 'label',
     });
+    if (this.args.selectedThemes?.some((theme) => theme.deprecated)) {
+      this.deprecatedThemes = yield this.store.queryAll('theme', {
+        filter: { deprecated: true },
+        sort: 'label',
+      });
+    }
   }
 
   @action

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1570,5 +1570,6 @@
   "agendaitems-confidential-warning-message": "Er zijn agendapunten met beperkte toegang opgenomen in het kort bestek, Deze zullen mee gepubliceerd worden als u bevestigt.",
   "download-documents-agenda-selection": "Selectie documenten",
   "download-documents-agenda-selection-all": "Alle documenten op deze agendaversie",
-  "download-documents-agenda-selection-current-only": "Enkel nieuwe documenten op deze agendaversie"
+  "download-documents-agenda-selection-current-only": "Enkel nieuwe documenten op deze agendaversie",
+  "deprecated-themes": "Legacy thema's"
 }


### PR DESCRIPTION
No ticket yet
Made this in 15 min as a POC that editing old themes was easily changed.
Styling is in the air, I wanted it to pop out and be obvious those are old.

