### PR TITLE
Fix "New" badge on agenda check by loading compared pieces with findRecord insteaf of queryRecord

### DIFF
--- a/app/services/agenda-service.js
+++ b/app/services/agenda-service.js
@@ -53,10 +53,7 @@ export default class AgendaService extends Service {
         item.id
       );
       if (!itemFromStore) {
-        const modelName = singularize(item.type);
-        itemFromStore = typeof item.id === 'string'
-          ? await this.store.findRecord(modelName, item.id)
-          : await this.store.queryRecord(modelName, item.id);
+        itemFromStore = await this.store.findRecord(singularize(item.type), item.id);
       }
       itemsFromStore.push(itemFromStore);
     }
@@ -77,10 +74,7 @@ export default class AgendaService extends Service {
         item.id
       );
       if (!itemFromStore) {
-        const modelName = singularize(item.type);
-        itemFromStore = typeof item.id === 'string'
-          ? await this.store.findRecord(modelName, item.id)
-          : await this.store.queryRecord(modelName, item.id);
+        itemFromStore = await this.store.findRecord(singularize(item.type), item.id);
       }
       itemsFromStore.push(itemFromStore);
     }
@@ -101,10 +95,7 @@ export default class AgendaService extends Service {
         piece.id
       );
       if (!pieceFromStore) {
-        const modelName = singularize(piece.type);
-        pieceFromStore = typeof piece.id === 'string'
-          ? await this.store.findRecord(modelName, piece.id)
-          : await this.store.queryRecord(modelName, piece.id);
+        pieceFromStore = await this.store.findRecord(singularize(piece.type), piece.id);
       }
       piecesFromStore.push(pieceFromStore);
     }

--- a/app/services/agenda-service.js
+++ b/app/services/agenda-service.js
@@ -53,10 +53,10 @@ export default class AgendaService extends Service {
         item.id
       );
       if (!itemFromStore) {
-        itemFromStore = await this.store.queryRecord(
-          singularize(item.type),
-          item.id
-        );
+        const modelName = singularize(item.type);
+        itemFromStore = typeof item.id === 'string'
+          ? await this.store.findRecord(modelName, item.id)
+          : await this.store.queryRecord(modelName, item.id);
       }
       itemsFromStore.push(itemFromStore);
     }
@@ -77,10 +77,10 @@ export default class AgendaService extends Service {
         item.id
       );
       if (!itemFromStore) {
-        itemFromStore = await this.store.queryRecord(
-          singularize(item.type),
-          item.id
-        );
+        const modelName = singularize(item.type);
+        itemFromStore = typeof item.id === 'string'
+          ? await this.store.findRecord(modelName, item.id)
+          : await this.store.queryRecord(modelName, item.id);
       }
       itemsFromStore.push(itemFromStore);
     }
@@ -101,10 +101,10 @@ export default class AgendaService extends Service {
         piece.id
       );
       if (!pieceFromStore) {
-        pieceFromStore = await this.store.queryRecord(
-          singularize(piece.type),
-          piece.id
-        );
+        const modelName = singularize(piece.type);
+        pieceFromStore = typeof piece.id === 'string'
+          ? await this.store.findRecord(modelName, piece.id)
+          : await this.store.queryRecord(modelName, piece.id);
       }
       piecesFromStore.push(pieceFromStore);
     }


### PR DESCRIPTION
queryRecord expected an object as the second argument, but in some cases it was being handed a string.
I've added a check where we check if the second argument is a string, if it is we will use findRecord.
If not, we will use queryRecord.

This fixes the bug where new items weren't being labeled with 'new'. 
https://kanselarij.atlassian.net/browse/KAS-5235