### PR TITLE
Sort by creation date instead of name for document versions

### DIFF
--- a/app/utils/documents.js
+++ b/app/utils/documents.js
@@ -70,9 +70,18 @@ export const sortDocumentContainers = async (
 };
 
 export const sortPieceVersions = (pieces) => {
-  // This function wraps sortPieces just so that the intent of calling it
-  // is more obvious, i.e. when calling this function you're passing in all
-  // the pieces that belong to a single document container.
+  // Sort by created date, if it's missing fallback to sorting by name
+  const createdAvailable = pieces.every((piece) => piece.created);
+  if (createdAvailable) {
+    return pieces.slice().sort(
+      (pieceA, pieceB) =>
+        pieceB.created - pieceA.created ||
+        compareFunction(
+          new VRDocumentName(pieceA.name),
+          new VRDocumentName(pieceB.name)
+        )
+    );
+  }
   return sortPiecesByName(pieces, VRDocumentName, compareFunction);
 };
 


### PR DESCRIPTION
Sort by creation date instead of name for document versions. I also added a fallback when creation date is not set, to still filter by name.