### PR TITLE
 bugfix/KAS-5143-agenda-grouping-stuck-when-tab-inactive

### DIFF
--- a/app/controllers/agenda/agendaitems.js
+++ b/app/controllers/agenda/agendaitems.js
@@ -3,7 +3,7 @@ import { inject as service } from '@ember/service';
 import { guidFor } from '@ember/object/internals';
 import { action, set } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { task, lastValue, all, animationFrame } from 'ember-concurrency';
+import { task, lastValue, all, timeout } from 'ember-concurrency';
 import {
   setAgendaitemsNumber,
   AgendaitemGroup
@@ -23,7 +23,7 @@ export default class AgendaAgendaitemsController extends Controller {
       },
     },
   ];
-  
+
   @service store;
   @service router;
   @service intl;
@@ -135,7 +135,7 @@ export default class AgendaAgendaitemsController extends Controller {
     const agendaitemGroups = [];
     let currentAgendaitemGroup;
     for (const agendaitem of agendaitemsArray) {
-      yield animationFrame(); // Computationally heavy task. This keeps the interface alive
+      yield timeout(0); // Computationally heavy task. This keeps the interface alive
       const agendaActivity = yield agendaitem.agendaActivity;
       const subcase = yield agendaActivity?.subcase;
       yield subcase?.type;


### PR DESCRIPTION
The groupNotasOnGroupName task uses yield animationFrame() to keep the UI responsive while iterating over agenda items. However, browsers pause requestAnimationFrame callbacks when a tab is not visible, causing the task to hang indefinitely until the user switches back to the tab.

Replaced animationFrame() with timeout(0). This still yields to the main thread each iteration to keep the UI responsive, but unlike requestAnimationFrame, setTimeout continues to fire in background tabs.