### PR TITLE
KAS-5214 fix submission inheriting old government areas

### DIFF
--- a/app/components/cases/new-submission.js
+++ b/app/components/cases/new-submission.js
@@ -81,14 +81,7 @@ export default class CasesNewSubmissionComponent extends Component {
       this.title = this.latestSubcase.title;
       this.subcaseName = this.latestSubcase.subcaseName;
       this.governmentAreas = await this.latestSubcase.governmentAreas;
-      for (const governmentArea of this.governmentAreas) {
-        await governmentArea.broader;
-        if (governmentArea.broader) {
-          this.selectedGovernmentFields.push(governmentArea);
-        } else {
-          this.selectedGovernmentDomains.push(governmentArea);
-        }
-      }
+      // the governmentAreas will be date filtered into selected fields and domains by the governmentAreasPanel
     }
   })
 

--- a/app/components/cases/subcases/government-areas-panel.js
+++ b/app/components/cases/subcases/government-areas-panel.js
@@ -58,9 +58,8 @@ export default class GovernmentAreasPanel extends Component {
     );
 
     let uniqueDomains = domainsFromAvailableFields
-      .uniq()
-      .slice()
-      .sort((d1, d2) => d1.label - d2.label);
+      .filter((value, index, array) => array.indexOf(value) === index) // like .uniq()
+      .sort((d1, d2) => d1.label.localeCompare(d2.label));
 
     // process args.governmentAreas into domains and fields
     const selectedDomains = [];
@@ -100,7 +99,6 @@ export default class GovernmentAreasPanel extends Component {
       if (isSelected) {
         this.args.onSelectDomains([domain]);
       }
-
       return new DomainSelection(
         domain,
         isSelected,

--- a/app/components/utils/government-areas/edit-government-areas-modal.js
+++ b/app/components/utils/government-areas/edit-government-areas-modal.js
@@ -14,14 +14,10 @@ export default class EditGovernmentAreasModal extends Component {
   constructor() {
     super(...arguments);
     this.loadGovernmentAreas.perform();
-    this.selectedGovernmentFields = this.args.governmentFields?.slice(0) || []; // making a copy
-    this.selectedGovernmentDomains =
-      this.args.governmentDomains?.slice(0) || []; // making a copy
   }
 
-  @task
-  *loadGovernmentAreas() {
-    const concepts = yield this.conceptStore.queryAllGovernmentFields();
+  loadGovernmentAreas = task(async () => {
+    const concepts = await this.conceptStore.queryAllGovernmentFields();
     const governmentFields = [];
     for (const concept of concepts.slice()) {
       const isInDateRange =
@@ -34,15 +30,43 @@ export default class EditGovernmentAreasModal extends Component {
       }
     }
     this.governmentFields = governmentFields;
-  }
+    await this.loadSelectedAreas.perform();
+  })
 
-  @task
-  *save() {
-    yield this.args.onSave(
+  save = task(async () => {
+    await this.args.onSave(
       this.selectedGovernmentDomains,
       this.selectedGovernmentFields
     );
-  }
+  })
+
+  loadSelectedAreas = task(async () => {
+    // problem solved here: if the government areas were inherited they could be outside the "active" range
+    // they are not shown in checkboxes and can't be deselected manually
+    // to solve this we remove all inactive fields and domains on save (based on referenceDate)
+
+    // get the active domains, in a set
+    let activeGovernmentDomains = await Promise.all(
+      this.governmentFields.slice().map((c) => c.broader)
+    );
+    const uniqueGovernmentDomains = activeGovernmentDomains
+      .filter((value, index, array) => array.indexOf(value) === index) // like .uniq()
+      .sort((d1, d2) => d1.label.localeCompare(d2.label));
+
+    const governmentFieldsFromArgs = this.args.governmentFields?.slice(0) || []; // making a copy
+    const governmentDomainsFromArgs = this.args.governmentDomains?.slice(0) || []; // making a copy
+
+    for (const governmentField of governmentFieldsFromArgs) {
+      if (this.governmentFields.includes(governmentField)) {
+        this.selectedGovernmentFields.push(governmentField);
+      }
+    }
+    for (const governmentDomain of governmentDomainsFromArgs) {
+      if (uniqueGovernmentDomains.includes(governmentDomain)) {
+        this.selectedGovernmentDomains.push(governmentDomain);
+      }
+    }
+  })
 
   @action
   selectField(selectedFields) {

--- a/app/components/utils/government-areas/government-areas-panel.js
+++ b/app/components/utils/government-areas/government-areas-panel.js
@@ -25,6 +25,7 @@ export default class GovernmentAreasPanel extends Component {
    * @argument governmentAreas: the list of concepts from the model
    * @argument allowEditing
    * @argument onSave
+   * @argument referenceDate
    */
 
   @tracked isOpenEditModal;

--- a/cypress/e2e/unit/submission_B.cy.js
+++ b/cypress/e2e/unit/submission_B.cy.js
@@ -142,6 +142,7 @@ context('Submission happy flows', () => {
       {
         name: 'Welzijn, Volksgezondheid en Gezin',
         selected: true,
+        // these fields are no longer active, they should not be added on submission creation
         fields: ['Welzijn', 'Gezondheids- en woonzorg'],
       }
     ],
@@ -377,14 +378,16 @@ context('Submission happy flows', () => {
     cy.get('@listItemsAreas').should('have.length', 1, {
       timeout: 5000,
     });
+    // the domain from previous subcase is NOT deprecated, so they are added on submission creation
     cy.get('@listItemsAreas')
       .eq(0)
       .find(utils.governmentAreasPanel.row.label)
       .should('contain', previousSubcaseInfo.domains[0].name);
+    // the fields from previous subcase are OUTSIDE active range, so they are NOT added on submission creation
     cy.get('@listItemsAreas')
       .eq(0)
       .find(utils.governmentAreasPanel.row.fields)
-      .should('contain', previousSubcaseInfo.domains[0].fields[(0, 1)]);
+      .should('not.contain', previousSubcaseInfo.domains[0].fields[(0, 1)]);
 
     // emails
     cy.get(submissions.notificationsPanel.edit).should('not.exist');


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5214

There were 2 issues going on here:

The first issue was that we added old government areas to submission from `latestSubcase`
Solved that by removing the code responsible in `app/components/cases/new-submission.js`
We don't need that piece of code. the `selectedGovernmentFields` will be populated when the selector initializes.
that populating only adds active domains and fields at the time of creation. 

Test it by:
open an older case/subcase (before 1/1/26) and make a new submission.
Even deprecated domains will get filtered out.


The second issue was after the above happened. Now we have subcases/agendaitems with old governmentAreas and the edit panel does not show any checkboxes.
Since the only way to "remove" those "hidden" fields and domains is pressing a checkbox (to change the current selection)
and then saving (the entire selection is saved) it was not possible to remove them
So we need to edit the current selection at some stage and remove the old ones.
Which I have done during construction of `app/components/utils/government-areas/edit-government-areas-modal.js`
The parent of that panel > `<Utils::GovernmentAreas::GovernmentAreasPanel` is used **almost** everywhere expect publication views AND new-submission / new-subcase-form

for the latter we use `<Cases::Subcases::GovernmentAreasPanel`
Which contains the following piece of code that will remove old fields during construction (which issue 1 relies on now)

https://github.com/kanselarij-vlaanderen/frontend-kaleidos/blob/feature/KAS-5214-old-government-areas-on-submission/app/components/cases/subcases/government-areas-panel.js#L74

Todo? not sure if I checked the scenario where a deprecated domain was selected (and no fields from it) when making new submission. is this inherited or not (since we should be unable to "select" it, it shouldn't be selected. but it might still exist in the `selectedDomains` property
