### PR TITLE
Prevent signflow from being started when decisions isnt released, prevent new document versions when sign flow is already started

### DIFF
--- a/app/components/documents/add-draft-document-card.js
+++ b/app/components/documents/add-draft-document-card.js
@@ -29,9 +29,12 @@ export default class DocumentsAddDraftDocumentCardComponent extends Component {
   @service intl;
   @service pieceAccessLevelService;
   @service draftSubmissionService;
+  @service signatureService;
 
   @tracked piece;
   @tracked documentContainer;
+
+  @tracked hasStartedSignFlow = false;
 
   @tracked isOpenUploadModal = false;
   @tracked isOpenVerifyDeleteModal = false;
@@ -113,6 +116,11 @@ export default class DocumentsAddDraftDocumentCardComponent extends Component {
         `You should provide @piece or @documentContainer as an argument to ${this.constructor.modelName}`
       );
     }
+    if (this.piece?.constructor.modelName === 'piece') {
+      this.hasStartedSignFlow = await this.signatureService.hasStartedSignFlow(
+        this.piece
+      );
+    }
   });
 
   loadFiles = task(async () => {
@@ -142,7 +150,9 @@ export default class DocumentsAddDraftDocumentCardComponent extends Component {
   });
 
   get mayShowAddNewVersion() {
-    return this.piece.constructor.modelName === 'piece';
+    return (
+      this.piece.constructor.modelName === 'piece' && !this.hasStartedSignFlow
+    );
   }
 
   get mayShowDeleteDraftPiece() {

--- a/app/components/documents/draft-document-card.js
+++ b/app/components/documents/draft-document-card.js
@@ -35,6 +35,7 @@ export default class DocumentsDraftDocumentCardComponent extends Component {
   @service draftSubmissionService;
   @service fileConversionService;
   @service currentSession;
+  @service signatureService;
 
   @tracked isOpenUploadModal = false;
   @tracked isOpenVerifyDeleteModal = false;
@@ -52,6 +53,8 @@ export default class DocumentsDraftDocumentCardComponent extends Component {
 
   @tracked sourceFile;
   @tracked derived;
+
+  @tracked hasStartedSignFlow = false;
 
   constructor() {
     super(...arguments);
@@ -90,7 +93,11 @@ export default class DocumentsDraftDocumentCardComponent extends Component {
   }
 
   get mayShowAddNewVersion() {
-    return this.args.isEditable && this.piece.constructor.modelName === 'piece';
+    return (
+      this.args.isEditable &&
+      this.piece.constructor.modelName === 'piece' &&
+      !this.hasStartedSignFlow
+    );
   }
 
   get dateToShowLabel() {
@@ -157,6 +164,11 @@ export default class DocumentsDraftDocumentCardComponent extends Component {
     } else {
       throw new Error(
         `You should provide @piece or @documentContainer as an argument to ${this.constructor.modelName}`
+      );
+    }
+    if (this.piece?.constructor.modelName === 'piece') {
+      this.hasStartedSignFlow = await this.signatureService.hasStartedSignFlow(
+        this.piece
       );
     }
   });

--- a/app/components/submission/header.hbs
+++ b/app/components/submission/header.hbs
@@ -18,6 +18,11 @@
               <AuButton
                 data-test-submission-header-action-create-subcase
                 @skin="naked"
+                @disabled={{this.hasStartedSignFlowOnUpdatedPieces}}
+                title={{if
+                  this.hasStartedSignFlowOnUpdatedPieces
+                  (t "cannot-accept-submission-with-started-sign-flow")
+                }}
                 {{on "click" (toggle "isOpenCreateSubcaseModal" this)}}
               >
                 {{#if this.isUpdate}}

--- a/app/components/submission/header.js
+++ b/app/components/submission/header.js
@@ -39,11 +39,35 @@ export default class SubmissionHeaderComponent extends Component {
   @tracked selectedMeeting;
 
   @tracked isForPostponedSubcase = false;
+  @tracked piecesWithStartedSignFlow = [];
 
   constructor() {
     super(...arguments);
     this.loadAgenda.perform();
     this.loadRequestedByIsCurrentMandatee.perform();
+    this.loadStartedSignFlows.perform();
+  }
+
+  loadStartedSignFlows = task(async () => {
+    if (!this.isUpdate) {
+      return;
+    }
+    const draftPieces = await this.args.submission?.pieces;
+    const found = [];
+    for (const draftPiece of draftPieces?.slice() ?? []) {
+      const previousPiece = await draftPiece.previousPiece;
+      if (
+        previousPiece?.id &&
+        (await this.signatureService.hasStartedSignFlow(previousPiece))
+      ) {
+        found.push(previousPiece);
+      }
+    }
+    this.piecesWithStartedSignFlow = found;
+  });
+
+  get hasStartedSignFlowOnUpdatedPieces() {
+    return this.piecesWithStartedSignFlow.length > 0;
   }
 
   loadAgenda = task(async () => {
@@ -346,7 +370,7 @@ export default class SubmissionHeaderComponent extends Component {
     return piece;
   });
 
-  createSubcase = task({ drop: true }, 
+  createSubcase = task({ drop: true },
     async (
       _fullCopy = false, // unused
       meeting = null,
@@ -365,6 +389,13 @@ export default class SubmissionHeaderComponent extends Component {
       if (!this.canCreateSubcase) {
         return this.toaster.error(
           this.intl.t('submission-edited-concurrently'),
+          this.intl.t('warning-title')
+        );
+      }
+      await this.loadStartedSignFlows.perform();
+      if (this.hasStartedSignFlowOnUpdatedPieces) {
+        return this.toaster.error(
+          this.intl.t('cannot-accept-submission-with-started-sign-flow'),
           this.intl.t('warning-title')
         );
       }

--- a/app/routes/signatures/index.js
+++ b/app/routes/signatures/index.js
@@ -61,19 +61,6 @@ export default class SignaturesIndexRoute extends Route {
     const filter = {
       ':has-no:meeting': true,
       'sign-subcase': {
-        'sign-marking-activity': {
-          piece: {
-            agendaitems: {
-              agenda: {
-                meeting: {
-                  'internal-decision-publication-activity': {
-                    ':has:start-date': `date-added-for-cache-busting-${new Date().toISOString()}`,
-                  },
-                },
-              },
-            },
-          },
-        },
         ':has-no:sign-preparation-activity': 'yes',
       },
       status: {
@@ -85,6 +72,17 @@ export default class SignaturesIndexRoute extends Route {
             CONSTANTS.DECISION_RESULT_CODE_IDS.GOEDGEKEURD,
             CONSTANTS.DECISION_RESULT_CODE_IDS.KENNISNAME,
           ].join(','),
+        },
+        treatment: {
+          agendaitems: {
+            agenda: {
+              meeting: {
+                'internal-decision-publication-activity': {
+                  ':has:start-date': `date-added-for-cache-busting-${new Date().toISOString()}`,
+                },
+              },
+            },
+          },
         },
       },
     };

--- a/app/services/signature-service.js
+++ b/app/services/signature-service.js
@@ -5,7 +5,8 @@ import fetch from 'fetch';
 import constants from 'frontend-kaleidos/config/constants';
 import { getJsonPayloadOrThrow } from 'frontend-kaleidos/utils/json-util';
 
-const { MARKED, PREPARED } = constants.SIGNFLOW_STATUSES;
+const { MARKED, PREPARED, TO_BE_APPROVED, TO_BE_SIGNED, SIGNED } =
+  constants.SIGNFLOW_STATUSES;
 
 export default class SignatureService extends Service {
   @service store;
@@ -281,6 +282,17 @@ export default class SignatureService extends Service {
     const signFlow = await signSubcase?.signFlow;
     const status = await signFlow?.belongsTo('status').reload();
     return status?.uri === MARKED;
+  }
+
+  // Check if a sign flow has been sent to signinghub and isn't refused/canceled yet
+  async hasStartedSignFlow(piece) {
+    const signMarkingActivity = await piece.belongsTo('signMarkingActivity').reload();
+    const signSubcase = await signMarkingActivity?.signSubcase;
+    const signFlow = await signSubcase?.signFlow;
+    const status = await signFlow?.belongsTo('status').reload();
+    return [PREPARED, TO_BE_APPROVED, TO_BE_SIGNED, SIGNED].includes(
+      status?.uri
+    );
   }
 
   async getSigningHubUrl(signFlow, piece) {

--- a/translations/nl-be.json
+++ b/translations/nl-be.json
@@ -1243,6 +1243,7 @@
   "email-address": "E-mailadres",
   "add-approval": "Goed te keuren door",
   "start-signing": "Ondertekenen opstarten",
+  "cannot-accept-submission-with-started-sign-flow": "Deze indiening bevat nieuwe versies van documenten waarvoor de ondertekenflow al is opgestart. De update kan niet aanvaard worden.",
   "cannot-start-signing": "Ondertekenen kan niet worden opgestart",
   "cannot-start-signing-message": "Eén of meerdere ondertekenaars van de geselecteerde documenten moeten zich nog authentificeren in Kaleidos. Dit wordt zo snel mogelijk in orde gebracht.",
   "cannot-sign": "Ondertekenen is niet mogelijk",


### PR DESCRIPTION
Stop displaying the signing workflows for a postponed agenda item that has been re-agendized.
We do this by looking at the decision inside the treatment's internal-decision-publication-activity.
The treatment always has the decisions of the latest agenda item.

Also prevent new document versions from being able to be created when a signflow already has started.
Also accepting new updates isn't allowed when a signflow already has started.